### PR TITLE
test: cover deterministic Windows sharing failure

### DIFF
--- a/src/deletion.rs
+++ b/src/deletion.rs
@@ -1743,6 +1743,41 @@ mod tests {
         assert!(outside_file.exists());
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn sharing_failure_is_reported_without_deleting_target() {
+        use std::os::windows::fs::OpenOptionsExt as _;
+
+        const FILE_SHARE_READ: u32 = 0x0000_0001;
+        const FILE_SHARE_WRITE: u32 = 0x0000_0002;
+
+        let root = tempfile::tempdir().expect("deletion root should exist");
+        let path = root.path().join("target");
+        std::fs::write(&path, b"payload").expect("target should be written");
+        let plan = build_plan(
+            root.path(),
+            target(root.path(), OsString::from("target"), FileType::File),
+            false,
+        )
+        .expect("file plan should build");
+        let blocker = std::fs::OpenOptions::new()
+            .read(true)
+            .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+            .open(&path)
+            .expect("sharing blocker should open");
+
+        let report = execute_plan(
+            root.path(),
+            plan,
+            &AtomicBool::new(false),
+            &AtomicBool::new(false),
+        );
+
+        assert_eq!(report.failed_entries(), 1);
+        assert!(path.exists());
+        drop(blocker);
+    }
+
     #[cfg(unix)]
     #[test]
     fn hostile_directory_name_uses_generated_challenge() {


### PR DESCRIPTION
## Summary

Add a deterministic Windows sharing-mode regression fixture for the permanent deletion path.

## Changes

- Open the planned file without `FILE_SHARE_DELETE`.
- Execute the normal identity-bound deletion plan.
- Require a failed deletion outcome and verify the target remains present.

The fixture is scoped to Windows and does not alter production deletion behavior.

## Safety and compatibility

This covers the failure disposition required when Windows sharing prevents deletion. Existing no-follow, identity revalidation, replacement-race, and partial-result behavior is unchanged. The documented limitation around deterministic POSIX-disposition-level sharing behavior remains until native Windows evidence exercises it directly.

No schema, CLI, configuration, packaging, generated-file, or accessibility changes.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo test --test pty_smoke --locked`
- `cargo verify`
- `cargo check --target x86_64-pc-windows-msvc --lib --locked`
- Published v0.1.0 consumer smoke test and all six release checksum validations

The Windows-specific test requires native Windows CI execution; the host cannot run Windows binaries.

Every new commit includes a DCO `Signed-off-by` trailer.