### PR TITLE
ci: pin release evidence workflows to exact SHA

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,6 +1,9 @@
 name: Hosted benchmark
 
 on:
+  push:
+    tags:
+      - "v*"
   pull_request:
     paths:
       - "benches/**"
@@ -21,11 +24,18 @@ jobs:
   tachyonfx:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    env:
+      RELEASE_SHA: ${{ github.sha }}
     steps:
-      - name: Check out source
+      - name: Check out source at release SHA
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
+          ref: ${{ github.sha }}
           persist-credentials: false
+      - name: Verify exact release checkout
+        run: |
+          test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+          printf 'Release SHA: %s\n' "$RELEASE_SHA"
       - name: Install pinned MSRV
         run: |
           rustup toolchain install 1.88.0 --profile minimal

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,6 +1,9 @@
 name: Fuzz smoke
 
 on:
+  push:
+    tags:
+      - "v*"
   schedule:
     - cron: "23 4 * * 1"
   workflow_dispatch:
@@ -16,11 +19,18 @@ jobs:
   smoke:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    env:
+      RELEASE_SHA: ${{ github.sha }}
     steps:
-      - name: Check out source
+      - name: Check out source at release SHA
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
+          ref: ${{ github.sha }}
           persist-credentials: false
+      - name: Verify exact release checkout
+        run: |
+          test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+          printf 'Release SHA: %s\n' "$RELEASE_SHA"
       - name: Install pinned nightly and cargo-fuzz
         run: |
           rustup toolchain install nightly-2026-08-18 --profile minimal


### PR DESCRIPTION
## Summary
- Run benchmark and fuzz workflows on v* release-tag pushes
- Check out and verify the exact event SHA in the job context
- Retain pull request, schedule, manual dispatch, and existing runtime bounds

## Verification
- Actionlint `.github/workflows/benchmark.yml` `.github/workflows/fuzz.yml`
- Ruby YAML parse for both workflow files

Scope is limited to `.github/workflows/benchmark.yml` and `.github/workflows/fuzz.yml`.