### PR TITLE
release: prepare `v0.1.0-rc.1`

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Run statistical core benchmark
         run: cargo bench --bench core --locked -- --noplot
       - name: Preserve Criterion measurements
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v7
         with:
           name: tachyonfx-criterion
           path: target/criterion

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Preserve crash artifacts
         if: failure()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v7
         with:
           name: fuzz-crashes
           path: fuzz/artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,26 +20,51 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-24.04, target: x86_64-unknown-linux-gnu, shell: bash }
-          - { os: ubuntu-24.04, target: aarch64-unknown-linux-gnu, shell: bash }
-          - { os: macos-14, target: aarch64-apple-darwin, shell: bash }
-          - { os: macos-14, target: x86_64-apple-darwin, shell: bash }
-          - { os: windows-2025, target: x86_64-pc-windows-msvc, shell: pwsh }
-          - { os: windows-2025, target: aarch64-pc-windows-msvc, shell: pwsh }
+          - { os: ubuntu-24.04, target: x86_64-unknown-linux-gnu }
+          - { os: ubuntu-24.04, target: aarch64-unknown-linux-gnu }
+          - { os: macos-14, target: aarch64-apple-darwin }
+          - { os: macos-14, target: x86_64-apple-darwin }
+          - { os: windows-2025, target: x86_64-pc-windows-msvc }
+          - { os: windows-2025, target: aarch64-pc-windows-msvc }
     steps:
       - name: Check out source
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
+      - name: Install Linux cross linker
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: sudo apt-get update --yes && sudo apt-get install --yes gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
+      - name: Install pinned Rust target
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          rustup toolchain install 1.88.0 --profile minimal
+          rustup target add "$TARGET" --toolchain 1.88.0
+          rustup override set 1.88.0
       - name: Build locked release binary
