### PR TITLE
fix: restore Nix and Windows PTY checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         run: cargo clippy --workspace --all-targets --locked -- -D warnings
       - name: Run unit, snapshot, and native PTY tests
         run: cargo test --workspace --locked
-      - name: Run release-profile PTY budgets
+      - name: Run release-profile PTY checks
         shell: bash
         run: |
           cargo build --release --package excise --locked
@@ -63,7 +63,11 @@ jobs:
           else
             binary="$PWD/target/release/excise"
           fi
-          EXCISE_PTY_BINARY="$binary" cargo test --test pty_smoke --locked
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            EXCISE_PTY_BINARY="$binary" cargo test --test pty_smoke --locked
+          else
+            EXCISE_PTY_BUDGETS=1 EXCISE_PTY_BINARY="$binary" cargo test --test pty_smoke --locked
+          fi
       - name: Verify package contents and build
         run: cargo package --package excise --locked
       - name: Check advisories, licenses, bans, and sources

--- a/flake.nix
+++ b/flake.nix
@@ -19,8 +19,12 @@
           version = "0.0.0-dev";
           src = pkgs.lib.cleanSource self;
           cargoLock.lockFile = ./Cargo.lock;
-          # Native CI runs the PTY and snapshot suites; the Nix sandbox cannot resolve the test binary.
-          doCheck = false;
+          preCheck = ''
+            cargo build --target ${pkgs.stdenv.hostPlatform.rust.rustcTargetSpec} --bin excise --locked --offline
+            export EXCISE_PTY_DEBUG_BINARY="$PWD/target/${pkgs.stdenv.hostPlatform.rust.rustcTargetSpec}/debug/excise"
+            cargo build --release --target ${pkgs.stdenv.hostPlatform.rust.rustcTargetSpec} --bin excise --locked --offline
+            export EXCISE_PTY_BINARY="$PWD/target/${pkgs.stdenv.hostPlatform.rust.rustcTargetSpec}/release/excise"
+          '';
           nativeBuildInputs = [ pkgs.installShellFiles ];
           postInstall = ''
             installManPage generated/man/excise.1

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsStr;
 use std::fs::Metadata;
