### PR TITLE
release: prepare `v0.1.0` stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Excise preserves the historical Diskonaut changelog below. Diskonaut versions an
 
 _No unreleased changes._
 
-## [0.1.0-rc.1] - 2026-08-21
+## [0.1.0] - 2026-08-21
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Surgical terminal storage navigator"
 keywords = ["disk-usage", "filesystem", "terminal", "tui"]
 categories = ["command-line-utilities", "filesystem"]
 
-version = "0.1.0-rc.1"
+version = "0.1.0"
 authors = ["Aram Drevekenin <aram@poor.dev>", "Tom Larcher <tom.larcher@gmail.com>"]
 readme = "README.md"
 homepage = "https://github.com/findyourexit/excise"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Excise is a surgical terminal storage navigator. It combines a responsive treema
 Excise is an independent successor to [Diskonaut](https://github.com/imsnif/diskonaut). The repository preserves Diskonaut's history and release tags while giving the project a new product, architecture, and maintenance life.
 
 > [!WARNING]
-> Excise is pre-release software. Permanent deletion has no trash or undo. Use development builds only on disposable data until a stable release is published.
+> Excise permanently deletes selected filesystem entries. There is no trash or undo. Use it only on data you can safely remove.
 
 ## Why Excise
 
@@ -22,7 +22,7 @@ Excise is an independent successor to [Diskonaut](https://github.com/imsnif/disk
 
 ## Build from source
 
-A stable release is not available yet. Build the current source with Rust 1.88 or newer:
+Build the current stable source with Rust 1.88 or newer:
 
 ```console
 git clone https://github.com/findyourexit/excise.git

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,12 @@ Excise performs permanent filesystem deletion, so data-loss defects are treated 
 
 ## Supported versions
 
-Excise has not published a stable release. The `main` branch is reviewed as pre-release software and must not be trusted with irreplaceable data. A support table will be added with the first stable release.
+Excise supports the latest stable release, currently `0.1.0`. The `main` branch is development software and must not be trusted with irreplaceable data.
+
+| Version | Status |
+|---|---|
+| `0.1.x` | Supported stable line |
+| `main` | Development only |
 
 ## Report privately
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting started
 
-Excise is pre-release software. Build it from source and begin with a disposable directory. Permanent deletion does not use a trash folder and cannot be undone.
+Excise permanently deletes selected filesystem entries. There is no trash or undo. Begin with a disposable directory.
 
 ## Requirements
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,6 +1,6 @@
 # Release process
 
-Excise has not published a stable release. This runbook defines the evidence and artifact shape expected before publication; it does not authorize a release by itself.
+This runbook defines the evidence and artifact shape expected for publication. It does not authorize a release by itself.
 
 ## Release commit
 

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
         let pkgs = nixpkgs.legacyPackages.${system};
         in pkgs.rustPlatform.buildRustPackage {
           pname = "excise";
-          version = "0.1.0-rc.1";
+          version = "0.1.0";
           src = pkgs.lib.cleanSource self;
           cargoLock.lockFile = ./Cargo.lock;
           preCheck = ''

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "0.1.0-rc.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/generated/man/excise.1
+++ b/generated/man/excise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH excise 1  "excise 0.1.0-rc.1"
+.TH excise 1  "excise 0.1.0"
 .SH NAME
 excise
 .SH SYNOPSIS
@@ -122,4 +122,4 @@ Print version
 [\fIfolder\fR]
 Folder to scan
 .SH VERSION
-v0.1.0\-rc.1
+v0.1.0


### PR DESCRIPTION
## Summary

- Prepare the first stable `v0.1.0` archive release.
- Keep the archive-only distribution decision and `publish = false`.
- Update Cargo manifests and lockfiles, Nix metadata, generated man page, changelog, README, getting-started guidance, security support policy, and release documentation.

## Distribution decision

This release remains archive-only. crates.io publication is not enabled by this PR.

## Verification

- `cargo check --workspace --locked`
- `cargo check --manifest-path fuzz/Cargo.toml --locked`
- `cargo check-generated`
- `cargo run --locked --package xtask -- check-distribution`
- `cargo verify`
- `cargo dist-local`

## Release gate

After this PR merges, dispatch the provenance-enabled release artifact workflow from the exact protected merge commit. Inspect all six archives, checksums, SPDX dependency SBOM, provenance subject set, and installer metadata before creating the immutable `v0.1.0` tag. Do not move historical Diskonaut tags.