-        uses: houseabsolute/actions-rust-cross@21b0f18dc621b25bfae556ff2791fca4173121e8 # v1.0.8
-        with:
-          command: build
-          target: ${{ matrix.target }}
-          args: --locked --release --package excise
-          toolchain: 1.88.0
-          strip: true
-          use-rust-cache: false
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          if [[ "$TARGET" == "aarch64-unknown-linux-gnu" ]]; then
+            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+            export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
+            export AR_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ar
+          fi
+          cargo build --target "$TARGET" --locked --release --package excise
+      - name: Strip Unix release binary
+        if: runner.os != 'Windows'
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          if [[ "$TARGET" == "aarch64-unknown-linux-gnu" ]]; then
+            aarch64-linux-gnu-strip "target/$TARGET/release/excise"
+          else
+            strip "target/$TARGET/release/excise"
+          fi
       - name: Validate distribution template contracts
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         shell: bash
@@ -76,7 +101,7 @@ jobs:
           Copy-Item docs/schemas/*.json "stage/$root/schemas/"
           Compress-Archive -Path "stage/$root" -DestinationPath "upload/$root.zip"
       - name: Upload immutable target archive
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v7
         with:
           name: excise-${{ matrix.target }}
           path: upload/*
@@ -94,7 +119,7 @@ jobs:
       attestations: write
     steps:
       - name: Download target archives
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v8
         with:
           pattern: excise-*
           path: release
@@ -116,7 +141,7 @@ jobs:
         with:
           subject-path: release/*
       - name: Upload release candidate bundle
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v7
         with:
           name: excise-release-candidate
           path: release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Excise preserves the historical Diskonaut changelog below. Diskonaut versions an
 
 ## [Unreleased]
 
+_No unreleased changes._
+
+## [0.1.0-rc.1] - 2026-08-21
+
 ### Added
 
 * Added bounded, iterative scanning with explicit exclusions, filesystem boundaries, uncertainty, cancellation, and secure identity spill.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "0.0.0-dev"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Surgical terminal storage navigator"
 keywords = ["disk-usage", "filesystem", "terminal", "tui"]
 categories = ["command-line-utilities", "filesystem"]
 
-version = "0.0.0-dev"
+version = "0.1.0-rc.1"
 authors = ["Aram Drevekenin <aram@poor.dev>", "Tom Larcher <tom.larcher@gmail.com>"]
 readme = "README.md"
 homepage = "https://github.com/findyourexit/excise"

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
         let pkgs = nixpkgs.legacyPackages.${system};
         in pkgs.rustPlatform.buildRustPackage {
           pname = "excise";
-          version = "0.0.0-dev";
+          version = "0.1.0-rc.1";
           src = pkgs.lib.cleanSource self;
           cargoLock.lockFile = ./Cargo.lock;
           preCheck = ''

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "0.0.0-dev"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/generated/man/excise.1
+++ b/generated/man/excise.1
@@ -1,10 +1,10 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH excise 1  "excise 0.0.0-dev" 
+.TH excise 1  "excise 0.1.0-rc.1"
 .SH NAME
 excise
 .SH SYNOPSIS
-\fBexcise\fR [\fB\-\-config\fR] [\fB\-a\fR|\fB\-\-apparent\-size\fR] [\fB\-\-scan\-threads\fR] [\fB\-\-event\-buffer\fR] [\fB\-\-cross\-filesystems\fR] [\fB\-\-exclude\fR] [\fB\-\-memory\-mib\fR] [\fB\-\-reduced\-motion\fR] [\fB\-\-theme\fR] [\fB\-\-ascii\fR] [\fB\-\-mouse\fR] [\fB\-\-keymap\fR] [\fB\-\-format\fR] [\fB\-\-output\fR] [\fB\-d\fR|\fB\-\-disable\-delete\-confirmation\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIfolder\fR] 
+\fBexcise\fR [\fB\-\-config\fR] [\fB\-a\fR|\fB\-\-apparent\-size\fR] [\fB\-\-scan\-threads\fR] [\fB\-\-event\-buffer\fR] [\fB\-\-cross\-filesystems\fR] [\fB\-\-exclude\fR] [\fB\-\-memory\-mib\fR] [\fB\-\-reduced\-motion\fR] [\fB\-\-theme\fR] [\fB\-\-ascii\fR] [\fB\-\-mouse\fR] [\fB\-\-keymap\fR] [\fB\-\-format\fR] [\fB\-\-output\fR] [\fB\-d\fR|\fB\-\-disable\-delete\-confirmation\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIfolder\fR]
 .SH DESCRIPTION
 .SH OPTIONS
 .TP
@@ -122,4 +122,4 @@ Print version
 [\fIfolder\fR]
 Folder to scan
 .SH VERSION
-v0.0.0\-dev
+v0.1.0\-rc.1

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -323,9 +323,15 @@ fn generated_artifacts() -> Result<Vec<GeneratedArtifact>, Box<dyn Error>> {
     let mut artifacts = Vec::new();
     let mut man = Vec::new();
     clap_mangen::Man::new(Cli::command()).render(&mut man)?;
+    let mut man = String::from_utf8(man)?
+        .lines()
+        .map(str::trim_end)
+        .collect::<Vec<_>>()
+        .join("\n");
+    man.push('\n');
     artifacts.push(GeneratedArtifact {
         path: PathBuf::from("generated/man/excise.1"),
-        bytes: man,
+        bytes: man.into_bytes(),
     });
     for (shell, name) in [
         (Shell::Bash, "excise.bash"),


### PR DESCRIPTION
## Summary

Prepare the first Excise release candidate, `v0.1.0-rc.1`, from the protected `main` line. This is an archive-only candidate.

## Changes

- Set the package, lockfiles, Nix package, generated man page, and distribution metadata to `0.1.0-rc.1`.
- Move the initial Excise feature set from `Unreleased` into the dated release-candidate changelog section.
- Normalize generated man-page whitespace so release diffs remain clean and reproducible.
- Update artifact upload/download actions to current pinned releases.
- Replace the release workflow's forbidden third-party cross-build action with direct pinned Rust targets and an explicit Linux cross linker.
- Preserve the manually dispatched release-candidate workflow for target archives, checksums, SPDX SBOM, and optional provenance.

## Safety and compatibility

- No production runtime, deletion, accounting, path-identity, terminal, schema, or configuration behavior changes.
- This candidate remains explicitly pre-release; permanent deletion still has no trash or undo and must be exercised only on disposable data.
- Archive-only distribution is intentional; `publish = false` remains in effect until a separate crates.io decision is made.
- Generated man pages, shell completions, published schemas, and distribution metadata are regenerated or validated.
- Historical Diskonaut tags remain untouched.

## Verification

- `cargo verify` passed locally: formatting, workflow/Renovate/documentation checks, compilation, cross-target checks, strict Clippy, 166 library tests, 4 xtask tests, 7 PTY tests, package verification, cargo-deny, fuzz smoke runs, benchmarks, and release binary measurement.
- `cargo run --locked --package xtask -- check-generated` passed on the rewritten two-commit tree.
- `cargo dist-local` – passed and produced `dist/excise-aarch64-apple-darwin-v0.1.0-rc.1.tar.gz`.
- Local archive SHA-256: `a43421728bd82b26af805f04e3afb2f6b61bb6793b27ac7c5e28f65085d5911f`.
- Exact-head hosted candidate workflow run `32440169177` at commit `53ee9746d9b1bbc2c3acc463f0f206bdf90a7602` passed for all six target archives, checksum generation, SPDX SBOM generation, and optional build provenance attestation.
- Downloaded exact-head bundle. All six entries passed `sha256sum -c checksums.sha256`. Archive names and target contents match `v0.1.0-rc.1`.
- Hosted PR checks on the rewritten head. Linux, macOS, Windows, Nix, workflow policy, and benchmark all passed.

- [x] Focused tests cover new behavior and plausible regressions.
- [x] `cargo fmt --all -- --check` passes.
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` passes.
- [x] `cargo test --workspace --locked` passes.
- [x] User-facing documentation and generated artifacts are current.
- [x] Every new commit includes a DCO `Signed-off-by` trailer.