### PR TITLE
docs: improve support guidance

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,14 +4,42 @@
 
 Search the [documentation](docs/README.md) and existing discussions first. Use [GitHub Discussions](https://github.com/findyourexit/excise/discussions) for installation, configuration, and usage questions.
 
+## Troubleshooting
+
+### Permission or sharing failures
+
+A scan permission error means Excise could not read metadata or enumerate part of the tree; the report is uncertain rather than a complete inventory. Check that the account has the needed access to the path and its parent directories, correct the ACL or mount access, and rescan.
+
+A deletion `failed` result means Excise did not confirm that entry as deleted. On Unix, check write and execute permission on the parent directory. On Windows, close applications, sync clients, indexers, or antivirus software that may hold an incompatible sharing handle, then start a fresh scan. Do not infer the filesystem state from the error alone.
+
+If a deletion was hard-cancelled, its result is imprecise; rescan before acting again. Preserve the exit code and deletion-history report when asking for help.
+
+### Boundaries and exclusions
+
+If paths are missing, check the default one-filesystem boundary and configured exclusions before treating them as read failures. `--cross-filesystems` permits traversal across mounts and should be used only when that scope is intended. `--exclude PATTERN` uses ordered gitignore-style patterns rooted at the scan path.
+
+Excluded entries and foreign-filesystem boundaries remain visible as zero-byte scoped records with their reason, but their descendants are not traversed. Symlink targets are not followed; on Windows this also includes junction and reparse targets.
+
+### Terminal and non-TTY output
+
+The TUI requires stdin and stdout TTYs, ANSI rendering, alternate-screen support, and a window at least `32 x 8`. Resize a smaller terminal or use a headless mode. Table and JSON modes run without a TTY, raw mode, or alternate screen and are suitable for redirection, shell pipelines, and CI. `--output FILE` is valid only with table or JSON mode.
+
+### Native paths and Windows limitations
+
+Text output uses escaped display paths: terminal and bidirectional controls, newlines, tabs, backslashes, invalid Unix path bytes, and ill-formed Windows UTF-16 are escaped. In JSON, `path` is lossless native data (`unix-bytes` on Unix or `windows-utf16-le` on Windows, base64); `display_path` is presentation text. See [Reports and schemas](docs/reports.md).
+
+Windows does not populate allocated-byte snapshots, so allocated and reclaimable upper bounds can be unknown; use `--apparent-size` for logical file lengths. Windows deletion uses no-follow handles, but ACLs and sharing modes can still reject an entry. See [Getting started](docs/getting-started.md) for first-use and platform guidance.
+
 ## Defects
 
 Use the issue chooser for reproducible bugs. Include the Excise version or commit, operating system, terminal, command, filesystem context, expected behavior, and actual behavior. Replace real paths with synthetic fixtures where possible.
 
 ## Security and deletion safety
 
+For normal first use, follow [Getting started](docs/getting-started.md) and the [permanent-deletion contract](docs/safety/deletion.md). Deletion is permanent; there is no trash or undo.
+
 Do not use a public issue for a vulnerability or an unintended-deletion path that could put users at risk. Follow [SECURITY.md](SECURITY.md) instead.
 
 ## Scope
 
-Support is best effort. The project does not provide private consulting, emergency recovery, or guarantees for pre-release builds. Excise preserves Diskonaut's history but does not provide support for historical Diskonaut releases.
+Support is best effort. The project does not provide private consulting, emergency recovery, or guarantees for pre-release builds. The repository preserves Diskonaut history and historical tags for archival reference; they are not Excise releases, and historical Diskonaut releases are unsupported. See [Project lineage](docs/lineage.md).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,28 +47,56 @@ excise /tmp/excise-demo
 
 Use a temporary directory appropriate to your platform on Windows.
 
+Keep the default confirmation enabled for first use. Wait for a complete scan, select a real file or directory, press `Backspace`, and review the escaped path, identity, and planned-entry count. The scan root, a filesystem or drive root, synthetic `Shared`, `Other`, or aggregate nodes, and incomplete or uncertain subtrees are not deletion targets. Press `Esc` to cancel.
+
+The default confirmation is explicit: files require `y`; safe printable directories require their exact leaf name; hostile or untypeable names require a generated challenge. `--disable-delete-confirmation` only enables a visible, session-only reduced confirmation mode; it does not remove the other guardrails and is not persisted. Prefer an ordinary user for first use; root/Administrator is warned and does not change identity checks.
+
+Every planned entry is independently enumerated and revalidated immediately before mutation. Changed, replaced, missing, or newly created entries are never silently deleted, so a run can be partial. There is no trash or undo.
+
 The default view uses identity-unique allocated bytes. Pass `--apparent-size` when logical file length is the intended comparison.
+
+## Interactive terminal
+
+The TUI requires stdin and stdout attached to TTYs, ANSI rendering, and alternate-screen support. It needs a window at least `32 x 8`; smaller windows show a resize message. If a terminal cannot provide these capabilities, use table or JSON mode instead. `--ascii` changes symbols and borders but does not remove the TTY requirement.
 
 ## Noninteractive use
 
-Table and JSON modes do not acquire raw mode or an alternate screen:
+Table and JSON modes run without a TTY, raw mode, or alternate screen, so use them for redirected output, shell pipelines, CI, or terminals without TUI capabilities:
 
 ```console
 excise --format table /path/to/inspect
 excise --format json --output scan.json /path/to/inspect
 ```
 
-A nonzero exit can still produce a useful bounded report. See [Reports and schemas](reports.md) for outcome classes.
+`--output FILE` writes the report instead of stdout and is valid only with table or JSON mode. A nonzero exit can still produce a useful bounded report. See [Reports and schemas](reports.md) for outcome classes and document state.
 
 ## Filesystem boundaries and exclusions
 
-Excise stays on the starting filesystem by default. Use `--cross-filesystems` only when traversal across mounts is intended.
+Excise stays on the starting filesystem by default. A directory on another filesystem is shown as a boundary and not traversed. Use `--cross-filesystems` only when traversal across mounts is intended; this broadens the scan scope.
 
 Exclusions use ordered gitignore-style patterns rooted at the scan path:
 
 ```console
 excise --exclude .git/ --exclude target/ /path/to/inspect
 ```
+
+An excluded entry is shown as a zero-byte scoped record with its reason; its descendants are not traversed. Symlink targets are not traversed; on Windows this also applies to junction and reparse targets. Check these scope rules before treating a missing path as a read failure.
+
+## Native paths and display
+
+TUI and text reports use a reversible escaped display form. Newlines, tabs, terminal controls, bidirectional controls, backslashes, invalid UTF-8 on Unix, and ill-formed UTF-16 on Windows are escaped so names cannot inject terminal controls. `display_path` is for people, not a byte-exact shell argument.
+
+JSON keeps `path` losslessly in a native encoding while `display_path` remains escaped. Unix paths use `unix-bytes` base64; Windows paths use `windows-utf16-le` base64. See [Reports and schemas](reports.md) and the [native-path schema](schemas/native-path.schema.json) when consuming reports.
+
+## Windows notes
+
+Run the Windows executable with Windows path syntax:
+
+```console
+target\release\excise.exe C:\path\to\inspect
+```
+
+Windows does not populate allocated-byte snapshots, so allocated and reclaimable upper bounds can be unknown; pass `--apparent-size` when logical file lengths are the intended comparison. Deletion uses no-follow handles, but ACLs and another process's sharing mode can still make an entry fail. Close applications, sync clients, indexers, or antivirus software before a fresh scan and retry. Junction and reparse targets are not followed.
 
 ## Next steps
 


### PR DESCRIPTION
## Summary
Add factual first-use, troubleshooting, terminal, path, and Windows guidance for users.

## Changes
- Explain permission and sharing failures, filesystem boundaries, exclusions, and non-TTY report use.
- Document terminal size/capability requirements, escaped display paths, and lossless native-path encodings.
- Clarify Windows accounting and sharing limitations plus the permanent-deletion first-use flow.
- Preserve the permanent-deletion safety contract and Diskonaut archive-only release history.

## Safety and compatibility
- Documentation-only change; no source, schema, generated, or release metadata changes.
- No deletion behavior or safety guarantee changed; docs continue to describe no trash/undo, identity checks, revalidation, and partial outcomes.
- Historical Diskonaut tags remain archival references, not Excise releases.

## Verification
- `git diff --check -- docs/getting-started.md SUPPORT.md` (pass).
- Targeted Markdown check for balanced fences, tabs, and relative links (pass).
- Project-wide formatters, linters, and test suites not run for this Markdown-only change.

- [ ] Focused tests cover new behavior and plausible regressions.
- [ ] `cargo fmt --all -- --check` passes.
- [ ] `cargo clippy --workspace --all-targets --locked -- -D warnings` passes.
- [ ] `cargo test --workspace --locked` passes.
- [x] User-facing documentation and generated artifacts are current.
- [x] Every new commit includes a DCO `Signed-off-by` trailer.