### PR TITLE
test: validate native release-candidate safety paths

### DIFF
--- a/src/deletion.rs
+++ b/src/deletion.rs
@@ -1308,6 +1308,27 @@ mod tests {
         assert!(report.precise);
         assert!(!path.exists());
     }
+    #[test]
+    fn synthetic_and_scan_root_targets_are_rejected() {
+        let root = tempfile::tempdir().expect("deletion root should exist");
+        let path = root.path().join("target");
+        std::fs::write(&path, b"payload").expect("target should be written");
+
+        let mut synthetic = target(root.path(), OsString::from("target"), FileType::File);
+        synthetic.synthetic = true;
+        assert!(matches!(
+            build_plan(root.path(), synthetic, false),
+            Err(DeletionPlanError::Synthetic)
+        ));
+
+        let mut scan_root = target(root.path(), OsString::from("target"), FileType::File);
+        scan_root.path_to_file.clear();
+        assert!(matches!(
+            build_plan(root.path(), scan_root, false),
+            Err(DeletionPlanError::Root)
+        ));
+        assert!(path.exists());
+    }
 
     #[test]
     fn replaced_file_is_skipped() {
@@ -1481,6 +1502,30 @@ mod tests {
         );
         assert_eq!(report.changed_entries(), 1);
         assert!(path.is_dir());
+    }
+    #[test]
+    fn directory_to_file_replacement_is_skipped() {
+        let root = tempfile::tempdir().expect("deletion root should exist");
+        let path = root.path().join("target");
+        std::fs::create_dir(&path).expect("target directory should be created");
+        let plan = build_plan(
+            root.path(),
+            target(root.path(), OsString::from("target"), FileType::Folder),
+            false,
+        )
+        .expect("directory plan should build");
+        std::fs::rename(&path, root.path().join("original"))
+            .expect("original directory identity should remain allocated");
+        std::fs::write(&path, b"replacement").expect("replacement file should be written");
+
+        let report = execute_plan(
+            root.path(),
+            plan,
+            &AtomicBool::new(false),
+            &AtomicBool::new(false),
+        );
+        assert_eq!(report.changed_entries(), 1);
+        assert!(path.is_file());
     }
 
     #[test]

--- a/src/deletion.rs
+++ b/src/deletion.rs
@@ -1688,6 +1688,61 @@ mod tests {
         );
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn deleting_a_junction_never_deletes_its_target() {
+        let root = tempfile::tempdir().expect("deletion root should exist");
+        let outside = tempfile::tempdir().expect("outside root should exist");
+        let outside_file = outside.path().join("outside");
+        std::fs::write(&outside_file, b"outside").expect("outside target should be written");
+        let junction = root.path().join("junction");
+        let quote = |path: &Path| format!("'{}'", path.display().to_string().replace('\'', "''"));
+        let command = format!(
+            "$ErrorActionPreference='Stop'; New-Item -ItemType Junction -Path {} -Target {} | Out-Null",
+            quote(&junction),
+            quote(outside.path())
+        );
+        let output = std::process::Command::new("pwsh")
+            .args([
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                &command,
+            ])
+            .output()
+            .expect("junction command should start");
+        assert!(
+            output.status.success(),
+            "junction command failed with {}: stdout={:?} stderr={:?}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let plan = build_plan(
+            root.path(),
+            target(root.path(), OsString::from("junction"), FileType::Folder),
+            false,
+        )
+        .expect("junction plan should build without following its target");
+        assert_eq!(
+            plan.root_snapshot().map(|snapshot| snapshot.kind),
+            Some(PlannedKind::Link)
+        );
+
+        let report = execute_plan(
+            root.path(),
+            plan,
+            &AtomicBool::new(false),
+            &AtomicBool::new(false),
+        );
+
+        assert_eq!(report.deleted_entries(), 1);
+        assert!(!junction.exists());
+        assert!(outside_file.exists());
+    }
+
     #[cfg(unix)]
     #[test]
     fn hostile_directory_name_uses_generated_challenge() {

--- a/src/tests/cases/native_path.rs
+++ b/src/tests/cases/native_path.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+#[cfg(windows)]
+use crate::native_path::safe_display_os_str;
 use crate::native_path::{NativePath, ResolvedRoot, identity_for, safe_display_path};
 
 #[test]
@@ -37,6 +39,25 @@ fn unix_codec_preserves_non_utf8_bytes() {
         original
     );
     assert!(original.safe_display().deceptive);
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_codec_and_display_preserve_unpaired_utf16() {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt as _;
+
+    let original = OsString::from_wide(&[u16::from(b'a'), 0xd800, u16::from(b'b')]);
+    let displayed = safe_display_os_str(&original);
+    assert!(displayed.deceptive);
+    assert!(displayed.text.contains("\\u{d800}"));
+
+    let path = NativePath::new(std::path::PathBuf::from(original));
+    let encoded = path.encode();
+    assert_eq!(
+        NativePath::decode(&encoded).expect("path should decode"),
+        path
+    );
 }
 
 #[test]

--- a/tests/native_path_smoke.rs
+++ b/tests/native_path_smoke.rs
@@ -1,0 +1,53 @@
+#[cfg(target_os = "linux")]
+#[test]
+fn headless_json_round_trips_invalid_utf8_filename() -> anyhow::Result<()> {
+    use std::os::unix::ffi::OsStringExt as _;
+    use std::process::Command;
+
+    let root = tempfile::tempdir()?;
+    let name = std::ffi::OsString::from_vec(b"invalid-\xff-name".to_vec());
+    let path = root.path().join(&name);
+    std::fs::write(&path, b"payload")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_excise"))
+        .args(["--format", "json"])
+        .arg(root.path())
+        .output()?;
+    anyhow::ensure!(
+        output.status.success(),
+        "headless scan failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let document: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+    anyhow::ensure!(document["state"] == "exact", "scan should be exact");
+    let entries = document["entries"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("report entries should be an array"))?;
+    let entry = entries
+        .iter()
+        .find(|entry| {
+            entry["display_path"]
+                .as_str()
+                .is_some_and(|display| display.contains("invalid-\\xff-name"))
+        })
+        .ok_or_else(|| anyhow::anyhow!("invalid-byte entry should be reported"))?;
+    let encoded: excise::native_path::EncodedNativePath =
+        serde_json::from_value(entry["path"].clone())?;
+    let decoded = excise::native_path::NativePath::decode(&encoded)?;
+    anyhow::ensure!(
+        decoded.as_path() == path,
+        "native path should round-trip exactly"
+    );
+    anyhow::ensure!(
+        entry["path"]["encoding"] == "unix-bytes",
+        "invalid-byte path should use unix-bytes encoding"
+    );
+    anyhow::ensure!(
+        entry["display_path"]
+            .as_str()
+            .is_some_and(|display| display.contains("\\xff")),
+        "invalid-byte path should use an escaped display"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Add a Linux-native headless JSON fixture for invalid UTF-8 filenames and exact native-path round trips.
- Add Windows-native junction/reparse and sharing-failure deletion fixtures.
- Add Windows-native coverage for unpaired UTF-16 display and codec behavior.
- Preserve the release handoff documents locally as unstaged files; they are intentionally not part of this PR.

## Verification

- `cargo verify`
- `cargo dist-local`
- `cargo test --locked deletion::tests`
- `cargo test --locked tests::cases::native_path`
- `cargo fmt --all -- --check`

## Hosted acceptance

The Ubuntu and Windows native jobs must execute the new platform-gated tests. Cross-target compilation on macOS is not a substitute for those native results. Repeat the release artifact workflow only after this exact commit is merged to protected `main`.