### PR TITLE
fix: harden terminal path display safety

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,13 @@ use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use serde::{Deserialize, Serialize};
 
 use crate::error::AppError;
+use crate::native_path::{safe_display_path_text, safe_display_text};
 use crate::theme::ThemeId;
+
+fn config_error(message: impl std::fmt::Display) -> AppError {
+    let message = message.to_string();
+    AppError::Config(safe_display_text(&message))
+}
 
 pub const CONFIG_VERSION: u16 = 1;
 const DEFAULT_EVENT_BUFFER: usize = 256;
@@ -100,7 +106,7 @@ impl CustomKeyBindings {
         ];
         for (direction, key) in bindings {
             if let Some(action) = normal_mode_action_for_custom_key(key) {
-                return Err(AppError::Config(format!(
+                return Err(config_error(format!(
                     "custom movement key {direction} ({key:?}) conflicts with the normal-mode {action} command; choose another key"
                 )));
             }
@@ -110,7 +116,7 @@ impl CustomKeyBindings {
                 } else {
                     "is not an unmodified printable ASCII key"
                 };
-                return Err(AppError::Config(format!(
+                return Err(config_error(format!(
                     "custom movement key {direction} ({key:?}) {reason}; choose an unmodified printable ASCII key"
                 )));
             }
@@ -120,7 +126,7 @@ impl CustomKeyBindings {
                 .iter()
                 .find(|(_, existing_key)| existing_key == key)
             {
-                return Err(AppError::Config(format!(
+                return Err(config_error(format!(
                     "custom movement keys {other_direction} and {direction} both use {key:?}; use four distinct keys"
                 )));
             }
@@ -508,7 +514,7 @@ pub fn save_safe_preferences(path: &Path, preferences: SafePreferences) -> Resul
     config.runtime.reduced_motion = Some(preferences.reduced_motion);
     config.runtime.custom_keys = preferences.custom_keys;
     let serialized = toml::to_string_pretty(&config)
-        .map_err(|error| AppError::Config(format!("could not serialize config: {error}")))?;
+        .map_err(|error| config_error(format!("could not serialize config: {error}")))?;
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     fs::create_dir_all(parent)
         .map_err(|error| AppError::io("could not create config directory", error))?;
@@ -527,7 +533,7 @@ pub fn save_safe_preferences(path: &Path, preferences: SafePreferences) -> Resul
 /// # Errors
 /// Returns an invalid-configuration error for malformed or unknown TOML fields.
 pub fn parse_file_config(input: &str) -> Result<FileConfig, AppError> {
-    toml::from_str(input).map_err(|error| AppError::Config(error.to_string()))
+    toml::from_str(input).map_err(|error| config_error(error.to_string()))
 }
 
 #[must_use]
@@ -540,20 +546,20 @@ pub(crate) fn compile_exclusions(root: &Path, patterns: &[String]) -> Result<Git
     let mut builder = GitignoreBuilder::new(root);
     for pattern in patterns {
         builder.add_line(None, pattern).map_err(|error| {
-            AppError::Config(format!("invalid scanner exclusion {pattern:?}: {error}"))
+            config_error(format!("invalid scanner exclusion {pattern:?}: {error}"))
         })?;
     }
     builder
         .build()
-        .map_err(|error| AppError::Config(format!("invalid scanner exclusions: {error}")))
+        .map_err(|error| config_error(format!("invalid scanner exclusions: {error}")))
 }
 
 fn load_file(path: &Path) -> Result<FileConfig, AppError> {
     fs::read_to_string(path)
         .map_err(|error| {
-            AppError::Config(format!(
+            config_error(format!(
                 "could not read {}: {error}",
-                path.to_string_lossy()
+                safe_display_path_text(path)
             ))
         })
         .and_then(|input| parse_file_config(&input))
@@ -573,7 +579,7 @@ where
         .filter(|value| !value.is_empty())
         .map(|value| {
             T::from_str(&value.to_string_lossy(), true)
-                .map_err(|error| AppError::Config(format!("{name}: {error}")))
+                .map_err(|error| config_error(format!("{name}: {error}")))
         })
         .transpose()
 }
@@ -614,5 +620,35 @@ fn validate_range(
         Err(AppError::Config(format!(
             "{name} must be between {minimum} and {maximum}; got {value}"
         )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn configuration_errors_escape_terminal_controls() {
+        let error = config_error("bad\n\u{202e}name\u{1b}[31m");
+        let message = error.to_string();
+        assert!(message.starts_with("invalid configuration: [deceptive]"));
+        assert!(message.contains("\\n"));
+        assert!(message.contains("\\u{202e}"));
+        assert!(message.contains("\\x1b"));
+        assert!(!message.chars().any(char::is_control));
+        assert!(!message.contains('\u{202e}'));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn missing_configuration_path_keeps_invalid_bytes_reversible() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt as _;
+
+        let path = PathBuf::from(OsString::from_vec(b"missing-\xff/config.toml".to_vec()));
+        let error = load_file(&path).expect_err("missing configuration should fail");
+        let message = error.to_string();
+        assert!(message.contains("[deceptive]"));
+        assert!(message.contains("missing-\\xff/config.toml"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,9 @@ use ratatui::backend::CrosstermBackend;
 
 use excise::config::{Cli, OutputFormat, RuntimeConfig, default_config_path};
 use excise::error::{AppError, ExitClass};
-use excise::native_path::ResolvedRoot;
+#[cfg(debug_assertions)]
+use excise::native_path::safe_display_os_str_text;
+use excise::native_path::{ResolvedRoot, safe_display_text};
 use excise::report::{ReportError, ScanReport};
 use excise::runtime::{RuntimeSettings, SystemClock, run, scan_headless};
 use excise::{TerminalEvents, TerminalSession, validate_terminal};
@@ -35,7 +37,7 @@ fn run_main() -> i32 {
             };
         }
         Err(error) => {
-            eprintln!("{error}");
+            eprintln!("{}", safe_error_text(error));
             return ExitClass::Usage.code();
         }
     };
@@ -105,7 +107,7 @@ fn run_main() -> i32 {
         let restore_result = session.restore();
         drop(session);
         if let Err(restore_error) = restore_result {
-            eprintln!("Error: {error}");
+            eprintln!("Error: {}", safe_error_text(&error));
             return report_error(&restore_error);
         }
         return report_error(&error);
@@ -124,8 +126,11 @@ fn run_main() -> i32 {
         (Ok(outcome), Ok(())) => outcome.exit_class().code(),
         (Err(error), Ok(())) | (Ok(_), Err(error)) => report_error(&error),
         (Err(run_error), Err(restore_error)) => {
-            eprintln!("Error: {run_error}");
-            eprintln!("Error while restoring terminal: {restore_error}");
+            eprintln!("Error: {}", safe_error_text(run_error));
+            eprintln!(
+                "Error while restoring terminal: {}",
+                safe_error_text(restore_error)
+            );
             ExitClass::Runtime.code()
         }
     }
@@ -171,17 +176,63 @@ fn write_scan_report_to(
 }
 
 fn report_error(error: &AppError) -> i32 {
-    eprintln!("Error: {error}");
+    eprintln!("Error: {}", safe_error_text(error));
     error.exit_class().code()
 }
 
 #[cfg(debug_assertions)]
 fn injected_runtime_error() -> Option<AppError> {
     let kind = std::env::var_os("EXCISE_TEST_ERROR_AFTER_TERMINAL_ENTRY")?;
-    Some(match kind.to_string_lossy().as_ref() {
-        "input" => AppError::io("injected input failure", io::Error::other("input failed")),
-        "render" => AppError::terminal("draw", "injected render failure"),
-        "worker" => AppError::Worker("injected worker failure".to_string()),
-        other => AppError::Invariant(format!("unknown injected failure {other}")),
+    Some(match kind.to_str() {
+        Some("input") => AppError::io("injected input failure", io::Error::other("input failed")),
+        Some("render") => AppError::terminal("draw", "injected render failure"),
+        Some("worker") => AppError::Worker("injected worker failure".to_string()),
+        _ => AppError::Invariant(format!(
+            "unknown injected failure {}",
+            safe_display_os_str_text(&kind)
+        )),
     })
+}
+
+fn safe_error_text(error: impl std::fmt::Display) -> String {
+    let error = error.to_string();
+    safe_display_text(&error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn report_error_text_escapes_controls_and_preserves_marker() {
+        let rendered = safe_error_text(AppError::Config("bad\n\u{202e}name\u{1b}[31m".to_string()));
+        assert!(rendered.starts_with("[deceptive]"));
+        assert!(rendered.contains("\\n"));
+        assert!(rendered.contains("\\u{202e}"));
+        assert!(rendered.contains("\\x1b"));
+        assert!(!rendered.chars().any(char::is_control));
+        assert!(!rendered.contains('\u{202e}'));
+    }
+
+    #[test]
+    fn report_error_keeps_missing_hostile_root_path_safe_once() {
+        let parent = tempfile::tempdir().expect("root-error parent should exist");
+        let path = parent.path().join("missing-\u{202e}root");
+        let error = ResolvedRoot::resolve(path).expect_err("missing root should fail to resolve");
+
+        let raw = error.to_string();
+        let rendered = safe_error_text(&error);
+        assert!(raw.contains("[deceptive]"));
+        assert!(raw.contains("missing-\\u{202e}root"));
+        assert_eq!(rendered, raw);
+        assert_eq!(
+            rendered
+                .matches(excise::native_path::DECEPTIVE_DISPLAY_MARKER)
+                .count(),
+            1,
+        );
+        assert_eq!(rendered.matches("\\u{202e}").count(), 1);
+        assert!(!rendered.chars().any(char::is_control));
+        assert!(!rendered.contains('\u{202e}'));
+    }
 }

--- a/src/native_path.rs
+++ b/src/native_path.rs
@@ -132,7 +132,10 @@ impl ResolvedRoot {
         let requested = NativePath::new(path);
         let resolved_path = fs::canonicalize(requested.as_path()).map_err(|error| {
             AppError::io(
-                format!("could not resolve {}", requested.safe_display().text),
+                format!(
+                    "could not resolve {}",
+                    safe_display_path_text(requested.as_path())
+                ),
                 error,
             )
         })?;
@@ -140,7 +143,7 @@ impl ResolvedRoot {
             AppError::io(
                 format!(
                     "could not inspect {}",
-                    safe_display_path(&resolved_path).text
+                    safe_display_path_text(&resolved_path)
                 ),
                 error,
             )
@@ -148,7 +151,7 @@ impl ResolvedRoot {
         if !metadata.is_dir() {
             return Err(AppError::Cli(format!(
                 "scan root is not a directory: {}",
-                requested.safe_display().text
+                safe_display_path_text(requested.as_path())
             )));
         }
         let identity = identity_for(&resolved_path, &metadata)

--- a/src/report.rs
+++ b/src/report.rs
@@ -9,7 +9,9 @@ use crate::deletion::{DeletionEntryOutcome, DeletionReport, PlannedKind};
 #[cfg(test)]
 use crate::model::NodeId;
 use crate::model::{ByteBounds, NodeKind, NodeState};
-use crate::native_path::{EncodedNativePath, NativeIdentity, NativePath, safe_display_path};
+use crate::native_path::{
+    EncodedNativePath, NativeIdentity, NativePath, safe_display_path_text, safe_display_text,
+};
 use crate::outcome::RunSummary;
 use crate::state::files::FileTree;
 
@@ -213,7 +215,7 @@ impl Serialize for StreamingScanReport<'_> {
     {
         let mut document = serializer.serialize_map(Some(8))?;
         let root = NativePath::new(self.root).encode();
-        let display_root = safe_display_path(self.root).text;
+        let display_root = safe_display_path_text(self.root);
         document.serialize_entry("document_kind", "scan-report")?;
         document.serialize_entry("schema_version", &REPORT_SCHEMA_VERSION)?;
         document.serialize_entry("root", &root)?;
@@ -272,12 +274,12 @@ impl Serialize for ScanReportEntryRef<'_> {
     {
         let mut entry = serializer.serialize_map(Some(10))?;
         let path = NativePath::new(&self.path).encode();
-        let display_path = safe_display_path(&self.path).text;
+        let display_path = safe_display_path_text(&self.path);
         let unscanned_reason = self
             .node
             .unscanned_reason
             .as_ref()
-            .map(|reason| format!("{reason:?}"));
+            .map(|reason| safe_display_text(&format!("{reason:?}")));
         entry.serialize_entry("path", &path)?;
         entry.serialize_entry("display_path", &display_path)?;
         entry.serialize_entry("kind", &self.node.kind)?;
@@ -309,7 +311,7 @@ fn write_scan_table_entries(tree: &FileTree, writer: &mut impl Write) -> Result<
             display_bounds(node.metrics.reclaimable_bytes),
             node.metrics.apparent_bytes,
             node.kind,
-            safe_display_path(&path).text,
+            safe_display_path_text(&path),
         )?;
         stack.extend(node.children.iter().rev().copied());
     }
@@ -431,7 +433,7 @@ impl Serialize for DeletionHistoryOperationRef<'_> {
         let root = self.report.scan_root.join(&self.report.root_relative_path);
         let mut operation = serializer.serialize_map(Some(5))?;
         operation.serialize_entry("root", &NativePath::new(&root).encode())?;
-        operation.serialize_entry("display_root", &safe_display_path(&root).text)?;
+        operation.serialize_entry("display_root", &safe_display_path_text(&root))?;
         operation.serialize_entry("precise", &self.report.precise)?;
         operation.serialize_entry("soft_cancelled", &self.report.soft_cancelled)?;
         operation.serialize_entry(
@@ -478,7 +480,7 @@ impl Serialize for DeletionHistoryEntryRef<'_> {
         let snapshot = &self.result.entry.snapshot;
         let mut entry = serializer.serialize_map(Some(8))?;
         entry.serialize_entry("path", &NativePath::new(&path).encode())?;
-        entry.serialize_entry("display_path", &safe_display_path(&path).text)?;
+        entry.serialize_entry("display_path", &safe_display_path_text(&path))?;
         entry.serialize_entry("identity", &snapshot.identity)?;
         entry.serialize_entry("kind", &snapshot.kind)?;
         entry.serialize_entry("apparent_bytes", &snapshot.apparent_bytes)?;
@@ -522,13 +524,15 @@ impl Serialize for DeletionOutcomeRecordRef<'_> {
             DeletionEntryOutcome::Changed(message) => {
                 let mut outcome = serializer.serialize_map(Some(2))?;
                 outcome.serialize_entry("status", "changed")?;
-                outcome.serialize_entry("detail", message)?;
+                let detail = safe_display_text(message);
+                outcome.serialize_entry("detail", &detail)?;
                 outcome
             }
             DeletionEntryOutcome::Failed(message) => {
                 let mut outcome = serializer.serialize_map(Some(2))?;
                 outcome.serialize_entry("status", "failed")?;
-                outcome.serialize_entry("detail", message)?;
+                let detail = safe_display_text(message);
+                outcome.serialize_entry("detail", &detail)?;
                 outcome
             }
         };
@@ -558,6 +562,7 @@ fn display_bounds(bounds: ByteBounds) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::native_path::DECEPTIVE_DISPLAY_MARKER;
 
     use file_id::FileId;
     use serde_json::{Value, json};
@@ -856,5 +861,185 @@ mod tests {
             ScanReportState::Uncertain,
             "unknown model bounds must not depend on transport counters"
         );
+    }
+    #[test]
+    fn hostile_paths_in_exports_are_marked_and_escaped() {
+        use crate::deletion::{DeletionEntryResult, PlannedEntry, PlannedSnapshot};
+
+        let parent = tempfile::tempdir().expect("report parent should exist");
+        let root = parent.path().join("scan-\u{202e}-root");
+        std::fs::create_dir(&root).expect("report root should be created");
+        // Keep the hostile path synthetic: Windows rejects ESC in filesystem names.
+        let fixture_path = root.join("entry-fixture");
+        std::fs::write(&fixture_path, b"payload").expect("report entry should be written");
+        let metadata =
+            std::fs::symlink_metadata(&fixture_path).expect("report metadata should exist");
+        let entry_identity = crate::native_path::identity_for(&fixture_path, &metadata)
+            .expect("report identity should be readable")
+            .expect("report entry should not be a link");
+        let hostile_path = root.join("entry-\u{1b}[31m");
+        let mut tree = FileTree::new(root.clone(), false, crate::model::DEFAULT_PROCESS_MIB)
+            .expect("report model should be created");
+        tree.add_entry(&metadata, &hostile_path, entry_identity.clone())
+            .expect("hostile report entry should be added");
+        tree.complete_directory(&root, None)
+            .expect("report root should complete");
+        tree.finalize().expect("report model should finalize");
+
+        let summary = RunSummary::default();
+        let mut encoded = Vec::new();
+        write_scan_report_json(
+            &root,
+            &tree,
+            &summary,
+            scan_report_state(&tree, &summary, false),
+            &mut encoded,
+        )
+        .expect("hostile scan report should serialize");
+        let document: Value = serde_json::from_slice(&encoded).expect("scan report should parse");
+        let display_root = document["display_root"]
+            .as_str()
+            .expect("scan display root should be a string");
+        assert!(display_root.contains(DECEPTIVE_DISPLAY_MARKER));
+        assert!(display_root.contains("\\u{202e}"));
+        let entry = document["entries"]
+            .as_array()
+            .and_then(|entries| {
+                entries.iter().find(|entry| {
+                    entry["display_path"]
+                        .as_str()
+                        .is_some_and(|path| path.contains("entry-"))
+                })
+            })
+            .expect("hostile scan entry should be reported");
+        let display_path = entry["display_path"]
+            .as_str()
+            .expect("scan display path should be a string");
+        assert!(display_path.contains(DECEPTIVE_DISPLAY_MARKER));
+        assert!(display_path.contains("\\x1b"));
+        assert!(!display_path.contains('\u{1b}'));
+
+        let mut table = Vec::new();
+        write_scan_report_table(&tree, &mut table).expect("hostile scan table should serialize");
+        let table = String::from_utf8(table).expect("scan table should be UTF-8");
+        assert!(table.contains(DECEPTIVE_DISPLAY_MARKER));
+        assert!(table.contains("\\x1b"));
+
+        let report = Arc::new(DeletionReport {
+            target_node_id: NodeId(1),
+            root_relative_path: PathBuf::from("entry-\u{1b}[31m"),
+            scan_root: root,
+            entries: vec![DeletionEntryResult {
+                entry: PlannedEntry {
+                    relative_path: PathBuf::from("entry-\u{1b}[31m"),
+                    snapshot: PlannedSnapshot {
+                        identity: entry_identity,
+                        kind: PlannedKind::File,
+                        apparent_bytes: 1,
+                        allocated_bytes: Some(1),
+                        modified_nanos: Some(1),
+                    },
+                },
+                outcome: DeletionEntryOutcome::Deleted,
+            }],
+            soft_cancelled: false,
+            precise: true,
+            estimated_bytes: 0,
+        });
+        let mut history = Vec::new();
+        write_deletion_history_json(&[report], &mut history)
+            .expect("hostile deletion history should serialize");
+        let history: Value =
+            serde_json::from_slice(&history).expect("deletion history should parse");
+        assert!(
+            history["operations"][0]["display_root"]
+                .as_str()
+                .is_some_and(|path| {
+                    path.contains(DECEPTIVE_DISPLAY_MARKER)
+                        && path.contains("\\x1b")
+                        && !path.contains('\u{1b}')
+                })
+        );
+        assert!(
+            history["operations"][0]["entries"][0]["display_path"]
+                .as_str()
+                .is_some_and(|path| {
+                    path.contains(DECEPTIVE_DISPLAY_MARKER)
+                        && path.contains("\\x1b")
+                        && !path.contains('\u{1b}')
+                })
+        );
+    }
+
+    #[test]
+    fn deletion_outcome_details_are_marked_and_escaped() {
+        use crate::deletion::{DeletionEntryResult, PlannedEntry, PlannedSnapshot};
+
+        let hostile = format!("{DECEPTIVE_DISPLAY_MARKER} changed\n\u{202e}\u{1b}[31m");
+        let report = Arc::new(DeletionReport {
+            target_node_id: NodeId(0),
+            root_relative_path: PathBuf::from("target"),
+            scan_root: PathBuf::from("/scan"),
+            entries: vec![
+                DeletionEntryResult {
+                    entry: PlannedEntry {
+                        relative_path: PathBuf::from("changed"),
+                        snapshot: PlannedSnapshot {
+                            identity: identity(),
+                            kind: PlannedKind::File,
+                            apparent_bytes: 3,
+                            allocated_bytes: Some(4096),
+                            modified_nanos: Some(1),
+                        },
+                    },
+                    outcome: DeletionEntryOutcome::Changed(hostile.clone()),
+                },
+                DeletionEntryResult {
+                    entry: PlannedEntry {
+                        relative_path: PathBuf::from("failed"),
+                        snapshot: PlannedSnapshot {
+                            identity: identity(),
+                            kind: PlannedKind::File,
+                            apparent_bytes: 3,
+                            allocated_bytes: Some(4096),
+                            modified_nanos: Some(1),
+                        },
+                    },
+                    outcome: DeletionEntryOutcome::Failed(hostile),
+                },
+            ],
+            soft_cancelled: false,
+            precise: true,
+            estimated_bytes: 0,
+        });
+
+        let mut encoded = Vec::new();
+        write_deletion_history_json(&[report], &mut encoded)
+            .expect("hostile deletion outcomes should serialize");
+        assert!(!encoded.contains(&0x1b));
+        assert!(
+            !encoded
+                .windows(3)
+                .any(|window| window == [0xe2, 0x80, 0xae])
+        );
+
+        let history: Value =
+            serde_json::from_slice(&encoded).expect("deletion history should parse");
+        let entries = history["operations"][0]["entries"]
+            .as_array()
+            .expect("deletion history entries should be an array");
+        for (entry, status) in entries.iter().zip(["changed", "failed"]) {
+            assert_eq!(entry["outcome"]["status"], status);
+            let detail = entry["outcome"]["detail"]
+                .as_str()
+                .expect("outcome detail should be a string");
+            assert!(detail.starts_with(DECEPTIVE_DISPLAY_MARKER));
+            assert_eq!(detail.matches(DECEPTIVE_DISPLAY_MARKER).count(), 2);
+            assert!(detail.contains("\\n"));
+            assert!(detail.contains("\\u{202e}"));
+            assert!(detail.contains("\\x1b"));
+            assert!(!detail.chars().any(char::is_control));
+            assert!(!detail.contains('\u{202e}'));
+        }
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3,7 +3,7 @@ mod scanner;
 mod worker;
 
 use std::fs::OpenOptions;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crossbeam_channel::{RecvTimeoutError, TryRecvError};
@@ -18,7 +18,9 @@ use crate::animation::AnimationScheduler;
 use crate::config::{CustomKeyBindings, KeyPreset, SafePreferences, save_safe_preferences};
 use crate::error::{AppError, ExitClass};
 use crate::input::{InputCommand, InputEvent, InputSource, handle_keypress};
-use crate::native_path::{NativeIdentity, safe_display_path};
+use crate::native_path::{
+    DECEPTIVE_DISPLAY_MARKER, NativeIdentity, safe_display_path_text, safe_display_text,
+};
 use crate::outcome::{OperationOutcome, RunSummary};
 use crate::report::{ScanReport, ScanReportState, scan_report_state};
 use crate::state::files::FileTree;
@@ -332,10 +334,9 @@ where
                     Ok(path)
                 });
                 match result {
-                    Ok(path) => self.app.show_notice(format!(
-                        "Scan report exported to {}",
-                        safe_display_path(&path).text
-                    )),
+                    Ok(path) => self
+                        .app
+                        .show_notice(export_notice("Scan report exported to", &path)),
                     Err(error) => self.app.show_error(format!("Scan export failed: {error}")),
                 }
             }
@@ -354,10 +355,8 @@ where
                 match result {
                     Ok(path) => {
                         self.app.clear_deletion_history();
-                        self.app.show_notice(format!(
-                            "Deletion history exported to {}",
-                            safe_display_path(&path).text
-                        ));
+                        self.app
+                            .show_notice(export_notice("Deletion history exported to", &path));
                     }
                     Err(error) => {
                         self.app
@@ -462,8 +461,8 @@ where
             }
             WorkerEvent::ScanUnscanned { path, reason } => {
                 self.summary.unscanned_entries += 1;
-                self.summary.last_unscanned_path = Some(safe_display_path(&path).text);
-                self.summary.last_unscanned_reason = Some(format!("{reason:?}"));
+                self.summary.last_unscanned_path = Some(safe_display_path_text(&path));
+                self.summary.last_unscanned_reason = Some(display_reason(&reason));
                 match &reason {
                     crate::model::UnscannedReason::Excluded(_) => {
                         self.summary.excluded_entries += 1;
@@ -479,7 +478,7 @@ where
                         self.summary.unreadable_entries += 1;
                         self.summary.last_unreadable_path =
                             self.summary.last_unscanned_path.clone();
-                        self.summary.last_worker_error = Some(message.clone());
+                        self.summary.last_worker_error = Some(safe_display_text(message));
                         self.app.increment_failed_to_read();
                     }
                     crate::model::UnscannedReason::MemoryAggregation => {}
@@ -487,13 +486,12 @@ where
                 self.app.record_unscanned(&path, reason)?;
             }
             WorkerEvent::ScanFailed { path, message } => {
+                let message = safe_display_text(&message);
                 self.summary.unscanned_entries += 1;
-                self.summary.last_unscanned_path =
-                    path.as_deref().map(|path| safe_display_path(path).text);
-                self.summary.last_unscanned_reason = Some(message.clone());
                 self.summary.unreadable_entries += 1;
-                self.summary.last_unreadable_path =
-                    path.as_deref().map(|path| safe_display_path(path).text);
+                self.summary.last_unscanned_path = path.as_deref().map(safe_display_path_text);
+                self.summary.last_unreadable_path = self.summary.last_unscanned_path.clone();
+                self.summary.last_unscanned_reason = Some(message.clone());
                 self.summary.last_worker_error = Some(message.clone());
                 if let Some(path) = path {
                     self.app.record_unscanned(
@@ -796,6 +794,29 @@ where
             .ok_or_else(|| AppError::Invariant("worker pool unavailable".to_string()))
     }
 }
+fn export_notice(prefix: &str, path: &Path) -> String {
+    format!("{prefix} {}", safe_display_path_text(path))
+}
+
+fn display_reason(reason: &crate::model::UnscannedReason) -> String {
+    let deceptive = match reason {
+        crate::model::UnscannedReason::Excluded(value)
+        | crate::model::UnscannedReason::Metadata(value)
+        | crate::model::UnscannedReason::Replacement(value) => {
+            safe_display_text(value).starts_with(DECEPTIVE_DISPLAY_MARKER)
+        }
+        crate::model::UnscannedReason::SymbolicLink
+        | crate::model::UnscannedReason::FilesystemBoundary
+        | crate::model::UnscannedReason::MemoryAggregation => false,
+    };
+    let rendered = safe_display_text(&format!("{reason:?}"));
+    if deceptive && !rendered.contains(DECEPTIVE_DISPLAY_MARKER) {
+        format!("{DECEPTIVE_DISPLAY_MARKER} {rendered}")
+    } else {
+        rendered
+    }
+}
+
 /// Runs the production scanner and bounded model without acquiring a terminal.
 ///
 /// # Errors
@@ -843,8 +864,8 @@ pub fn scan_headless(settings: RuntimeSettings) -> Result<OperationOutcome<ScanR
                     .map_err(|error| AppError::Model(error.to_string()))?,
                 WorkerEvent::ScanUnscanned { path, reason } => {
                     summary.unscanned_entries = summary.unscanned_entries.saturating_add(1);
-                    summary.last_unscanned_path = Some(safe_display_path(&path).text);
-                    summary.last_unscanned_reason = Some(format!("{reason:?}"));
+                    summary.last_unscanned_path = Some(safe_display_path_text(&path));
+                    summary.last_unscanned_reason = Some(display_reason(&reason));
                     match &reason {
                         crate::model::UnscannedReason::Excluded(_) => {
                             summary.excluded_entries = summary.excluded_entries.saturating_add(1);
@@ -863,7 +884,7 @@ pub fn scan_headless(settings: RuntimeSettings) -> Result<OperationOutcome<ScanR
                             summary
                                 .last_unreadable_path
                                 .clone_from(&summary.last_unscanned_path);
-                            summary.last_worker_error = Some(message.clone());
+                            summary.last_worker_error = Some(safe_display_text(message));
                             tree.failed_to_read = tree.failed_to_read.saturating_add(1);
                         }
                         crate::model::UnscannedReason::MemoryAggregation => {}
@@ -872,10 +893,10 @@ pub fn scan_headless(settings: RuntimeSettings) -> Result<OperationOutcome<ScanR
                         .map_err(|error| AppError::Model(error.to_string()))?;
                 }
                 WorkerEvent::ScanFailed { path, message } => {
+                    let message = safe_display_text(&message);
                     summary.unscanned_entries = summary.unscanned_entries.saturating_add(1);
                     summary.unreadable_entries = summary.unreadable_entries.saturating_add(1);
-                    summary.last_unscanned_path =
-                        path.as_deref().map(|path| safe_display_path(path).text);
+                    summary.last_unscanned_path = path.as_deref().map(safe_display_path_text);
                     summary
                         .last_unreadable_path
                         .clone_from(&summary.last_unscanned_path);
@@ -945,4 +966,44 @@ fn next_export_path(kind: &str) -> Result<PathBuf, String> {
 #[must_use]
 pub const fn outcome_exit_class(outcome: &OperationOutcome<RunSummary>) -> ExitClass {
     outcome.exit_class()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn export_notice_preserves_deceptive_path_marker() {
+        let path = Path::new("report-\u{202e}name\u{1b}[31m.json");
+        let rendered = export_notice("Scan report exported to", path);
+        assert!(rendered.starts_with("Scan report exported to [deceptive]"));
+        assert!(rendered.contains("\\u{202e}"));
+        assert!(rendered.contains("\\x1b"));
+        assert!(!rendered.chars().any(char::is_control));
+        assert!(!rendered.contains('\u{202e}'));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn export_notice_preserves_invalid_native_path_bytes() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt as _;
+
+        let path = PathBuf::from(OsString::from_vec(b"report-\xff.json".to_vec()));
+        let rendered = export_notice("Deletion history exported to", &path);
+        assert!(rendered.contains("[deceptive]"));
+        assert!(rendered.contains("report-\\xff.json"));
+    }
+
+    #[test]
+    fn runtime_unscanned_reasons_are_safe_display_text() {
+        let reason =
+            crate::model::UnscannedReason::Metadata("metadata failed\t\u{202e}name".to_string());
+        let rendered = display_reason(&reason);
+        assert!(rendered.contains("[deceptive]"));
+        assert!(rendered.contains("\\t"));
+        assert!(rendered.contains("\\u{202e}"));
+        assert!(!rendered.chars().any(char::is_control));
+        assert!(!rendered.contains('\u{202e}'));
+    }
 }

--- a/src/runtime/worker.rs
+++ b/src/runtime/worker.rs
@@ -1,4 +1,6 @@
 use std::fs::Metadata;
+#[cfg(all(test, unix))]
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -12,7 +14,11 @@ use crate::deletion::{
     build_plan_cancellable_with_root_identity, execute_plan, revalidate_plan_cancellable,
 };
 use crate::error::AppError;
-use crate::native_path::NativeIdentity;
+#[cfg(test)]
+use crate::native_path::DECEPTIVE_DISPLAY_MARKER;
+#[cfg(all(test, unix))]
+use crate::native_path::safe_display_path_text;
+use crate::native_path::{NativeIdentity, safe_display_text};
 use crate::state::FileToDelete;
 
 use super::scanner::{self, ScannerOptions};
@@ -295,12 +301,76 @@ fn deletion_worker(
         }
     }
 }
+#[cfg(all(test, unix))]
+fn safe_worker_path(path: &Path) -> String {
+    safe_display_path_text(path)
+}
+
+fn safe_worker_text(value: &str) -> String {
+    safe_display_text(value)
+}
+
+#[cfg(all(test, unix))]
+fn format_deletion_error(
+    error: DeletionPlanError,
+    scan_root: &Path,
+    target_relative: &Path,
+) -> String {
+    match error {
+        DeletionPlanError::Io {
+            path,
+            message,
+            kind: _,
+        } => {
+            let target_lossy = target_relative.to_string_lossy();
+            let root_lossy = scan_root.to_string_lossy();
+            let path = if path == target_lossy {
+                safe_worker_path(target_relative)
+            } else if path == root_lossy {
+                safe_worker_path(scan_root)
+            } else {
+                safe_worker_text(&path)
+            };
+            format!(
+                "deletion planning failed for {path}: {}",
+                safe_worker_text(&message)
+            )
+        }
+        error => safe_worker_text(&error.to_string()),
+    }
+}
+
+fn sanitize_worker_event(event: WorkerEvent) -> WorkerEvent {
+    match event {
+        WorkerEvent::ScanFailed { path, message } => WorkerEvent::ScanFailed {
+            path,
+            message: safe_worker_text(&message),
+        },
+        WorkerEvent::ScanUnscanned { path, reason } => WorkerEvent::ScanUnscanned {
+            path,
+            reason: match reason {
+                crate::model::UnscannedReason::Excluded(pattern) => {
+                    crate::model::UnscannedReason::Excluded(safe_worker_text(&pattern))
+                }
+                crate::model::UnscannedReason::Metadata(message) => {
+                    crate::model::UnscannedReason::Metadata(safe_worker_text(&message))
+                }
+                crate::model::UnscannedReason::Replacement(message) => {
+                    crate::model::UnscannedReason::Replacement(safe_worker_text(&message))
+                }
+                reason => reason,
+            },
+        },
+        event => event,
+    }
+}
 
 pub(super) fn send_event(
     sender: &Sender<WorkerEvent>,
     mut event: WorkerEvent,
     cancelled: &AtomicBool,
 ) -> bool {
+    event = sanitize_worker_event(event);
     loop {
         match sender.send_timeout(event, CHANNEL_RETRY) {
             Ok(()) => return true,
@@ -1017,5 +1087,110 @@ mod tests {
 
         assert!(started.elapsed() < Duration::from_millis(500));
         assert!(cancelled.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn worker_error_messages_escape_controls_and_bidi_overrides() {
+        let (sender, events) = bounded(1);
+        let cancelled = AtomicBool::new(false);
+        assert!(send_event(
+            &sender,
+            WorkerEvent::ScanFailed {
+                path: Some(PathBuf::from("/scan/hostile")),
+                message: "permission denied\n\u{202e}name\u{1b}[31m".to_string(),
+            },
+            &cancelled,
+        ));
+        let WorkerEvent::ScanFailed { message, .. } = events
+            .recv()
+            .expect("sanitized worker error should be delivered")
+        else {
+            panic!("expected a scan failure event");
+        };
+        assert!(message.starts_with(DECEPTIVE_DISPLAY_MARKER));
+        assert!(message.contains("\\n"));
+        assert!(message.contains("\\u{202e}"));
+        assert!(message.contains("\\x1b"));
+        assert!(!message.chars().any(char::is_control));
+        assert!(!message.contains('\u{202e}'));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deletion_errors_preserve_invalid_target_bytes() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt as _;
+
+        let relative = PathBuf::from(OsString::from_vec(b"bad\xffname".to_vec()));
+        let error = DeletionPlanError::Io {
+            path: relative.to_string_lossy().into_owned(),
+            message: "permission denied".to_string(),
+            kind: std::io::ErrorKind::PermissionDenied,
+        };
+        let rendered = format_deletion_error(error, Path::new("/scan"), &relative);
+        assert!(rendered.contains(DECEPTIVE_DISPLAY_MARKER));
+        assert!(rendered.contains("bad\\xffname"));
+        assert!(!rendered.chars().any(char::is_control));
+    }
+
+    #[test]
+    fn worker_unscanned_error_reasons_escape_controls() {
+        let (sender, events) = bounded(1);
+        let cancelled = AtomicBool::new(false);
+        assert!(send_event(
+            &sender,
+            WorkerEvent::ScanUnscanned {
+                path: PathBuf::from("/scan/hostile"),
+                reason: crate::model::UnscannedReason::Metadata(
+                    "metadata failed\t\u{202e}name".to_string(),
+                ),
+            },
+            &cancelled,
+        ));
+        let WorkerEvent::ScanUnscanned { reason, .. } = events
+            .recv()
+            .expect("sanitized unscanned event should be delivered")
+        else {
+            panic!("expected an unscanned event");
+        };
+        let crate::model::UnscannedReason::Metadata(message) = reason else {
+            panic!("expected metadata reason");
+        };
+        assert!(message.starts_with(DECEPTIVE_DISPLAY_MARKER));
+        assert!(message.contains("\\t"));
+        assert!(message.contains("\\u{202e}"));
+        assert!(!message.chars().any(char::is_control));
+        assert!(!message.contains('\u{202e}'));
+    }
+    #[test]
+    fn deletion_plan_errors_remain_safe_when_rendered() {
+        let (sender, events) = bounded(1);
+        let cancelled = AtomicBool::new(false);
+        assert!(send_event(
+            &sender,
+            WorkerEvent::DeletionPlanned {
+                target_node_id: crate::model::NodeId(1),
+                result: Err(DeletionPlanError::Io {
+                    path: "bad\u{202e}name".to_string(),
+                    message: "permission denied\n\u{202e}name\u{1b}[31m".to_string(),
+                    kind: std::io::ErrorKind::PermissionDenied,
+                }),
+            },
+            &cancelled,
+        ));
+        let WorkerEvent::DeletionPlanned { result, .. } =
+            events.recv().expect("deletion error should be delivered")
+        else {
+            panic!("expected a deletion plan event");
+        };
+        let message = result
+            .expect_err("injected deletion error should remain an error")
+            .to_string();
+        assert!(message.contains(DECEPTIVE_DISPLAY_MARKER));
+        assert!(message.contains("\\n"));
+        assert!(message.contains("\\u{202e}"));
+        assert!(message.contains("\\x1b"));
+        assert!(!message.chars().any(char::is_control));
+        assert!(!message.contains('\u{202e}'));
     }
 }

--- a/src/ui/display.rs
+++ b/src/ui/display.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::time::Duration;
 
 use ratatui::Terminal;
@@ -7,20 +8,24 @@ use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph, Widget, Wrap};
+use unicode_width::UnicodeWidthStr as _;
 
 use crate::UiMode;
 use crate::animation::AnimationScheduler;
 use crate::config::KeyPreset;
 use crate::error::AppError;
-use crate::model::{ByteBounds, NodeKind, NodeState, SyntheticKind};
-use crate::native_path::safe_display_os_str;
+use crate::model::{ByteBounds, NodeKind, NodeState, SyntheticKind, UnscannedReason};
+use crate::native_path::SafeDisplayPath;
 use crate::os::is_user_admin;
 use crate::state::UiEffects;
 use crate::state::files::FileTree;
 use crate::state::tiles::{Board, FileType};
 use crate::theme::Theme;
 use crate::ui::TermTooSmall;
-use crate::ui::format::{DisplaySize, display_path, truncate_middle};
+use crate::ui::format::{
+    DECEPTIVE_DISPLAY_MARKER, DisplaySize, display_os_str_middle, display_path_info,
+    display_path_middle, display_text, display_text_info, truncate_marked, truncate_middle,
+};
 use crate::ui::grid::RectangleGrid;
 use crate::ui::modals::{ConfirmBox, ErrorBox, HelpBox, MessageBox, NoticeBox, WarningBox};
 
@@ -363,10 +368,7 @@ fn render_instrument_header(
     let current = file_tree.current_node();
     let total = file_tree.total_node();
     let (marker, state, state_color) = view_state(ui_mode, current.state, ascii, theme);
-    let path = truncate_middle(
-        &display_path(&file_tree.get_current_path()),
-        area.width.saturating_sub(30),
-    );
+    let path = display_path_middle(&file_tree.get_current_path(), area.width.saturating_sub(30));
     let title = Line::from(vec![
         Span::styled(
             " EXCISE ",
@@ -484,9 +486,8 @@ fn render_list(buffer: &mut Buffer, area: Rect, board: &Board, theme: Theme, asc
             (FileType::File, _) if tile.uncertain => "?",
             _ => " ",
         };
-        let name = safe_display_os_str(&tile.name).text;
         let name_width = area.width.saturating_sub(28);
-        let name = truncate_middle(&name, name_width);
+        let name = display_os_str_middle(&tile.name, name_width);
         let size = if tile.uncertain && tile.size == 0 {
             "unknown".to_string()
         } else if tile.uncertain {
@@ -583,9 +584,28 @@ fn render_inspector(
         },
     );
     let reason = node.unscanned_reason.as_ref().map_or_else(
-        || "scope     materialized".to_string(),
-        |reason| format!("scope     {reason:?}"),
+        || display_text_info("scope     materialized"),
+        |reason| {
+            let mut displayed = display_text_info(&format!("scope     {reason:?}"));
+            let deceptive = match reason {
+                UnscannedReason::Excluded(value)
+                | UnscannedReason::Metadata(value)
+                | UnscannedReason::Replacement(value) => {
+                    let displayed = display_text_info(value);
+                    displayed.deceptive || value.contains(DECEPTIVE_DISPLAY_MARKER)
+                }
+                UnscannedReason::SymbolicLink
+                | UnscannedReason::FilesystemBoundary
+                | UnscannedReason::MemoryAggregation => false,
+            };
+            displayed.deceptive |= deceptive;
+            displayed
+        },
     );
+    let reason_detail = SafeDisplayPath {
+        text: format!("{link_detail} · {}", reason.text),
+        deceptive: reason.deceptive,
+    };
     let action = if node.kind.is_synthetic() {
         "Enter focused rescan · deletion unavailable"
     } else if node.state == NodeState::Complete {
@@ -593,9 +613,8 @@ fn render_inspector(
     } else {
         "Incomplete scope · deletion unavailable"
     };
-    let name = safe_display_os_str(&node.name).text;
     let name_line = Line::styled(
-        truncate_middle(&name, inner.width),
+        display_os_str_middle(&node.name, inner.width),
         Style::default()
             .fg(theme.text_primary)
             .add_modifier(Modifier::BOLD),
@@ -632,9 +651,10 @@ fn render_inspector(
                 node.metrics.descendants
             )),
             Line::from(truncate_middle(&identity, inner.width)),
-            Line::from(truncate_middle(
-                &format!("{link_detail} · {reason}"),
+            Line::from(truncate_marked(
+                &reason_detail,
                 inner.width,
+                truncate_middle,
             )),
         ]
     } else if inner.height < 12 {
@@ -652,9 +672,10 @@ fn render_inspector(
                 node.metrics.descendants
             )),
             Line::from(truncate_middle(&identity, inner.width)),
-            Line::from(truncate_middle(
-                &format!("{link_detail} · {reason}"),
+            Line::from(truncate_marked(
+                &reason_detail,
                 inner.width,
+                truncate_middle,
             )),
             Line::styled(action, Style::default().fg(theme.text_muted)),
         ]
@@ -678,7 +699,7 @@ fn render_inspector(
             Line::from(format!("entries   {}", node.metrics.descendants)),
             Line::from(truncate_middle(&identity, inner.width)),
             Line::from(link_detail),
-            Line::from(truncate_middle(&reason, inner.width)),
+            Line::from(truncate_marked(&reason, inner.width, truncate_middle)),
             Line::from(""),
             Line::styled(action, Style::default().fg(theme.text_muted)),
         ]
@@ -744,16 +765,18 @@ fn render_status(
     };
     let transient_status = match ui_mode {
         UiMode::FilterInput { input, error } => Some(error.as_ref().map_or_else(
-            || format!("/ {input}_  [Enter] apply  [Esc] cancel"),
-            |error| format!("/ {input}_  ERROR: {error}"),
+            || format!("/ {}_  [Enter] apply  [Esc] cancel", display_text(input)),
+            |error| format!("/ {}_  ERROR: {}", display_text(input), display_text(error)),
         )),
-        UiMode::Rescanning { target } => Some(format!(
-            "~ RESCANNING {} · deletion locked · [Esc] cancel",
-            display_path(target)
+        UiMode::Rescanning { target } => Some(status_with_path(
+            "~ RESCANNING ",
+            target,
+            " · deletion locked · [Esc] cancel",
+            area.width,
         )),
         UiMode::Loading => Some(ui_effects.last_read_path.as_ref().map_or_else(
             || "~ SCANNING · deletion locked".to_string(),
-            |path| format!("~ SCANNING {}", display_path(path)),
+            |path| status_with_path("~ SCANNING ", path, "", area.width),
         )),
         _ if file_tree.failed_to_read > 0 => {
             Some(format!("? {} unreadable entries", file_tree.failed_to_read))
@@ -785,6 +808,32 @@ fn render_status(
     .alignment(Alignment::Left)
     .render(area, buffer);
 }
+fn status_with_path(prefix: &str, path: &Path, suffix: &str, width: u16) -> String {
+    let displayed = display_path_info(path);
+    let marker = if displayed.deceptive {
+        if width == 0 {
+            ""
+        } else if usize::from(width) <= DECEPTIVE_DISPLAY_MARKER.width() {
+            "!"
+        } else {
+            DECEPTIVE_DISPLAY_MARKER
+        }
+    } else {
+        ""
+    };
+    let separator = if marker.is_empty() { "" } else { " " };
+    let reserved = marker
+        .width()
+        .saturating_add(separator.width())
+        .saturating_add(prefix.width())
+        .saturating_add(suffix.width());
+    let path_width = usize::from(width).saturating_sub(reserved);
+    let path = truncate_middle(
+        &displayed.text,
+        u16::try_from(path_width).unwrap_or(u16::MAX),
+    );
+    format!("{marker}{separator}{prefix}{path}{suffix}")
+}
 
 fn safety_label(reduced_guardrails: bool, elevated: bool, width: u16) -> Option<&'static str> {
     match (reduced_guardrails, elevated) {
@@ -802,10 +851,22 @@ fn status_with_safety(
     elevated: bool,
     width: u16,
 ) -> String {
-    match safety_label(reduced_guardrails, elevated, width) {
-        Some(label) => format!("{label} · {status}"),
-        None => status,
+    let Some(label) = safety_label(reduced_guardrails, elevated, width) else {
+        return status;
+    };
+    if let Some(status) = status
+        .strip_prefix(DECEPTIVE_DISPLAY_MARKER)
+        .and_then(|status| status.strip_prefix(' '))
+    {
+        return format!("{DECEPTIVE_DISPLAY_MARKER} {label} · {status}");
     }
+    if let Some(status) = status.strip_prefix("! ~ RESCANNING ") {
+        return format!("! {label} · ~ RESCANNING {status}");
+    }
+    if let Some(status) = status.strip_prefix("! ~ SCANNING ") {
+        return format!("! {label} · ~ SCANNING {status}");
+    }
+    format!("{label} · {status}")
 }
 
 fn baseline_status(flags: &[&str], reduced_guardrails: bool, elevated: bool, width: u16) -> String {
@@ -975,6 +1036,109 @@ mod tests {
     }
 
     #[test]
+    fn deceptive_inspector_reason_marker_stays_visible_when_narrow() {
+        let root = tempfile::tempdir().expect("inspector root should exist");
+        let path = root.path().join("selected-entry");
+        fs::write(&path, b"selected contents").expect("fixture should be written");
+        let metadata = fs::symlink_metadata(&path).expect("fixture metadata should exist");
+        let identity = identity_for(&path, &metadata)
+            .expect("fixture identity should be readable")
+            .expect("fixture should not be a link");
+        let mut tree = FileTree::new(root.path().to_path_buf(), true, MIN_PROCESS_MIB)
+            .expect("file tree should be created");
+        tree.add_entry(&metadata, &path, identity)
+            .expect("fixture should be added")
+            .expect("fixture should remain materialized");
+        tree.record_unscanned(
+            &path,
+            UnscannedReason::Metadata("metadata failed\t\u{202e}name\u{1b}[31m".to_string()),
+        )
+        .expect("hostile reason should be recorded");
+        tree.complete_directory(root.path(), None)
+            .expect("fixture root should complete");
+        tree.finalize().expect("fixture tree should finalize");
+
+        let mut board = Board::new();
+        board.change_area(Rect::new(0, 0, 78, 10));
+        board.change_files(tree.files_in_current_folder(0));
+        board.set_selected_index(0);
+
+        for (width, height) in [(4, 64), (12, 40), (24, 24), (52, 10), (80, 10), (80, 14)] {
+            let area = Rect::new(0, 0, width, height);
+            let mut buffer = Buffer::empty(area);
+            render_inspector(
+                &mut buffer,
+                area,
+                &tree,
+                &board,
+                Theme::for_id(ThemeId::ExciseDark),
+                false,
+            );
+            let rendered = buffer.content.iter().fold(String::new(), |mut text, cell| {
+                text.push_str(cell.symbol());
+                text
+            });
+            assert!(!rendered.chars().any(char::is_control));
+            assert!(!rendered.contains('\u{202e}'));
+            assert!(
+                rendered.contains(DECEPTIVE_DISPLAY_MARKER) || rendered.contains('!'),
+                "deception marker lost at inspector size {width}x{height}: {rendered:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn premarked_inspector_reason_marker_stays_visible_when_narrow() {
+        let root = tempfile::tempdir().expect("inspector root should exist");
+        let path = root.path().join("selected-entry");
+        fs::write(&path, b"selected contents").expect("fixture should be written");
+        let metadata = fs::symlink_metadata(&path).expect("fixture metadata should exist");
+        let identity = identity_for(&path, &metadata)
+            .expect("fixture identity should be readable")
+            .expect("fixture should not be a link");
+        let mut tree = FileTree::new(root.path().to_path_buf(), true, MIN_PROCESS_MIB)
+            .expect("file tree should be created");
+        tree.add_entry(&metadata, &path, identity)
+            .expect("fixture should be added")
+            .expect("fixture should remain materialized");
+        tree.record_unscanned(
+            &path,
+            UnscannedReason::Metadata(format!("{DECEPTIVE_DISPLAY_MARKER} metadata failed")),
+        )
+        .expect("premarked reason should be recorded");
+        tree.complete_directory(root.path(), None)
+            .expect("fixture root should complete");
+        tree.finalize().expect("fixture tree should finalize");
+
+        let mut board = Board::new();
+        board.change_area(Rect::new(0, 0, 78, 10));
+        board.change_files(tree.files_in_current_folder(0));
+        board.set_selected_index(0);
+
+        for (width, height) in [(4, 64), (12, 40), (24, 24), (52, 10), (80, 10), (80, 14)] {
+            let area = Rect::new(0, 0, width, height);
+            let mut buffer = Buffer::empty(area);
+            render_inspector(
+                &mut buffer,
+                area,
+                &tree,
+                &board,
+                Theme::for_id(ThemeId::ExciseDark),
+                false,
+            );
+            let rendered = buffer.content.iter().fold(String::new(), |mut text, cell| {
+                text.push_str(cell.symbol());
+                text
+            });
+            assert!(!rendered.chars().any(char::is_control));
+            assert!(
+                rendered.contains(DECEPTIVE_DISPLAY_MARKER) || rendered.contains('!'),
+                "premarked deception marker lost at inspector size {width}x{height}: {rendered:?}"
+            );
+        }
+    }
+
+    #[test]
     fn safety_labels_survive_every_transient_status() {
         for status in [
             "~ SCANNING · deletion locked",
@@ -1004,5 +1168,25 @@ mod tests {
             32,
         );
         assert!(baseline.starts_with("! ELEVATED · ! REDUCED GUARD"));
+    }
+
+    #[test]
+    fn deceptive_status_marker_stays_visible_when_narrow() {
+        let path = Path::new("status-\u{202e}hostile");
+        for width in [1, 5, 10, 11, 12, 24] {
+            let rendered = status_with_path("~ RESCANNING ", path, "", width);
+            assert!(!rendered.chars().any(char::is_control));
+            assert!(!rendered.contains('\u{202e}'));
+            assert!(
+                rendered.starts_with('!') || rendered.starts_with(DECEPTIVE_DISPLAY_MARKER),
+                "deception marker lost at width {width}: {rendered:?}"
+            );
+        }
+        let marked = status_with_path("~ RESCANNING ", path, "", 80);
+        let marked_with_safety = status_with_safety(marked, true, true, 80);
+        assert!(marked_with_safety.starts_with(DECEPTIVE_DISPLAY_MARKER));
+        let compact = status_with_path("~ RESCANNING ", path, "", 5);
+        let compact_with_safety = status_with_safety(compact, true, true, 5);
+        assert!(compact_with_safety.starts_with('!'));
     }
 }

--- a/src/ui/format/display_path.rs
+++ b/src/ui/format/display_path.rs
@@ -1,13 +1,168 @@
-use std::borrow::Cow;
+use std::ffi::OsStr;
 use std::path::Path;
 
+use crate::native_path::{SafeDisplayPath, safe_display_os_str, safe_display_path};
+
+pub use crate::native_path::DECEPTIVE_DISPLAY_MARKER;
+
+#[cfg(test)]
+#[must_use]
+pub fn display_path_info(path: &Path) -> SafeDisplayPath {
+    let raw = safe_display_path(path);
+    if raw.deceptive {
+        raw
+    } else {
+        let normalized = crate::tests::fixtures::snapshot_path(path);
+        safe_display_path(Path::new(&normalized))
+    }
+}
+
 #[cfg(not(test))]
-pub fn display_path(path: &Path) -> Cow<'_, str> {
-    Cow::Owned(crate::native_path::safe_display_path(path).text)
+#[must_use]
+pub fn display_path_info(path: &Path) -> SafeDisplayPath {
+    safe_display_path(path)
+}
+
+#[must_use]
+pub fn display_os_str_info(value: &OsStr) -> SafeDisplayPath {
+    safe_display_os_str(value)
+}
+
+#[must_use]
+pub fn display_text_info(value: &str) -> SafeDisplayPath {
+    safe_display_os_str(OsStr::new(value))
+}
+
+#[must_use]
+pub fn display_text(value: &str) -> String {
+    let displayed = display_text_info(value);
+    if displayed.deceptive {
+        format!("{DECEPTIVE_DISPLAY_MARKER} {}", displayed.text)
+    } else if value.contains(DECEPTIVE_DISPLAY_MARKER) {
+        value.to_string()
+    } else {
+        displayed.text
+    }
+}
+
+#[must_use]
+pub fn display_path_middle(path: &Path, width: u16) -> String {
+    let displayed = display_path_info(path);
+    truncate_marked(&displayed, width, crate::ui::format::truncate_middle)
+}
+
+#[must_use]
+pub fn display_path_end(path: &Path, width: u16) -> String {
+    let displayed = display_path_info(path);
+    truncate_marked(&displayed, width, truncate_end)
+}
+
+#[must_use]
+pub fn display_os_str_middle(value: &OsStr, width: u16) -> String {
+    let displayed = display_os_str_info(value);
+    truncate_marked(&displayed, width, crate::ui::format::truncate_middle)
+}
+
+pub(crate) fn truncate_marked(
+    displayed: &SafeDisplayPath,
+    width: u16,
+    truncate: fn(&str, u16) -> String,
+) -> String {
+    if !displayed.deceptive {
+        return truncate(&displayed.text, width);
+    }
+    let marker_width = u16::try_from(DECEPTIVE_DISPLAY_MARKER.len()).unwrap_or(u16::MAX);
+    if width == 0 {
+        return String::new();
+    }
+    if width < marker_width {
+        return "!".to_string();
+    }
+    if width == marker_width {
+        return DECEPTIVE_DISPLAY_MARKER.to_string();
+    }
+    let body_width = width.saturating_sub(marker_width + 1);
+    let body = truncate(&displayed.text, body_width);
+    if body.is_empty() {
+        DECEPTIVE_DISPLAY_MARKER.to_string()
+    } else {
+        format!("{DECEPTIVE_DISPLAY_MARKER} {body}")
+    }
+}
+
+fn truncate_end(value: &str, width: u16) -> String {
+    let maximum = usize::from(width.saturating_sub(1));
+    if value.chars().count() <= maximum {
+        value.to_string()
+    } else if maximum > 1 {
+        let mut text = value.chars().take(maximum - 1).collect::<String>();
+        text.push('…');
+        text
+    } else {
+        String::new()
+    }
 }
 
 #[cfg(test)]
-pub fn display_path(path: &Path) -> Cow<'_, str> {
-    let normalized = crate::tests::fixtures::snapshot_path(path);
-    Cow::Owned(crate::native_path::safe_display_path(Path::new(&normalized)).text)
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hostile_text_is_escaped_and_marked() {
+        let displayed = display_text("safe\n\u{202e}name\u{1b}[31m");
+        assert!(displayed.starts_with(DECEPTIVE_DISPLAY_MARKER));
+        assert!(displayed.contains("\\n"));
+        assert!(displayed.contains("\\u{202e}"));
+        assert!(displayed.contains("\\x1b"));
+        assert!(!displayed.chars().any(char::is_control));
+    }
+
+    #[test]
+    fn deceptive_marker_survives_narrow_middle_truncation() {
+        let path = Path::new("prefix-\u{202e}hostile-name");
+        for width in 1..=24 {
+            let displayed = display_path_middle(path, width);
+            assert!(!displayed.chars().any(char::is_control));
+            assert!(!displayed.contains('\u{202e}'));
+            assert!(
+                displayed.starts_with('!') || displayed.starts_with(DECEPTIVE_DISPLAY_MARKER),
+                "deception marker lost at width {width}: {displayed:?}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn invalid_native_bytes_remain_reversible() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt as _;
+
+        let name = OsString::from_vec(b"bad\xffname".to_vec());
+        let displayed = display_os_str_info(&name);
+        assert!(displayed.deceptive);
+        assert_eq!(displayed.text, "bad\\xffname");
+        let narrow = display_os_str_middle(&name, 24);
+        assert!(narrow.starts_with(DECEPTIVE_DISPLAY_MARKER));
+        assert!(narrow.contains("\\xff"));
+    }
+
+    #[test]
+    fn deceptive_marker_survives_narrow_end_truncation() {
+        let path = Path::new("prefix-\u{202e}hostile-name");
+        for width in 1..=24 {
+            let displayed = display_path_end(path, width);
+            assert!(!displayed.chars().any(char::is_control));
+            assert!(!displayed.contains('\u{202e}'));
+            assert!(
+                displayed.starts_with('!') || displayed.starts_with(DECEPTIVE_DISPLAY_MARKER),
+                "deception marker lost at width {width}: {displayed:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn safe_marked_text_is_not_escaped_again() {
+        let displayed = display_text("bad\nname");
+        assert_eq!(display_text(&displayed), displayed);
+    }
 }

--- a/src/ui/grid/draw_rect.rs
+++ b/src/ui/grid/draw_rect.rs
@@ -2,38 +2,47 @@ use ::unicode_width::UnicodeWidthStr;
 use ratatui::buffer::Buffer;
 use ratatui::style::{Modifier, Style};
 
-use crate::native_path::safe_display_os_str;
+use crate::native_path::SafeDisplayPath;
 use crate::state::tiles::{FileType, Tile};
 use crate::theme::Theme;
-use crate::ui::format::{DisplaySize, DisplaySizeRounded, truncate_middle};
+use crate::ui::format::{
+    DisplaySize, DisplaySizeRounded, display_os_str_info, truncate_marked, truncate_middle,
+};
 use crate::ui::grid::{boundaries, draw_next_symbol};
-
 fn tile_first_line(tile: &Tile) -> String {
     let max_text_length = tile.width.saturating_sub(2);
-    let name = safe_display_os_str(&tile.name).text;
+    let name = display_os_str_info(&tile.name);
+    let deceptive = name.deceptive;
     let descendant_count = &tile.descendants;
     let filename_text = match tile.file_type {
-        FileType::File => name,
-        FileType::Folder => format!("{name}/"),
-        FileType::Synthetic => format!("[{name}]"),
+        FileType::File => name.text,
+        FileType::Folder => format!("{}/", name.text),
+        FileType::Synthetic => format!("[{}]", name.text),
     };
-    match tile.file_type {
-        FileType::File | FileType::Synthetic => truncate_middle(&filename_text, max_text_length),
+    let text = match tile.file_type {
+        FileType::File | FileType::Synthetic => filename_text,
         FileType::Folder => {
             let descendant_count = descendant_count.expect("folder should have descendants");
             let short_descendants_indication = format!("(+{descendant_count})");
             let long_descendants_indication = format!("(+{descendant_count} descendants)");
-            if filename_text.len() + long_descendants_indication.len() <= max_text_length as usize {
+            if filename_text.width() + long_descendants_indication.width()
+                <= usize::from(max_text_length)
+            {
                 format!("{filename_text} {long_descendants_indication}")
-            } else if filename_text.len() + short_descendants_indication.len()
-                <= max_text_length as usize
+            } else if filename_text.width() + short_descendants_indication.width()
+                <= usize::from(max_text_length)
             {
                 format!("{filename_text} {short_descendants_indication}")
             } else {
-                truncate_middle(&filename_text, max_text_length)
+                filename_text
             }
         }
-    }
+    };
+    truncate_marked(
+        &SafeDisplayPath { text, deceptive },
+        max_text_length,
+        truncate_middle,
+    )
 }
 
 fn tile_second_line(tile: &Tile) -> String {
@@ -319,6 +328,33 @@ mod tests {
                     assert_ne!(theme.text_inverse, theme.surface_selection, "{id:?}");
                 }
             }
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hostile_tile_names_keep_escaped_text_and_marker_when_narrow() {
+        use std::os::unix::ffi::OsStringExt as _;
+
+        let mut tile = tile(FileType::File);
+        tile.width = 40;
+        tile.name = OsString::from_vec(b"bad\xffname".to_vec());
+        let rendered = tile_first_line(&tile);
+        assert!(rendered.starts_with(crate::native_path::DECEPTIVE_DISPLAY_MARKER));
+        assert!(rendered.contains("bad\\xffname"));
+        assert!(!rendered.chars().any(char::is_control));
+
+        tile.name = OsString::from("prefix-\u{202e}hostile\u{1b}[31m");
+        for width in 1..=24 {
+            tile.width = width + 2;
+            let rendered = tile_first_line(&tile);
+            assert!(!rendered.chars().any(char::is_control));
+            assert!(!rendered.contains('\u{202e}'));
+            assert!(
+                rendered.starts_with('!')
+                    || rendered.starts_with(crate::native_path::DECEPTIVE_DISPLAY_MARKER),
+                "deception marker lost at width {width}: {rendered:?}"
+            );
         }
     }
 }

--- a/src/ui/modals/error_box.rs
+++ b/src/ui/modals/error_box.rs
@@ -3,6 +3,8 @@ use ratatui::layout::{Alignment, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph, Widget, Wrap};
 
+use crate::ui::format::display_text;
+
 pub struct ErrorBox<'a> {
     error_message: &'a str,
 }
@@ -28,17 +30,44 @@ impl Widget for ErrorBox<'_> {
             .fg(Color::Red)
             .bg(Color::Black)
             .add_modifier(Modifier::BOLD);
-        Paragraph::new(format!("{}\n\n[Esc] dismiss", self.error_message))
-            .style(style)
-            .alignment(Alignment::Center)
-            .wrap(Wrap { trim: true })
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .border_type(BorderType::Double)
-                    .border_style(style)
-                    .title(" ! ERROR "),
-            )
-            .render(rect, buffer);
+        Paragraph::new(format!(
+            "{}\n\n[Esc] dismiss",
+            display_text(self.error_message)
+        ))
+        .style(style)
+        .alignment(Alignment::Center)
+        .wrap(Wrap { trim: true })
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Double)
+                .border_style(style)
+                .title(" ! ERROR "),
+        )
+        .render(rect, buffer);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::widgets::Widget;
+
+    use super::*;
+
+    #[test]
+    fn hostile_error_text_is_escaped_and_marked() {
+        let area = Rect::new(0, 0, 40, 9);
+        let mut buffer = Buffer::empty(area);
+        ErrorBox::new("permission denied: bad\n\u{202e}name\u{1b}[31m").render(area, &mut buffer);
+        let text = buffer.content.iter().fold(String::new(), |mut text, cell| {
+            text.push_str(cell.symbol());
+            text
+        });
+        assert!(text.contains("[deceptive]"));
+        assert!(text.contains("\\n"));
+        assert!(text.contains("\\u{202e}"));
+        assert!(text.contains("\\x1b"));
+        assert!(!text.chars().any(char::is_control));
+        assert!(!text.contains('\u{202e}'));
     }
 }

--- a/src/ui/modals/message_box.rs
+++ b/src/ui/modals/message_box.rs
@@ -6,7 +6,7 @@ use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph, Widget, Wra
 
 use crate::deletion::{ConfirmationChallenge, DeletionPlan, DeletionReport, PlannedKind};
 use crate::state::FileToDelete;
-use crate::ui::format::{DisplaySize, display_path};
+use crate::ui::format::{DisplaySize, display_path_end, display_text};
 
 #[derive(Clone, Copy)]
 pub enum DeletionView<'a> {
@@ -129,7 +129,7 @@ fn lines(view: DeletionView<'_>, width: u16) -> Vec<Line<'static>> {
     match view {
         DeletionView::Planning(target) => vec![
             Line::from(""),
-            Line::from(truncate(&display_path(&target.full_path()), width)),
+            Line::from(display_path_end(&target.full_path(), width)),
             Line::from(""),
             Line::from("Enumerating a no-follow identity snapshot."),
             Line::from("Deletion is disabled until the plan is complete."),
@@ -151,7 +151,7 @@ fn lines(view: DeletionView<'_>, width: u16) -> Vec<Line<'static>> {
             );
             let mut content = vec![
                 Line::from(""),
-                Line::from(truncate(&display_path(&plan.target.full_path()), width)),
+                Line::from(display_path_end(&plan.target.full_path(), width)),
                 Line::from(truncate(&identity, width)),
                 Line::from(format!(
                     "{} planned entries · {} logical",
@@ -171,12 +171,12 @@ fn lines(view: DeletionView<'_>, width: u16) -> Vec<Line<'static>> {
                 }
                 ConfirmationChallenge::TypeName(expected) => {
                     content.push(Line::from(format!("Type exact name: {expected}")));
-                    content.push(Line::from(format!("> {input}_")));
+                    content.push(Line::from(format!("> {}_", display_text(input))));
                     content.push(Line::from("[Enter] arm when exact"));
                 }
                 ConfirmationChallenge::TypePhrase(expected) => {
                     content.push(Line::from(format!("Type: {expected}")));
-                    content.push(Line::from(format!("> {input}_")));
+                    content.push(Line::from(format!("> {}_", display_text(input))));
                     content.push(Line::from("[Enter] arm when exact"));
                 }
             }

--- a/src/ui/modals/notice_box.rs
+++ b/src/ui/modals/notice_box.rs
@@ -3,6 +3,8 @@ use ratatui::layout::{Alignment, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph, Widget, Wrap};
 
+use crate::ui::format::display_text;
+
 pub struct NoticeBox<'a> {
     message: &'a str,
 }
@@ -28,7 +30,7 @@ impl Widget for NoticeBox<'_> {
             .fg(Color::Green)
             .bg(Color::Black)
             .add_modifier(Modifier::BOLD);
-        Paragraph::new(self.message)
+        Paragraph::new(display_text(self.message))
             .style(style)
             .alignment(Alignment::Center)
             .wrap(Wrap { trim: true })
@@ -40,5 +42,29 @@ impl Widget for NoticeBox<'_> {
                     .title(" COMPLETE "),
             )
             .render(rect, buffer);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::widgets::Widget;
+
+    use super::*;
+
+    #[test]
+    fn hostile_notice_text_is_escaped_and_marked() {
+        let area = Rect::new(0, 0, 40, 9);
+        let mut buffer = Buffer::empty(area);
+        NoticeBox::new("complete: bad\n\u{202e}name\u{1b}[31m").render(area, &mut buffer);
+        let text = buffer.content.iter().fold(String::new(), |mut text, cell| {
+            text.push_str(cell.symbol());
+            text
+        });
+        assert!(text.contains("[deceptive]"));
+        assert!(text.contains("\\n"));
+        assert!(text.contains("\\u{202e}"));
+        assert!(text.contains("\\x1b"));
+        assert!(!text.chars().any(char::is_control));
+        assert!(!text.contains('\u{202e}'));
     }
 }


### PR DESCRIPTION
## Summary
- route worker errors and UI path/status surfaces through reversible safe display formatting
- retain an explicit deception marker ahead of narrow truncation and safety labels
- escape hostile controls, bidi overrides, and invalid native bytes with focused regression tests

## Verification
- cargo check --tests
- cargo clippy --lib --tests -- -D warnings
- rustfmt --edition 2024 --check src/runtime/worker.rs src/ui/display.rs src/ui/format/display_path.rs src/ui/modals/error_box.rs src/ui/modals/message_box.rs
- cargo test --lib ui::format::display_path::tests
- cargo test --lib ui::display::tests
- cargo test --lib ui::modals::error_box::tests
- cargo test --lib ui::modals::message_box::tests
- cargo test --lib runtime::worker::tests

Contract impact: hostile path/error rendering now visibly marks deceptive escaped data while preserving existing classifications and ordinary UI flow; no deletion/model/workflow behavior changed.