-use std::io::Write;
+use std::io::{self, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -26,6 +26,14 @@ use crate::theme::Theme;
 use crate::ui::Display;
 const MIB: usize = 1024 * 1024;
 const MINIMUM_PLAN_BYTES: usize = 4 * 1024;
+fn emit_pty_test_marker(label: &str) {
+    if std::env::var_os("EXCISE_PTY_TEST_MARKERS").is_none() {
+        return;
+    }
+    let mut stdout = io::stdout();
+    let _ = writeln!(stdout, "\n__EXCISE_PTY_{label}__");
+    let _ = stdout.flush();
+}
 
 pub enum UiMode {
     Loading,
@@ -231,6 +239,7 @@ where
         self.ui_mode = UiMode::Normal;
         self.loaded = true;
         self.render_and_update_board();
+        emit_pty_test_marker("SCAN_COMPLETE");
     }
     pub fn add_entry_to_base_folder(
         &mut self,
@@ -300,6 +309,7 @@ where
         self.ui_mode = UiMode::Exiting {
             save_preferences: self.preferences_dirty,
         };
+        emit_pty_test_marker("QUIT_PROMPT");
         self.mark_dirty();
     }
 

--- a/tests/pty_smoke.rs
+++ b/tests/pty_smoke.rs
@@ -49,16 +49,12 @@ impl Drop for ChildGuard {
 
 #[test]
 fn launches_renders_accepts_input_and_restores_terminal() -> anyhow::Result<()> {
-    if std::env::consts::OS == "windows" {
-        // Hosted Windows ConPTY does not reliably deliver completion markers.
-        return Ok(());
-    }
     let (status, output, metrics) = run_pty_interaction(b"y", None)?;
     if !status.success() {
         bail!("Excise exited unsuccessfully: {status}; captured {output:?}");
     }
     let metrics = metrics.context("normal run did not record PTY metrics")?;
-    if std::env::var_os("EXCISE_PTY_BINARY").is_some() {
+    if std::env::var_os("EXCISE_PTY_BUDGETS").is_some() {
         assert!(
             metrics.first_frame <= FIRST_FRAME_BUDGET,
             "first frame took {:?}; captured {output:?}",
@@ -80,10 +76,6 @@ fn launches_renders_accepts_input_and_restores_terminal() -> anyhow::Result<()> 
 
 #[test]
 fn hard_cancel_restores_terminal_and_uses_exit_130() -> anyhow::Result<()> {
-    if std::env::consts::OS == "windows" {
-        // Hosted Windows ConPTY does not reliably deliver completion markers.
-        return Ok(());
-    }
     let (status, output, _) = run_pty_interaction(b"\x03", None)?;
     if status.exit_code() != 130 {
         bail!("hard cancel exited with {status}; captured {output:?}");
@@ -130,6 +122,34 @@ fn typed_runtime_errors_restore_before_diagnostics() -> anyhow::Result<()> {
     }
     Ok(())
 }
+fn windows_conpty() -> bool {
+    std::env::consts::OS == "windows"
+}
+
+fn scan_ready_marker() -> &'static [u8] {
+    if windows_conpty() {
+        b"__EXCISE_PTY_SCAN_COMPLETE__"
+    } else {
+        b"COMPLETE"
+    }
+}
+
+fn initial_ready_marker() -> &'static [u8] {
+    if windows_conpty() {
+        scan_ready_marker()
+    } else {
+        b"Folder is empty"
+    }
+}
+
+fn quit_ready_marker() -> &'static [u8] {
+    if windows_conpty() {
+        b"__EXCISE_PTY_QUIT_PROMPT__"
+    } else {
+        b"Quit Excise?"
+    }
+}
+
 fn run_pty_interaction(
     exit_input: &[u8],
     injected_failure: Option<&str>,
@@ -173,16 +193,17 @@ fn run_pty_interaction(
     let mut measured = None;
     let mut quit_started = None;
     if injected_failure.is_none() {
-        wait_for_output(&output, b"Folder is empty", STARTUP_TIMEOUT)?;
+        let scan_marker = scan_ready_marker();
+        wait_for_output(&output, initial_ready_marker(), STARTUP_TIMEOUT)?;
         let terminal_started = first_output
             .lock()
             .expect("failed to lock PTY timing")
             .expect("terminal emitted no output");
         let first_frame = terminal_started.elapsed();
-        wait_for_output(&output, b"COMPLETE", STARTUP_TIMEOUT)?;
+        wait_for_output(&output, scan_marker, STARTUP_TIMEOUT)?;
         let input_started = Instant::now();
         write_input(&writer, b"q")?;
-        wait_for_output(&output, b"Quit Excise?", STARTUP_TIMEOUT)?;
+        wait_for_output(&output, quit_ready_marker(), STARTUP_TIMEOUT)?;
         let input_to_frame = input_started.elapsed();
         quit_started = Some(Instant::now());
         write_input(&writer, exit_input)?;
@@ -237,14 +258,21 @@ fn run_pty_interaction(
 
 fn pty_command(root: &std::path::Path, injected_failure: Option<&str>) -> CommandBuilder {
     let binary = if injected_failure.is_some() {
-        std::ffi::OsString::from(env!("CARGO_BIN_EXE_excise"))
+        std::env::var_os("EXCISE_PTY_DEBUG_BINARY")
+            .filter(|path| std::path::Path::new(path).is_file())
+            .unwrap_or_else(|| std::ffi::OsString::from(env!("CARGO_BIN_EXE_excise")))
     } else {
         std::env::var_os("EXCISE_PTY_BINARY")
+            .filter(|path| std::path::Path::new(path).is_file())
             .unwrap_or_else(|| std::ffi::OsString::from(env!("CARGO_BIN_EXE_excise")))
     };
     let mut command = CommandBuilder::new(binary);
     command.arg(root);
+    command.cwd(root);
     command.env("TERM", "xterm-256color");
+    if std::env::consts::OS == "windows" {
+        command.env("EXCISE_PTY_TEST_MARKERS", "1");
+    }
     match injected_failure {
         Some("panic") => command.env("EXCISE_TEST_PANIC_AFTER_TERMINAL_ENTRY", "1"),
         Some(kind) => command.env("EXCISE_TEST_ERROR_AFTER_TERMINAL_ENTRY", kind),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -289,7 +289,12 @@ fn run_with_env(
     value: &OsStr,
 ) -> Result<(), Box<dyn Error>> {
     println!("\n==> {label}");
-    let status = Command::new(program).args(args).env(key, value).status()?;
+    let mut command = Command::new(program);
+    command.args(args).env(key, value);
+    if !cfg!(windows) {
+        command.env("EXCISE_PTY_BUDGETS", "1");
+    }
+    let status = command.status()?;
     if status.success() {
         Ok(())
     } else {


### PR DESCRIPTION
## Summary

Restore the Nix package checks and Windows ConPTY coverage in the native verification workflow. The PR keeps existing application behavior intact while making PTY lifecycle assertions deterministic across supported hosts.

## Changes

- Add opt-in PTY lifecycle markers for scan completion and quit confirmation; Windows tests use these markers instead of brittle screen text.
- Make PTY smoke tests select release binaries for normal interaction and debug binaries for injected panic/runtime-error paths.
- Set the PTY child working directory to its fixture root, avoiding Nix sandbox `$HOME` assumptions.
- Run release-profile PTY checks on all native CI targets; enforce timing budgets on Unix hosts and retain functional checks without host-sensitive timing thresholds on Windows.
- Re-enable Nix package checks by building both debug and release test binaries during `preCheck`.
- Keep local `cargo verify` behavior aligned with the Windows CI timing policy.

## Safety and compatibility

- No production deletion, path identity, accounting, schema, or migration behavior changes.
- PTY markers are emitted only when `EXCISE_PTY_TEST_MARKERS` is set; normal users see no additional output.
- Terminal restoration, alternate-screen cleanup, exit codes, and injected failure diagnostics remain asserted.
- Windows ConPTY uses explicit markers; Unix retains existing text and terminal-control assertions.
- Nix uses the repository fixture as the child working directory and explicit target-profile binaries.
- No user-facing documentation or generated artifacts require updates.

## Verification

- `cargo verify` — passed locally, including formatting, workflow/Renovate/documentation checks, compilation, cross-target checks, strict Clippy, 166 library tests, 4 xtask tests, 7 PTY tests, packaging, cargo-deny, fuzz smoke runs, benchmarks, and release binary measurement.
- Hosted Native verification — passed on Linux, macOS, and Windows.
- Hosted Nix flake package — passed.
- Workflow and dependency policy syntax — passed.
- Hosted TachyonFX benchmark — passed.
- PTY scenarios cover normal scan/quit, hard cancel, panic restoration, and typed runtime-error restoration.

- [x] Focused tests cover new behavior and plausible regressions.
- [x] `cargo fmt --all -- --check` passes.
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` passes.
- [x] `cargo test --workspace --locked` passes.
- [x] User-facing documentation and generated artifacts are current (not applicable; no user-facing or generated contracts changed).
- [x] Every new commit includes a DCO `Signed-off-by` trailer.