### PR TITLE
fix: harden deletion safety and hard-link accounting

### DIFF
--- a/fuzz/fuzz_targets/runtime_events.rs
+++ b/fuzz/fuzz_targets/runtime_events.rs
@@ -57,8 +57,13 @@ fuzz_target!(|data: &[u8]| {
         KeyModifiers::NONE,
     ))));
 
+    let metadata = std::fs::symlink_metadata(&root).expect("fuzz root metadata should exist");
+    let root_identity = excise::native_path::identity_for(&root, &metadata)
+        .expect("fuzz root identity should be readable")
+        .expect("fuzz root should not be a symbolic link");
     let settings = RuntimeSettings {
         root: root.clone(),
+        root_identity,
         scan_threads: 1,
         event_capacity: 16,
         cross_filesystems: false,

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,7 @@
 use std::ffi::OsStr;
 use std::fs::Metadata;
 use std::io::{self, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -9,11 +9,14 @@ use ratatui::backend::Backend;
 
 use crate::animation::AnimationScheduler;
 use crate::config::{CustomKeyBindings, KeyPreset};
-use crate::deletion::{ConfirmationChallenge, DeletionPlan, DeletionReport, deletion_supported};
+use crate::deletion::{
+    ConfirmationChallenge, DeletionPlan, DeletionReport, current_scan_root_identity,
+    deletion_supported,
+};
 use crate::error::AppError;
 use crate::filter::FilterPattern;
 use crate::model::{ModelError, NodeState, SyntheticKind, UnscannedReason};
-use crate::native_path::NativeIdentity;
+use crate::native_path::{NativeIdentity, identity_for};
 use crate::outcome::RunSummary;
 use crate::report::{
     ReportError, scan_is_uncertain, scan_report_state, write_deletion_history_json,
@@ -26,6 +29,19 @@ use crate::theme::Theme;
 use crate::ui::Display;
 const MIB: usize = 1024 * 1024;
 const MINIMUM_PLAN_BYTES: usize = 4 * 1024;
+
+fn directory_target_was_replaced(path: &Path, expected: &NativeIdentity) -> bool {
+    let Ok(metadata) = std::fs::symlink_metadata(path) else {
+        return true;
+    };
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return true;
+    }
+    let Ok(Some(actual)) = identity_for(path, &metadata) else {
+        return true;
+    };
+    actual.file_id != expected.file_id || actual.reparse_point != expected.reparse_point
+}
 fn emit_pty_test_marker(label: &str) {
     if std::env::var_os("EXCISE_PTY_TEST_MARKERS").is_none() {
         return;
@@ -70,6 +86,11 @@ pub enum UiMode {
     WarningMessage,
 }
 
+pub(crate) enum DeletionReplanResult {
+    Ready(Box<FileToDelete>),
+    Missing,
+}
+
 impl UiMode {
     #[must_use]
     pub const fn allows_motion(&self) -> bool {
@@ -93,6 +114,7 @@ where
     deletion_history: Vec<Arc<DeletionReport>>,
     deletion_history_bytes: usize,
     deletion_history_limit: usize,
+    deletion_replan: Option<FileToDelete>,
     preferences_dirty: bool,
     keymap: KeyPreset,
     custom_keys: Option<CustomKeyBindings>,
@@ -104,7 +126,7 @@ impl<B> App<B>
 where
     B: Backend,
 {
-    #[allow(clippy::too_many_arguments)]
+    #[allow(dead_code, clippy::too_many_arguments)]
     pub fn new(
         terminal_backend: B,
         path_in_filesystem: PathBuf,
@@ -115,11 +137,66 @@ where
         custom_keys: Option<CustomKeyBindings>,
         mouse_enabled: bool,
     ) -> Result<Self, AppError> {
+        let root_identity = current_scan_root_identity(&path_in_filesystem)
+            .map_err(|error| AppError::Model(error.to_string()))?;
+        Self::new_with_root_identity(
+            terminal_backend,
+            path_in_filesystem,
+            root_identity,
+            show_apparent_size,
+            disable_delete_confirmation,
+            process_memory_mib,
+            keymap,
+            custom_keys,
+            mouse_enabled,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_root_identity(
+        terminal_backend: B,
+        path_in_filesystem: PathBuf,
+        root_identity: NativeIdentity,
+        show_apparent_size: bool,
+        disable_delete_confirmation: bool,
+        process_memory_mib: usize,
+        keymap: KeyPreset,
+        custom_keys: Option<CustomKeyBindings>,
+        mouse_enabled: bool,
+    ) -> Result<Self, AppError> {
         let display = Display::new(terminal_backend)?;
         let board = Board::new();
-        let file_tree = FileTree::new(path_in_filesystem, show_apparent_size, process_memory_mib)
-            .map_err(model_error)?;
-        Ok(Self {
+        let file_tree = FileTree::new_with_root_identity(
+            path_in_filesystem,
+            root_identity,
+            show_apparent_size,
+            process_memory_mib,
+        )
+        .map_err(model_error)?;
+        Ok(Self::from_parts(
+            display,
+            board,
+            file_tree,
+            disable_delete_confirmation,
+            keymap,
+            custom_keys,
+            mouse_enabled,
+            process_memory_mib,
+        ))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn from_parts(
+        display: Display<B>,
+        board: Board,
+        file_tree: FileTree,
+        disable_delete_confirmation: bool,
+        keymap: KeyPreset,
+        custom_keys: Option<CustomKeyBindings>,
+        mouse_enabled: bool,
+        process_memory_mib: usize,
+    ) -> Self {
+        Self {
             is_running: true,
             loaded: false,
             board,
@@ -136,7 +213,8 @@ where
             deletion_history_bytes: 0,
             deletion_history_limit: process_memory_mib.saturating_mul(MIB) / 8,
             deletion_history: Vec::new(),
-        })
+            deletion_replan: None,
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -264,8 +342,14 @@ where
             .map_err(model_error)
     }
 
-    pub fn complete_directory(&mut self, path: &std::path::Path) -> Result<(), AppError> {
-        self.file_tree.complete_directory(path).map_err(model_error)
+    pub fn complete_directory(
+        &mut self,
+        path: &std::path::Path,
+        expected_identity: Option<&NativeIdentity>,
+    ) -> Result<(), AppError> {
+        self.file_tree
+            .complete_directory(path, expected_identity)
+            .map_err(model_error)
     }
 
     pub fn finalize_scan(&mut self) -> Result<(), AppError> {
@@ -280,6 +364,10 @@ where
     #[must_use]
     pub fn internal_scan_paths(&self) -> Vec<PathBuf> {
         self.file_tree.internal_scan_paths()
+    }
+    #[must_use]
+    pub fn identity_for_path(&self, path: &std::path::Path) -> Option<NativeIdentity> {
+        self.file_tree.identity_for_path(path)
     }
 
     #[must_use]
@@ -445,6 +533,7 @@ where
                 return None;
             }
         };
+        self.deletion_replan = None;
         self.ui_mode = UiMode::PlanningDeletion(Box::new(file_to_delete.display_copy()));
         self.mark_dirty();
         Some(file_to_delete)
@@ -503,14 +592,12 @@ where
             }
         }
     }
-
     pub fn pop_confirmation_character(&mut self) {
         if let UiMode::DeleteConfirm { input, .. } = &mut self.ui_mode {
             input.pop();
             self.mark_dirty();
         }
     }
-
     pub fn take_confirmed_deletion_plan(&mut self) -> Option<DeletionPlan> {
         let confirmed = matches!(
             &self.ui_mode,
@@ -537,6 +624,10 @@ where
         Some(*plan)
     }
 
+    pub fn take_deletion_replan(&mut self) -> Option<FileToDelete> {
+        self.deletion_replan.take()
+    }
+
     pub fn prompt_deletion_cancel(&mut self) {
         if let UiMode::Deleting {
             planned_entries,
@@ -546,6 +637,96 @@ where
             self.ui_mode = UiMode::DeletionCancel { planned_entries };
             self.mark_dirty();
         }
+    }
+
+    pub(crate) fn begin_deletion_replan(
+        &mut self,
+        target_node_id: crate::model::NodeId,
+        plan: DeletionPlan,
+    ) -> Result<Option<PathBuf>, AppError> {
+        if plan.target.node_id != target_node_id {
+            self.show_error("Deletion validation returned an unexpected target");
+            return Ok(None);
+        }
+        self.begin_deletion_replan_target(plan.target)
+    }
+
+    pub(crate) fn begin_pending_deletion_replan(
+        &mut self,
+        target_node_id: crate::model::NodeId,
+    ) -> Result<Option<PathBuf>, AppError> {
+        let target = match &self.ui_mode {
+            UiMode::PlanningDeletion(target) if target.node_id == target_node_id => {
+                (**target).clone()
+            }
+            _ => return Ok(None),
+        };
+        self.begin_deletion_replan_target(target)
+    }
+
+    fn begin_deletion_replan_target(
+        &mut self,
+        mut target: FileToDelete,
+    ) -> Result<Option<PathBuf>, AppError> {
+        let target_path = target.full_path();
+        let target_is_directory =
+            target.expected_snapshot.kind == crate::model::NodeKind::Directory;
+        let target_was_replaced = target_is_directory
+            && target
+                .expected_snapshot
+                .identity
+                .as_ref()
+                .is_none_or(|expected| directory_target_was_replaced(&target_path, expected));
+        let rescan_target = if target_was_replaced {
+            target_path
+                .parent()
+                .map_or_else(|| target.path_in_filesystem.clone(), Path::to_path_buf)
+        } else if target_is_directory {
+            target_path.clone()
+        } else {
+            target_path
+                .parent()
+                .map_or_else(|| target.path_in_filesystem.clone(), Path::to_path_buf)
+        };
+        target.reviewed_entries.clear();
+        self.begin_rescan(rescan_target.clone())?;
+        self.deletion_replan = Some(target);
+        self.ui_effects.deletion_in_progress = false;
+        Ok(Some(rescan_target))
+    }
+
+    pub(crate) fn rebuild_deletion_replan(&mut self) -> Option<DeletionReplanResult> {
+        let stale = self.take_deletion_replan()?;
+        let path = stale.full_path();
+        let mut target = match self.file_tree.deletion_target_for_path(&path) {
+            Ok(target) => target,
+            Err(crate::model::ModelError::InvalidPath(_)) => {
+                return Some(DeletionReplanResult::Missing);
+            }
+            Err(error) => {
+                self.show_error(format!("Deletion rescan could not refresh target: {error}"));
+                return None;
+            }
+        };
+        target.reviewed_entries = match self
+            .file_tree
+            .reviewed_subtree(target.node_id, self.maximum_deletion_plan_bytes())
+        {
+            Ok(entries) => entries,
+            Err(error) => {
+                self.show_error(format!("Deletion rescan could not review target: {error}"));
+                return None;
+            }
+        };
+        self.ui_mode = UiMode::PlanningDeletion(Box::new(target.display_copy()));
+        self.mark_dirty();
+        Some(DeletionReplanResult::Ready(Box::new(target)))
+    }
+
+    pub(crate) fn complete_missing_deletion(&mut self) {
+        self.ui_effects.deletion_in_progress = false;
+        self.ui_mode = UiMode::Normal;
+        self.render_and_update_board();
     }
 
     pub fn resume_deletion(&mut self, stopping: bool) {
@@ -558,10 +739,19 @@ where
         }
     }
 
+    #[allow(dead_code)]
     pub fn complete_deletion(&mut self, report: DeletionReport) -> bool {
+        self.try_complete_deletion(report).unwrap_or(false)
+    }
+
+    pub fn try_complete_deletion(&mut self, report: DeletionReport) -> Result<bool, AppError> {
         self.ui_effects.deletion_in_progress = false;
         let deleted = report.deleted_entries() > 0;
-        self.file_tree.apply_deletion_report(&report);
+        if let Err(error) = self.file_tree.try_apply_deletion_report(&report) {
+            self.ui_mode = UiMode::ErrorMessage(format!("Deletion accounting failed: {error}"));
+            self.mark_dirty();
+            return Err(model_error(error));
+        }
         let report = Arc::new(report);
         if report.estimated_bytes <= self.remaining_deletion_history_bytes() {
             self.deletion_history_bytes = self
@@ -572,7 +762,7 @@ where
         self.ui_mode = UiMode::DeletionResult { report };
         self.board.reset_selected_index();
         self.render_and_update_board();
-        deleted
+        Ok(deleted)
     }
 
     #[must_use]
@@ -655,6 +845,8 @@ where
     }
 
     pub fn normal_mode(&mut self) {
+        self.deletion_replan = None;
+        self.ui_effects.deletion_in_progress = false;
         self.ui_mode = UiMode::Normal;
         self.render_and_update_board();
     }
@@ -678,6 +870,7 @@ where
 
     pub fn cancel_rescan(&mut self) -> Result<(), AppError> {
         self.file_tree.cancel_rescan().map_err(model_error)?;
+        self.deletion_replan = None;
         self.ui_mode = UiMode::Normal;
         self.render_and_update_board();
         Ok(())
@@ -691,7 +884,6 @@ where
         self.ui_mode = UiMode::FilterInput { input, error: None };
         self.mark_dirty();
     }
-
     pub fn push_filter_character(&mut self, character: char) {
         if character.is_control() {
             return;
@@ -774,6 +966,13 @@ fn model_error(error: ModelError) -> AppError {
 mod tests {
     use ratatui::backend::TestBackend;
 
+    #[cfg(unix)]
+    use crate::deletion::{PlannedKind, PlannedSnapshot, ReviewedEntry, build_plan};
+    #[cfg(unix)]
+    use crate::native_path::identity_for;
+    #[cfg(unix)]
+    use crate::state::tiles::FileType;
+
     use super::*;
 
     fn report(estimated_bytes: usize) -> DeletionReport {
@@ -815,5 +1014,74 @@ mod tests {
         app.clear_deletion_history();
         assert!(app.deletion_history.is_empty());
         assert_eq!(app.remaining_deletion_history_bytes(), limit);
+    }
+    #[cfg(unix)]
+    #[test]
+    fn confirmed_plan_is_deferred_to_worker_revalidation() {
+        use std::os::unix::fs::MetadataExt as _;
+        use std::time::UNIX_EPOCH;
+
+        let root = tempfile::tempdir().expect("app root should exist");
+        let path = root.path().join("target");
+        std::fs::write(&path, b"original").expect("target should be written");
+        let metadata = std::fs::symlink_metadata(&path).expect("target metadata should exist");
+        let identity = identity_for(&path, &metadata)
+            .expect("target identity should be readable")
+            .expect("target should not be a symbolic link");
+        let snapshot = PlannedSnapshot {
+            identity: identity.clone(),
+            kind: PlannedKind::File,
+            apparent_bytes: u128::from(metadata.len()),
+            allocated_bytes: Some(u128::from(metadata.blocks()).saturating_mul(512)),
+            modified_nanos: metadata
+                .modified()
+                .ok()
+                .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+                .map(|duration| duration.as_nanos()),
+        };
+        let target = FileToDelete {
+            node_id: crate::model::NodeId(1),
+            synthetic: false,
+            path_in_filesystem: root.path().to_path_buf(),
+            path_to_file: vec![std::ffi::OsString::from("target")],
+            file_type: FileType::File,
+            num_descendants: None,
+            size: snapshot.apparent_bytes,
+            expected_snapshot: crate::model::EntrySnapshot {
+                identity: Some(identity),
+                kind: crate::model::NodeKind::File,
+                apparent_bytes: snapshot.apparent_bytes,
+                allocated_bytes: snapshot.allocated_bytes,
+                modified_nanos: snapshot.modified_nanos,
+            },
+            reviewed_entries: vec![ReviewedEntry {
+                relative_path: PathBuf::from("target"),
+                snapshot,
+            }],
+        };
+        let plan = build_plan(root.path(), target, false).expect("deletion plan should build");
+        let mut app = App::new(
+            TestBackend::new(80, 24),
+            root.path().to_path_buf(),
+            false,
+            false,
+            128,
+            KeyPreset::Vim,
+            None,
+            false,
+        )
+        .expect("app should initialize");
+        app.ui_mode = UiMode::DeleteConfirm {
+            input: plan.challenge.expected_input().to_string(),
+            plan: Some(Box::new(plan)),
+        };
+        std::fs::write(&path, b"replacement").expect("target should change");
+
+        let confirmed = app
+            .take_confirmed_deletion_plan()
+            .expect("confirmed plan should be handed to the worker");
+        assert_eq!(confirmed.entries.len(), 1);
+        assert!(matches!(app.ui_mode, UiMode::Deleting { .. }));
+        assert!(app.take_deletion_replan().is_none());
     }
 }

--- a/src/deletion.rs
+++ b/src/deletion.rs
@@ -1,5 +1,6 @@
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::ffi::{OsStr, OsString};
+use std::fmt;
 use std::fs::File;
 use std::io;
 use std::mem::size_of;
@@ -12,11 +13,12 @@ use cap_primitives::fs::{self as cap_fs, FollowSymlinks};
 use file_id::FileId;
 use serde::{Deserialize, Serialize};
 use sysinfo::Disks;
-use thiserror::Error;
 
 use crate::model::NodeId;
 use crate::model::NodeKind;
-use crate::native_path::{NativeIdentity, safe_display_os_str};
+use crate::native_path::{
+    NativeIdentity, identity_for, safe_display_os_str, safe_display_path_text, safe_display_text,
+};
 use crate::state::FileToDelete;
 
 pub const DEFAULT_PLAN_LIMIT_BYTES: usize = 64 * 1024 * 1024;
@@ -77,6 +79,7 @@ impl ConfirmationChallenge {
 pub struct DeletionPlan {
     pub target: FileToDelete,
     pub root_relative_path: PathBuf,
+    pub scan_root_identity: NativeIdentity,
     pub entries: Vec<PlannedEntry>,
     pub challenge: ConfirmationChallenge,
     pub apparent_bytes: u128,
@@ -159,6 +162,38 @@ impl DeletionReport {
                 total.saturating_add(entry.entry.snapshot.apparent_bytes)
             })
     }
+    #[must_use]
+    pub fn deleted_allocated_bytes(&self) -> u128 {
+        let mut allocations = HashMap::<FileId, (u64, Option<u64>, Option<u128>)>::new();
+        for result in &self.entries {
+            if !matches!(result.outcome, DeletionEntryOutcome::Deleted) {
+                continue;
+            }
+            let snapshot = &result.entry.snapshot;
+            let allocation = allocations.entry(snapshot.identity.file_id).or_insert((
+                0,
+                snapshot.identity.link_count,
+                snapshot.allocated_bytes,
+            ));
+            allocation.0 = allocation.0.saturating_add(1);
+            allocation.1 = match (allocation.1, snapshot.identity.link_count) {
+                (Some(left), Some(right)) => Some(left.max(right)),
+                _ => None,
+            };
+            allocation.2 = match (allocation.2, snapshot.allocated_bytes) {
+                (Some(left), Some(right)) => Some(left.max(right)),
+                (left, None) | (None, left) => left,
+            };
+        }
+        allocations
+            .values()
+            .filter_map(|(deleted, links, allocated)| {
+                links
+                    .filter(|links| *links > 0 && *deleted >= *links)
+                    .and(*allocated)
+            })
+            .fold(0_u128, u128::saturating_add)
+    }
 
     fn count(&self, predicate: impl Fn(&DeletionEntryOutcome) -> bool) -> u64 {
         u64::try_from(
@@ -171,26 +206,85 @@ impl DeletionReport {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Clone, Debug)]
 pub enum DeletionPlanError {
-    #[error("aggregate and synthetic nodes cannot be deleted")]
     Synthetic,
-    #[error("scan roots and filesystem roots cannot be deleted")]
     Root,
-    #[error("deletion target is not a safe relative path")]
     InvalidRelativePath,
-    #[error("deletion target changed while its plan was built")]
     Changed,
-    #[error("deletion planning was cancelled")]
+    Missing(PathBuf),
     Cancelled,
-    #[error("deletion plan exceeds its {limit} byte memory limit")]
-    MemoryLimit { limit: usize },
-    #[error("deletion planning failed for {path}: {message}")]
+    MemoryLimit {
+        limit: usize,
+    },
     Io {
         path: String,
         message: String,
         kind: io::ErrorKind,
     },
+}
+impl fmt::Display for DeletionPlanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Synthetic => {
+                formatter.write_str("aggregate and synthetic nodes cannot be deleted")
+            }
+            Self::Root => formatter.write_str("scan roots and filesystem roots cannot be deleted"),
+            Self::InvalidRelativePath => {
+                formatter.write_str("deletion target is not a safe relative path")
+            }
+            Self::Changed => {
+                formatter.write_str("deletion target changed while its plan was built")
+            }
+            Self::Missing(path) => write!(
+                formatter,
+                "planned deletion entry is missing: {}",
+                safe_display_path_text(path)
+            ),
+            Self::Cancelled => formatter.write_str("deletion planning was cancelled"),
+            Self::MemoryLimit { limit } => write!(
+                formatter,
+                "deletion plan exceeds its {limit} byte memory limit"
+            ),
+            Self::Io { path, message, .. } => write!(
+                formatter,
+                "deletion planning failed for {}: {}",
+                safe_display_text(path),
+                safe_display_text(message)
+            ),
+        }
+    }
+}
+
+impl std::error::Error for DeletionPlanError {}
+
+impl DeletionPlanError {
+    #[must_use]
+    pub(crate) const fn is_stale(&self) -> bool {
+        matches!(
+            self,
+            Self::Changed
+                | Self::Io {
+                    kind: io::ErrorKind::NotFound,
+                    ..
+                }
+        )
+    }
+
+    #[must_use]
+    pub(crate) const fn is_cancelled(&self) -> bool {
+        matches!(self, Self::Cancelled)
+    }
+
+    #[must_use]
+    pub(crate) const fn is_missing(&self) -> bool {
+        matches!(self, Self::Missing(_))
+    }
+
+    #[must_use]
+    pub(crate) fn is_missing_target(&self, plan: &DeletionPlan) -> bool {
+        matches!(self, Self::Missing(path) if path == &plan.root_relative_path)
+    }
 }
 
 /// Builds and revalidates an identity-bound deletion plan.
@@ -203,8 +297,10 @@ pub fn build_plan(
     target: FileToDelete,
     reduced_guardrails: bool,
 ) -> Result<DeletionPlan, DeletionPlanError> {
-    build_plan_cancellable(
+    let scan_root_identity = current_scan_root_identity(scan_root)?;
+    build_plan_cancellable_with_root_identity(
         scan_root,
+        scan_root_identity,
         target,
         reduced_guardrails,
         &AtomicBool::new(false),
@@ -217,9 +313,28 @@ pub fn build_plan(
 /// # Errors
 /// Returns a planning error when the target is ineligible, changed, unreadable, cancelled, or
 /// exceeds `maximum_bytes`.
-#[allow(clippy::too_many_lines)]
 pub fn build_plan_cancellable(
     scan_root: &Path,
+    target: FileToDelete,
+    reduced_guardrails: bool,
+    cancelled: &AtomicBool,
+    maximum_bytes: usize,
+) -> Result<DeletionPlan, DeletionPlanError> {
+    let scan_root_identity = current_scan_root_identity(scan_root)?;
+    build_plan_cancellable_with_root_identity(
+        scan_root,
+        scan_root_identity,
+        target,
+        reduced_guardrails,
+        cancelled,
+        maximum_bytes,
+    )
+}
+
+#[allow(clippy::too_many_lines)]
+pub(crate) fn build_plan_cancellable_with_root_identity(
+    scan_root: &Path,
+    scan_root_identity: NativeIdentity,
     mut target: FileToDelete,
     reduced_guardrails: bool,
     cancelled: &AtomicBool,
@@ -230,12 +345,29 @@ pub fn build_plan_cancellable(
     }
     let relative = relative_target(&target)?;
     let full_path = target.full_path();
-    if target.expected_snapshot.kind == NodeKind::Directory
-        && is_mount_root(&full_path).map_err(|error| plan_io(&full_path, error))?
-    {
-        return Err(DeletionPlanError::Root);
+    if target.expected_snapshot.kind == NodeKind::Directory {
+        let mount_root = match is_mount_root(&full_path) {
+            Ok(value) => value,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => false,
+            Err(error) => return Err(plan_io(&full_path, error)),
+        };
+        if mount_root {
+            let unchanged = target
+                .expected_snapshot
+                .identity
+                .as_ref()
+                .is_some_and(|expected| {
+                    current_scan_root_identity(&full_path)
+                        .is_ok_and(|actual| same_object(expected, &actual))
+                });
+            return Err(if unchanged {
+                DeletionPlanError::Root
+            } else {
+                DeletionPlanError::Changed
+            });
+        }
     }
-    let root = open_root(scan_root)?;
+    let root = open_root(scan_root, &scan_root_identity)?;
     let (snapshot, directory_handle) = inspect_relative(&root, &relative)?;
     validate_model_snapshot(&target, &snapshot)?;
     let challenge = challenge_for(&target, &snapshot, reduced_guardrails);
@@ -265,7 +397,10 @@ pub fn build_plan_cancellable(
                     .take()
                     .ok_or(DeletionPlanError::InvalidRelativePath)?
             } else {
-                let (actual, handle) = inspect_relative(&root, &relative_path)?;
+                let (actual, handle) = match inspect_relative(&root, &relative_path) {
+                    Err(DeletionPlanError::Missing(_)) => return Err(DeletionPlanError::Changed),
+                    result => result?,
+                };
                 if actual != expected {
                     return Err(DeletionPlanError::Changed);
                 }
@@ -342,6 +477,7 @@ pub fn build_plan_cancellable(
     let plan = DeletionPlan {
         target,
         root_relative_path: relative,
+        scan_root_identity,
         entries,
         challenge,
         apparent_bytes,
@@ -359,17 +495,23 @@ pub fn revalidate_plan(scan_root: &Path, plan: &DeletionPlan) -> Result<(), Dele
     revalidate_plan_cancellable(scan_root, plan, &AtomicBool::new(false))
 }
 
-fn revalidate_plan_cancellable(
+pub(crate) fn revalidate_plan_cancellable(
     scan_root: &Path,
     plan: &DeletionPlan,
     cancelled: &AtomicBool,
 ) -> Result<(), DeletionPlanError> {
-    let root = open_root(scan_root)?;
+    let root = open_root(scan_root, &plan.scan_root_identity)?;
     for entry in &plan.entries {
         if cancelled.load(Ordering::Acquire) {
             return Err(DeletionPlanError::Cancelled);
         }
-        let (actual, _) = inspect_relative(&root, &entry.relative_path)?;
+        let (actual, _) = match inspect_relative(&root, &entry.relative_path) {
+            Err(DeletionPlanError::Missing(path)) if path == plan.root_relative_path => {
+                return Err(DeletionPlanError::Missing(path));
+            }
+            Err(DeletionPlanError::Missing(_)) => return Err(DeletionPlanError::Changed),
+            result => result?,
+        };
         if actual != entry.snapshot {
             return Err(DeletionPlanError::Changed);
         }
@@ -427,21 +569,46 @@ fn execute_plan_unix_with_hook<F>(
     plan: DeletionPlan,
     soft_cancelled: &AtomicBool,
     hard_cancelled: &AtomicBool,
-    mut after_isolation: F,
+    after_isolation: F,
 ) -> DeletionReport
 where
     F: FnMut(),
 {
-    let root = match open_root(scan_root) {
+    execute_plan_unix_with_hooks(
+        scan_root,
+        plan,
+        soft_cancelled,
+        hard_cancelled,
+        after_isolation,
+        |_| {},
+    )
+}
+
+#[cfg(any(target_os = "linux", target_vendor = "apple"))]
+fn execute_plan_unix_with_hooks<F, G>(
+    scan_root: &Path,
+    plan: DeletionPlan,
+    soft_cancelled: &AtomicBool,
+    hard_cancelled: &AtomicBool,
+    mut after_isolation: F,
+    mut after_inspection: G,
+) -> DeletionReport
+where
+    F: FnMut(),
+    G: FnMut(&OsStr),
+{
+    let root = match open_root(scan_root, &plan.scan_root_identity) {
         Ok(root) => root,
         Err(error) => return failed_report(scan_root, plan, &error.to_string()),
     };
     let estimated_bytes = plan.estimated_bytes;
     let target_node_id = plan.target.node_id;
     let root_relative_path = plan.root_relative_path.clone();
+    let planned_link_counts = planned_link_counts(&plan.entries);
+    let mut deleted_link_counts = HashMap::new();
     let mut results = Vec::with_capacity(plan.entries.len());
     let mut stopped = false;
-    for entry in plan.entries {
+    for mut entry in plan.entries {
         if stopped
             || soft_cancelled.load(Ordering::Acquire)
             || hard_cancelled.load(Ordering::Acquire)
@@ -453,7 +620,20 @@ where
             });
             continue;
         }
-        let outcome = execute_unix_entry(&root, &entry, &mut after_isolation);
+        let outcome = execute_unix_entry(
+            &root,
+            &mut entry,
+            &mut after_isolation,
+            &mut after_inspection,
+        );
+        if matches!(&outcome, DeletionEntryOutcome::Deleted) {
+            note_deleted_link(&mut entry, &planned_link_counts, &deleted_link_counts);
+            let file_id = entry.snapshot.identity.file_id;
+            deleted_link_counts
+                .entry(file_id)
+                .and_modify(|count| *count = count.saturating_add(1))
+                .or_insert(1);
+        }
         results.push(DeletionEntryResult { entry, outcome });
     }
     DeletionReport {
@@ -469,20 +649,26 @@ where
 
 #[cfg(any(target_os = "linux", target_vendor = "apple"))]
 #[allow(clippy::too_many_lines)]
-fn execute_unix_entry<F>(
+fn execute_unix_entry<F, G>(
     root: &File,
-    entry: &PlannedEntry,
+    entry: &mut PlannedEntry,
     after_isolation: &mut F,
+    after_inspection: &mut G,
 ) -> DeletionEntryOutcome
 where
     F: FnMut(),
+    G: FnMut(&OsStr),
 {
     let (parent, original_name) = match open_parent(root, &entry.relative_path) {
         Ok(value) => value,
         Err(DeletionPlanError::Io {
             kind: io::ErrorKind::NotFound,
             ..
-        }) => return DeletionEntryOutcome::Missing,
+        }) => {
+            return DeletionEntryOutcome::Changed(
+                "entry parent or namespace disappeared".to_string(),
+            );
+        }
         Err(error) => return DeletionEntryOutcome::Failed(error.to_string()),
     };
     let (detached_name, placeholder) = match create_placeholder(&parent) {
@@ -490,17 +676,30 @@ where
         Err(error) => return DeletionEntryOutcome::Failed(error.to_string()),
     };
     if let Err(error) = exchange_names(&parent, &original_name, &detached_name) {
+        let disappeared = error.kind() == io::ErrorKind::NotFound;
         let cleanup = remove_verified_placeholder(&parent, &detached_name, &placeholder);
-        return DeletionEntryOutcome::Failed(cleanup.map_or_else(
-            |cleanup_error| format!("{error}; placeholder cleanup failed: {cleanup_error}"),
-            |()| error.to_string(),
-        ));
+        return if disappeared {
+            cleanup.map_or_else(
+                |cleanup_error| {
+                    DeletionEntryOutcome::Failed(format!(
+                        "target disappeared; placeholder cleanup failed: {cleanup_error}"
+                    ))
+                },
+                |()| DeletionEntryOutcome::Missing,
+            )
+        } else {
+            DeletionEntryOutcome::Failed(cleanup.map_or_else(
+                |cleanup_error| format!("{error}; placeholder cleanup failed: {cleanup_error}"),
+                |()| error.to_string(),
+            ))
+        };
     }
     after_isolation();
 
     let actual = match inspect_child(&parent, &detached_name, &entry.relative_path) {
         Ok((snapshot, handle)) => {
             drop(handle);
+            entry.snapshot.identity.link_count = snapshot.identity.link_count;
             snapshot
         }
         Err(DeletionPlanError::Io {
@@ -534,6 +733,23 @@ where
         };
     }
 
+    let link_hold = if matches!(entry.snapshot.kind, PlannedKind::File | PlannedKind::Link) {
+        if actual.identity.link_count.is_some() {
+            if let Ok(name) = create_link_hold(&parent, &detached_name) {
+                Some(name)
+            } else {
+                entry.snapshot.identity.link_count = None;
+                None
+            }
+        } else {
+            entry.snapshot.identity.link_count = None;
+            None
+        }
+    } else {
+        None
+    };
+    after_inspection(&detached_name);
+
     let removal = match entry.snapshot.kind {
         PlannedKind::Directory => cap_fs::remove_dir(&parent, Path::new(&detached_name)),
         PlannedKind::File | PlannedKind::Link => {
@@ -541,27 +757,57 @@ where
         }
     };
     match removal {
-        Ok(()) => finalize_placeholder(&parent, &original_name, &detached_name, &placeholder)
-            .map_or_else(
-                |error| {
-                    DeletionEntryOutcome::Failed(format!(
-                        "target deleted; namespace cleanup failed: {error}"
-                    ))
-                },
-                |()| DeletionEntryOutcome::Deleted,
-            ),
+        Ok(()) => {
+            if let Some(link_hold) = link_hold.as_ref() {
+                if !link_hold_matches_count(&parent, link_hold, actual.identity.link_count)
+                    .unwrap_or(false)
+                {
+                    entry.snapshot.identity.link_count = None;
+                }
+            }
+            let finalization =
+                finalize_placeholder(&parent, &original_name, &detached_name, &placeholder);
+            let hold_cleanup = link_hold
+                .as_ref()
+                .map(|name| remove_link_hold(&parent, name, &actual.identity));
+            match (finalization, hold_cleanup) {
+                (Ok(()), Some(Ok(())) | None) => DeletionEntryOutcome::Deleted,
+                (Ok(()), Some(Err(error))) => DeletionEntryOutcome::Failed(format!(
+                    "target deleted; hard-link check cleanup failed: {error}"
+                )),
+                (Err(error), Some(Ok(())) | None) => DeletionEntryOutcome::Failed(format!(
+                    "target deleted; namespace cleanup failed: {error}"
+                )),
+                (Err(error), Some(Err(cleanup_error))) => DeletionEntryOutcome::Failed(format!(
+                    "target deleted; namespace cleanup failed: {error}; hard-link check cleanup failed: {cleanup_error}"
+                )),
+            }
+        }
         Err(error) if error.kind() == io::ErrorKind::NotFound => {
-            finalize_placeholder(&parent, &original_name, &detached_name, &placeholder).map_or_else(
-                |cleanup_error| {
-                    DeletionEntryOutcome::Failed(format!(
-                        "target disappeared; namespace cleanup failed: {cleanup_error}"
-                    ))
-                },
-                |()| DeletionEntryOutcome::Missing,
-            )
+            let finalization =
+                finalize_placeholder(&parent, &original_name, &detached_name, &placeholder);
+            let hold_cleanup = link_hold
+                .as_ref()
+                .map(|name| remove_link_hold(&parent, name, &actual.identity));
+            match (finalization, hold_cleanup) {
+                (Ok(()), Some(Ok(())) | None) => DeletionEntryOutcome::Missing,
+                (Ok(()), Some(Err(cleanup_error))) => DeletionEntryOutcome::Failed(format!(
+                    "target disappeared; hard-link check cleanup failed: {cleanup_error}"
+                )),
+                (Err(error), Some(Ok(())) | None) => DeletionEntryOutcome::Failed(format!(
+                    "target disappeared; namespace cleanup failed: {error}"
+                )),
+                (Err(error), Some(Err(cleanup_error))) => DeletionEntryOutcome::Failed(format!(
+                    "target disappeared; namespace cleanup failed: {error}; hard-link check cleanup failed: {cleanup_error}"
+                )),
+            }
         }
         Err(error) => {
             let restore = restore_detached(&parent, &original_name, &detached_name, &placeholder);
+            let hold_cleanup = link_hold
+                .as_ref()
+                .map(|name| remove_link_hold(&parent, name, &actual.identity));
+            let cleanup_error = hold_cleanup.and_then(Result::err);
             if error.kind() == io::ErrorKind::DirectoryNotEmpty {
                 restore.map_or_else(
                     |restore_error| {
@@ -570,15 +816,28 @@ where
                         ))
                     },
                     |()| {
-                        DeletionEntryOutcome::Changed(
-                            "directory contains a new or changed entry".to_string(),
-                        )
+                        if let Some(cleanup_error) = cleanup_error {
+                            DeletionEntryOutcome::Failed(format!(
+                                "directory changed; hard-link check cleanup failed: {cleanup_error}"
+                            ))
+                        } else {
+                            DeletionEntryOutcome::Changed(
+                                "directory contains a new or changed entry".to_string(),
+                            )
+                        }
                     },
                 )
             } else {
                 DeletionEntryOutcome::Failed(restore.map_or_else(
                     |restore_error| format!("{error}; namespace recovery failed: {restore_error}"),
-                    |()| error.to_string(),
+                    |()| {
+                        cleanup_error.map_or_else(
+                            || error.to_string(),
+                            |cleanup_error| {
+                                format!("{error}; hard-link check cleanup failed: {cleanup_error}")
+                            },
+                        )
+                    },
                 ))
             }
         }
@@ -592,16 +851,18 @@ fn execute_plan_windows(
     soft_cancelled: &AtomicBool,
     hard_cancelled: &AtomicBool,
 ) -> DeletionReport {
-    let root = match open_root(scan_root) {
+    let root = match open_root(scan_root, &plan.scan_root_identity) {
         Ok(root) => root,
         Err(error) => return failed_report(scan_root, plan, &error.to_string()),
     };
     let estimated_bytes = plan.estimated_bytes;
     let target_node_id = plan.target.node_id;
     let root_relative_path = plan.root_relative_path.clone();
+    let planned_link_counts = planned_link_counts(&plan.entries);
+    let mut deleted_link_counts = HashMap::new();
     let mut results = Vec::with_capacity(plan.entries.len());
     let mut stopped = false;
-    for entry in plan.entries {
+    for mut entry in plan.entries {
         if stopped
             || soft_cancelled.load(Ordering::Acquire)
             || hard_cancelled.load(Ordering::Acquire)
@@ -613,7 +874,15 @@ fn execute_plan_windows(
             });
             continue;
         }
-        let outcome = execute_windows_entry(&root, &entry);
+        let outcome = execute_windows_entry(&root, &mut entry);
+        if matches!(&outcome, DeletionEntryOutcome::Deleted) {
+            note_deleted_link(&mut entry, &planned_link_counts, &deleted_link_counts);
+            let file_id = entry.snapshot.identity.file_id;
+            deleted_link_counts
+                .entry(file_id)
+                .and_modify(|count| *count = count.saturating_add(1))
+                .or_insert(1);
+        }
         results.push(DeletionEntryResult { entry, outcome });
     }
     DeletionReport {
@@ -628,7 +897,7 @@ fn execute_plan_windows(
 }
 
 #[cfg(windows)]
-fn execute_windows_entry(root: &File, entry: &PlannedEntry) -> DeletionEntryOutcome {
+fn execute_windows_entry(root: &File, entry: &mut PlannedEntry) -> DeletionEntryOutcome {
     use cap_primitives::fs::{_WindowsByHandle as _, OpenOptionsExt as _};
 
     const DELETE: u32 = 0x0001_0000;
@@ -677,6 +946,13 @@ fn execute_windows_entry(root: &File, entry: &PlannedEntry) -> DeletionEntryOutc
         Ok(snapshot) => snapshot,
         Err(error) => return DeletionEntryOutcome::Failed(error.to_string()),
     };
+    if kind == PlannedKind::File {
+        // A pathname-independent post-open hard-link count can still change
+        // before handle deletion; report regular-file allocation conservatively.
+        entry.snapshot.identity.link_count = None;
+    } else {
+        entry.snapshot.identity.link_count = actual.identity.link_count;
+    }
     if !matches_for_execution(&entry.snapshot, &actual) {
         return DeletionEntryOutcome::Changed(
             "identity, type, size, allocation, or modification changed".to_string(),
@@ -824,12 +1100,68 @@ fn finalize_placeholder(
     remove_verified_placeholder(parent, detached, placeholder)
 }
 
+#[cfg(any(target_os = "linux", target_vendor = "apple"))]
+fn create_link_hold(parent: &File, source: &OsStr) -> io::Result<OsString> {
+    use std::sync::atomic::AtomicU64;
+
+    static NEXT_LINK_HOLD: AtomicU64 = AtomicU64::new(0);
+    for _ in 0..128 {
+        let sequence = NEXT_LINK_HOLD.fetch_add(1, Ordering::Relaxed);
+        let name = OsString::from(format!(
+            ".excise-link-check-{:x}-{sequence:x}",
+            std::process::id()
+        ));
+        match cap_fs::hard_link(parent, Path::new(source), parent, Path::new(&name)) {
+            Ok(()) => return Ok(name),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        "could not reserve a hard-link verification name",
+    ))
+}
+
+#[cfg(any(target_os = "linux", target_vendor = "apple"))]
+fn link_hold_matches_count(parent: &File, hold: &OsStr, expected: Option<u64>) -> io::Result<bool> {
+    let metadata = cap_fs::stat(parent, Path::new(hold), FollowSymlinks::No)?;
+    let snapshot = snapshot_from_cap_metadata(parent, hold, &metadata, PlannedKind::File)?;
+    Ok(snapshot.identity.link_count == expected)
+}
+
+#[cfg(any(target_os = "linux", target_vendor = "apple"))]
+fn remove_link_hold(parent: &File, hold: &OsStr, expected: &NativeIdentity) -> io::Result<()> {
+    let metadata = match cap_fs::stat(parent, Path::new(hold), FollowSymlinks::No) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    let actual = snapshot_from_cap_metadata(parent, hold, &metadata, PlannedKind::File)?;
+    if !same_object(expected, &actual.identity) {
+        return Err(io::Error::other(
+            "hard-link verification name no longer contains the target",
+        ));
+    }
+    match cap_fs::remove_file(parent, Path::new(hold)) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
 fn inspect_relative(
     root: &File,
     relative: &Path,
 ) -> Result<(PlannedSnapshot, Option<File>), DeletionPlanError> {
     let (parent, name) = open_parent(root, relative)?;
-    inspect_child(&parent, &name, relative)
+    match inspect_child(&parent, &name, relative) {
+        Err(DeletionPlanError::Io {
+            kind: io::ErrorKind::NotFound,
+            ..
+        }) => Err(DeletionPlanError::Missing(relative.to_path_buf())),
+        result => result,
+    }
 }
 
 fn inspect_child(
@@ -857,8 +1189,41 @@ fn inspect_child(
     }
 }
 
-fn open_root(path: &Path) -> Result<File, DeletionPlanError> {
-    cap_fs::open_ambient_dir(path, ambient_authority()).map_err(|error| plan_io(path, error))
+pub(crate) fn current_scan_root_identity(path: &Path) -> Result<NativeIdentity, DeletionPlanError> {
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| plan_io(path, error))?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Err(DeletionPlanError::Changed);
+    }
+    let identity = identity_for(path, &metadata)
+        .map_err(|error| plan_io(path, error))?
+        .ok_or(DeletionPlanError::Changed)?;
+    if identity.reparse_point {
+        return Err(DeletionPlanError::Changed);
+    }
+    Ok(identity)
+}
+
+pub(crate) fn validate_scan_root_identity(
+    path: &Path,
+    expected: &NativeIdentity,
+) -> Result<(), DeletionPlanError> {
+    if !same_object(expected, &current_scan_root_identity(path)?) {
+        return Err(DeletionPlanError::Changed);
+    }
+    Ok(())
+}
+
+fn open_root(path: &Path, expected: &NativeIdentity) -> Result<File, DeletionPlanError> {
+    validate_scan_root_identity(path, expected)?;
+    let root = cap_fs::open_ambient_dir(path, ambient_authority())
+        .map_err(|error| plan_io(path, error))?;
+    let handle_snapshot = snapshot_from_open_file(&root, PlannedKind::Directory)
+        .map_err(|error| plan_io(path, error))?;
+    if !same_object(expected, &handle_snapshot.identity) {
+        return Err(DeletionPlanError::Changed);
+    }
+    validate_scan_root_identity(path, expected)?;
+    Ok(root)
 }
 
 fn validate_model_snapshot(
@@ -949,23 +1314,23 @@ fn challenge_for(
     snapshot: &PlannedSnapshot,
     reduced_guardrails: bool,
 ) -> ConfirmationChallenge {
-    if reduced_guardrails {
-        return ConfirmationChallenge::ReducedGuard;
-    }
-    if snapshot.kind != PlannedKind::Directory {
-        return ConfirmationChallenge::ConfirmFile;
-    }
     let name = target.path_to_file.last().map_or_else(
         || safe_display_os_str(OsStr::new("")),
         |name| safe_display_os_str(name),
     );
     if name.deceptive {
-        ConfirmationChallenge::TypePhrase(format!(
+        return ConfirmationChallenge::TypePhrase(format!(
             "DELETE {}",
             challenge_code(&snapshot.identity.file_id)
-        ))
-    } else {
+        ));
+    }
+    if reduced_guardrails {
+        return ConfirmationChallenge::ReducedGuard;
+    }
+    if snapshot.kind == PlannedKind::Directory {
         ConfirmationChallenge::TypeName(name.text)
+    } else {
+        ConfirmationChallenge::ConfirmFile
     }
 }
 
@@ -993,6 +1358,45 @@ fn matches_for_execution(expected: &PlannedSnapshot, actual: &PlannedSnapshot) -
 
 fn same_object(expected: &NativeIdentity, actual: &NativeIdentity) -> bool {
     expected.file_id == actual.file_id && expected.reparse_point == actual.reparse_point
+}
+
+fn planned_link_counts(entries: &[PlannedEntry]) -> HashMap<FileId, u64> {
+    let mut counts: HashMap<FileId, u64> = HashMap::new();
+    for entry in entries {
+        if matches!(entry.snapshot.kind, PlannedKind::File | PlannedKind::Link)
+            && entry.snapshot.identity.link_count.is_some()
+        {
+            counts
+                .entry(entry.snapshot.identity.file_id)
+                .and_modify(|count| *count = count.saturating_add(1))
+                .or_insert(1);
+        }
+    }
+    counts
+}
+
+fn note_deleted_link(
+    entry: &mut PlannedEntry,
+    planned: &HashMap<FileId, u64>,
+    deleted: &HashMap<FileId, u64>,
+) {
+    if !matches!(entry.snapshot.kind, PlannedKind::File | PlannedKind::Link) {
+        return;
+    }
+    let Some(actual) = entry.snapshot.identity.link_count else {
+        return;
+    };
+    let Some(planned) = planned.get(&entry.snapshot.identity.file_id).copied() else {
+        entry.snapshot.identity.link_count = None;
+        return;
+    };
+    let already_deleted = deleted
+        .get(&entry.snapshot.identity.file_id)
+        .copied()
+        .unwrap_or(0);
+    if actual > planned.saturating_sub(already_deleted) {
+        entry.snapshot.identity.link_count = None;
+    }
 }
 
 #[cfg(unix)]
@@ -1024,7 +1428,7 @@ fn snapshot_from_std_metadata(
         } else {
             u128::from(metadata.len())
         },
-        allocated_bytes: (kind == PlannedKind::File)
+        allocated_bytes: matches!(kind, PlannedKind::File | PlannedKind::Link)
             .then(|| u128::from(metadata.blocks()).saturating_mul(512)),
         modified_nanos: modified_nanos(metadata),
     })
@@ -1058,7 +1462,10 @@ fn snapshot_from_open_file(handle: &File, kind: PlannedKind) -> io::Result<Plann
         } else {
             u128::from(metadata.len())
         },
-        allocated_bytes: None,
+        allocated_bytes: (kind != PlannedKind::Directory)
+            .then(|| crate::os::physical_size_from_handle(handle))
+            .transpose()?
+            .map(u128::from),
         modified_nanos,
     })
 }
@@ -1103,7 +1510,7 @@ fn snapshot_from_cap_metadata(
         kind,
         apparent_bytes: u128::from(metadata.len()),
 
-        allocated_bytes: (kind == PlannedKind::File)
+        allocated_bytes: matches!(kind, PlannedKind::File | PlannedKind::Link)
             .then(|| u128::from(metadata.blocks()).saturating_mul(512)),
         modified_nanos,
     })
@@ -1150,8 +1557,8 @@ fn snapshot_from_cap_metadata(
 #[allow(clippy::needless_pass_by_value)]
 fn plan_io(path: &Path, error: io::Error) -> DeletionPlanError {
     DeletionPlanError::Io {
-        path: path.to_string_lossy().into_owned(),
-        message: error.to_string(),
+        path: safe_display_path_text(path),
+        message: safe_display_text(&error.to_string()),
         kind: error.kind(),
     }
 }
@@ -1191,24 +1598,25 @@ mod tests {
     use crate::state::tiles::FileType;
 
     fn reviewed_snapshot(path: &Path, metadata: &std::fs::Metadata) -> PlannedSnapshot {
-        let kind = if metadata.is_dir() {
-            PlannedKind::Directory
-        } else if metadata.file_type().is_symlink() {
+        let identity = crate::native_path::identity_for(path, metadata)
+            .expect("fixture identity lookup should succeed")
+            .expect("fixture identity should be readable");
+        let kind = if metadata.file_type().is_symlink() || identity.reparse_point {
             PlannedKind::Link
+        } else if metadata.is_dir() {
+            PlannedKind::Directory
         } else {
             PlannedKind::File
         };
         PlannedSnapshot {
-            identity: crate::native_path::identity_for(path, metadata)
-                .expect("fixture identity lookup should succeed")
-                .expect("fixture identity should be readable"),
+            identity,
             kind,
             apparent_bytes: if kind == PlannedKind::Directory {
                 0
             } else {
                 u128::from(metadata.len())
             },
-            allocated_bytes: (kind == PlannedKind::File && !cfg!(windows))
+            allocated_bytes: matches!(kind, PlannedKind::File | PlannedKind::Link)
                 .then(|| {
                     crate::os::physical_size(path, metadata)
                         .ok()
@@ -1281,6 +1689,88 @@ mod tests {
             },
             reviewed_entries,
         }
+    }
+
+    #[test]
+    fn plan_io_display_escapes_hostile_path_and_message() {
+        let path = Path::new("plan-\u{1b}[31m-\u{202e}name");
+        let error = plan_io(path, io::Error::other("metadata failed\t\u{202e}"));
+        let rendered = error.to_string();
+
+        assert!(rendered.contains("[deceptive]"));
+        assert!(rendered.contains("\\x1b"));
+        assert!(rendered.contains("\\u{202e}"));
+        assert!(rendered.contains("\\t"));
+        assert!(!rendered.chars().any(char::is_control));
+        assert!(!rendered.contains('\u{202e}'));
+    }
+
+    #[test]
+    fn missing_parent_is_stale_but_missing_target_is_explicit() {
+        let root = tempfile::tempdir().expect("deletion root should exist");
+        let parent = root.path().join("parent");
+        std::fs::create_dir(&parent).expect("parent should be created");
+        let nested = parent.join("target");
+        std::fs::write(&nested, b"payload").expect("nested target should be written");
+
+        let reviewed = target(root.path(), OsString::from("parent/target"), FileType::File);
+        std::fs::remove_dir_all(&parent).expect("parent should be removed");
+        let parent_error = build_plan(root.path(), reviewed, false)
+            .expect_err("missing parent should reject the stale namespace");
+        assert!(parent_error.is_stale());
+        assert!(!parent_error.is_missing());
+        assert!(matches!(
+            parent_error,
+            DeletionPlanError::Io {
+                kind: io::ErrorKind::NotFound,
+                ..
+            }
+        ));
+
+        let path = root.path().join("target");
+        std::fs::write(&path, b"payload").expect("target should be written");
+        let reviewed = target(root.path(), OsString::from("target"), FileType::File);
+        std::fs::remove_file(&path).expect("target should be removed");
+        let target_error = build_plan(root.path(), reviewed, false)
+            .expect_err("missing target should be reported explicitly");
+        assert!(target_error.is_missing());
+        assert!(!target_error.is_stale());
+        assert!(matches!(
+            target_error,
+            DeletionPlanError::Missing(path) if path == Path::new("target")
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hard_link_created_after_identity_inspection_is_not_reclaimable() {
+        let root = tempfile::tempdir().expect("deletion root should exist");
+        let path = root.path().join("target");
+        let late_link = root.path().join("late-link");
+        std::fs::write(&path, b"payload").expect("target should be written");
+        let plan = build_plan(
+            root.path(),
+            target(root.path(), OsString::from("target"), FileType::File),
+            false,
+        )
+        .expect("file plan should build");
+
+        let report = execute_plan_unix_with_hooks(
+            root.path(),
+            plan,
+            &AtomicBool::new(false),
+            &AtomicBool::new(false),
+            || {},
+            |detached| {
+                std::fs::hard_link(root.path().join(detached), &late_link)
+                    .expect("late hard link should be created");
+            },
+        );
+
+        assert_eq!(report.deleted_entries(), 1);
+        assert_eq!(report.deleted_allocated_bytes(), 0);
+        assert!(!path.exists());
+        assert!(late_link.exists());
     }
 
     #[test]
@@ -1654,6 +2144,10 @@ mod tests {
             plan.root_snapshot().map(|snapshot| snapshot.kind),
             Some(PlannedKind::Link)
         );
+        let link_allocation = plan
+            .root_snapshot()
+            .and_then(|snapshot| snapshot.allocated_bytes)
+            .expect("link-object allocation should be known");
 
         let report = execute_plan(
             root.path(),
@@ -1663,6 +2157,7 @@ mod tests {
         );
 
         assert_eq!(report.deleted_entries(), 1);
+        assert_eq!(report.deleted_allocated_bytes(), link_allocation);
         assert!(!link.exists());
         assert!(outside_file.exists());
     }
@@ -1730,6 +2225,10 @@ mod tests {
             plan.root_snapshot().map(|snapshot| snapshot.kind),
             Some(PlannedKind::Link)
         );
+        let junction_allocation = plan
+            .root_snapshot()
+            .and_then(|snapshot| snapshot.allocated_bytes)
+            .expect("reparse-object allocation should be known");
 
         let report = execute_plan(
             root.path(),
@@ -1739,6 +2238,7 @@ mod tests {
         );
 
         assert_eq!(report.deleted_entries(), 1);
+        assert_eq!(report.deleted_allocated_bytes(), junction_allocation);
         assert!(!junction.exists());
         assert!(outside_file.exists());
     }
@@ -1778,6 +2278,31 @@ mod tests {
         drop(blocker);
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn regular_file_deletion_reports_allocation_as_unknown() {
+        let root = tempfile::tempdir().expect("deletion root should exist");
+        let path = root.path().join("target");
+        std::fs::write(&path, b"payload").expect("target should be written");
+        let plan = build_plan(
+            root.path(),
+            target(root.path(), OsString::from("target"), FileType::File),
+            false,
+        )
+        .expect("file plan should build");
+
+        let report = execute_plan(
+            root.path(),
+            plan,
+            &AtomicBool::new(false),
+            &AtomicBool::new(false),
+        );
+
+        assert_eq!(report.deleted_entries(), 1);
+        assert_eq!(report.deleted_allocated_bytes(), 0);
+        assert!(!path.exists());
+    }
+
     #[cfg(unix)]
     #[test]
     fn hostile_directory_name_uses_generated_challenge() {
@@ -1797,5 +2322,169 @@ mod tests {
             plan.challenge,
             ConfirmationChallenge::TypePhrase(_)
         ));
+    }
+    #[cfg(unix)]
+    #[test]
+    fn hostile_file_name_uses_generated_challenge() {
+        use std::os::unix::ffi::OsStringExt as _;
+
+        let root = tempfile::tempdir().expect("deletion root should exist");
+        let name = OsString::from_vec(b"bad\x1bfile".to_vec());
+        std::fs::write(root.path().join(&name), b"payload")
+            .expect("hostile file should be written");
+        let plan = build_plan(
+            root.path(),
+            target(root.path(), name, FileType::File),
+            false,
+        )
+        .expect("hostile file plan should build");
+
+        assert!(matches!(
+            plan.challenge,
+            ConfirmationChallenge::TypePhrase(ref phrase) if phrase.starts_with("DELETE ")
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replaced_scan_root_is_rejected_before_execution() {
+        let parent = tempfile::tempdir().expect("deletion parent should exist");
+        let scan_root = parent.path().join("scan-root");
+        let original = parent.path().join("original-root");
+        std::fs::create_dir(&scan_root).expect("scan root should be created");
+        std::fs::write(scan_root.join("target"), b"original").expect("target should be written");
+        let plan = build_plan(
+            &scan_root,
+            target(&scan_root, OsString::from("target"), FileType::File),
+            false,
+        )
+        .expect("file plan should build");
+
+        std::fs::rename(&scan_root, &original).expect("original root should be displaced");
+        std::fs::create_dir(&scan_root).expect("replacement root should be created");
+        std::fs::write(scan_root.join("target"), b"replacement")
+            .expect("replacement target should be written");
+
+        let report = execute_plan(
+            &scan_root,
+            plan,
+            &AtomicBool::new(false),
+            &AtomicBool::new(false),
+        );
+
+        assert_eq!(report.failed_entries(), 1);
+        assert!(scan_root.join("target").exists());
+        assert!(original.join("target").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn allocated_bytes_are_reported_only_after_last_hard_link_deletion() {
+        let root = tempfile::tempdir().expect("deletion root should exist");
+        let first = root.path().join("first");
+        let second = root.path().join("second");
+        std::fs::write(&first, b"payload").expect("hard-link source should be written");
+        std::fs::hard_link(&first, &second).expect("hard link should be created");
+
+        let first_plan = build_plan(
+            root.path(),
+            target(root.path(), OsString::from("first"), FileType::File),
+            false,
+        )
+        .expect("first hard-link plan should build");
+        let first_allocated = first_plan
+            .root_snapshot()
+            .and_then(|snapshot| snapshot.allocated_bytes)
+            .expect("first allocation should be known");
+        let first_report = execute_plan(
+            root.path(),
+            first_plan,
+            &AtomicBool::new(false),
+            &AtomicBool::new(false),
+        );
+        assert_eq!(first_report.deleted_allocated_bytes(), 0);
+        assert!(second.exists());
+
+        let second_report = execute_plan(
+            root.path(),
+            build_plan(
+                root.path(),
+                target(root.path(), OsString::from("second"), FileType::File),
+                false,
+            )
+            .expect("last hard-link plan should build"),
+            &AtomicBool::new(false),
+            &AtomicBool::new(false),
+        );
+        assert_eq!(second_report.deleted_allocated_bytes(), first_allocated);
+        assert!(!second.exists());
+    }
+    #[cfg(unix)]
+    #[test]
+    fn external_hard_link_created_after_planning_is_not_reported_as_freed() {
+        let root = tempfile::tempdir().expect("deletion root should exist");
+        let outside = tempfile::tempdir().expect("external root should exist");
+        let external = outside.path().join("external");
+        let first = root.path().join("first");
+        std::fs::write(&first, b"payload").expect("hard-link source should be written");
+        let plan = build_plan(
+            root.path(),
+            target(root.path(), OsString::from("first"), FileType::File),
+            false,
+        )
+        .expect("file plan should build");
+        std::fs::hard_link(&first, &external).expect("external hard link should be created");
+
+        let report = execute_plan(
+            root.path(),
+            plan,
+            &AtomicBool::new(false),
+            &AtomicBool::new(false),
+        );
+
+        assert_eq!(report.deleted_entries(), 1);
+        assert_eq!(report.deleted_allocated_bytes(), 0);
+        assert_eq!(
+            external
+                .metadata()
+                .expect("external link should remain")
+                .len(),
+            7
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn planned_hard_links_still_report_allocation_after_both_delete() {
+        let root = tempfile::tempdir().expect("deletion root should exist");
+        let directory = root.path().join("target");
+        std::fs::create_dir(&directory).expect("target directory should be created");
+        let first = directory.join("first");
+        let second = directory.join("second");
+        std::fs::write(&first, b"payload").expect("hard-link source should be written");
+        std::fs::hard_link(&first, &second).expect("hard link should be created");
+        let plan = build_plan(
+            root.path(),
+            target(root.path(), OsString::from("target"), FileType::Folder),
+            false,
+        )
+        .expect("directory plan should build");
+        let allocated = plan
+            .entries
+            .iter()
+            .find(|entry| entry.relative_path == Path::new("target/first"))
+            .and_then(|entry| entry.snapshot.allocated_bytes)
+            .expect("allocation should be known");
+
+        let report = execute_plan(
+            root.path(),
+            plan,
+            &AtomicBool::new(false),
+            &AtomicBool::new(false),
+        );
+
+        assert_eq!(report.deleted_entries(), 3);
+        assert_eq!(report.deleted_allocated_bytes(), allocated);
+        assert!(!directory.exists());
     }
 }

--- a/src/input/controls.rs
+++ b/src/input/controls.rs
@@ -57,13 +57,15 @@ pub(crate) enum InputCommand {
     StartRescan(PathBuf),
     CancelRescan,
     PlanDeletion(FileToDelete),
-    ExecuteDeletion(DeletionPlan),
+    CancelDeletionPlan,
+    RevalidateDeletion(DeletionPlan),
     ExportScan,
     ExportDeletionHistory,
     CycleTheme,
     SavePreferencesAndExit,
     DiscardPreferencesAndExit,
     SoftCancelDeletion,
+    ResumeDeletion,
     HardCancel,
 }
 
@@ -309,7 +311,7 @@ fn handle_keypress_planning_mode<B: Backend>(evt: &Event, app: &mut App<B>) -> I
     match evt {
         key!(Esc) => {
             app.normal_mode();
-            InputCommand::None
+            InputCommand::CancelDeletionPlan
         }
         key!(ctrl 'c') => {
             app.exit();
@@ -346,7 +348,7 @@ fn handle_keypress_delete_confirm_mode<B: Backend>(evt: &Event, app: &mut App<B>
         }
         key!(Enter) => app
             .take_confirmed_deletion_plan()
-            .map_or(InputCommand::None, InputCommand::ExecuteDeletion),
+            .map_or(InputCommand::None, InputCommand::RevalidateDeletion),
         Event::Key(KeyEvent {
             code: KeyCode::Char(character),
             modifiers,
@@ -355,7 +357,7 @@ fn handle_keypress_delete_confirm_mode<B: Backend>(evt: &Event, app: &mut App<B>
             app.push_confirmation_character(*character);
             if app.confirmation_is_single_key() {
                 app.take_confirmed_deletion_plan()
-                    .map_or(InputCommand::None, InputCommand::ExecuteDeletion)
+                    .map_or(InputCommand::None, InputCommand::RevalidateDeletion)
             } else {
                 InputCommand::None
             }
@@ -380,18 +382,12 @@ fn handle_keypress_deleting_mode<B: Backend>(evt: &Event, app: &mut App<B>) -> I
 
 fn handle_keypress_deletion_cancel_mode<B: Backend>(evt: &Event, app: &mut App<B>) -> InputCommand {
     match evt {
-        key!(char 's') => {
-            app.resume_deletion(true);
-            InputCommand::SoftCancelDeletion
-        }
+        key!(char 's') => InputCommand::SoftCancelDeletion,
         key!(ctrl 'c') | key!(char 'h') => {
             app.exit();
             InputCommand::HardCancel
         }
-        key!(Esc) | key!(char 'b') => {
-            app.resume_deletion(false);
-            InputCommand::None
-        }
+        key!(Esc) | key!(char 'b') => InputCommand::ResumeDeletion,
         _ => InputCommand::None,
     }
 }
@@ -449,5 +445,96 @@ fn handle_keypress_exiting_mode<B: Backend>(evt: &Event, app: &mut App<B>) -> In
             InputCommand::None
         }
         _ => InputCommand::None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+    use ratatui::backend::TestBackend;
+
+    use crate::UiMode;
+    use crate::config::KeyPreset;
+
+    use super::*;
+
+    fn key(code: KeyCode, modifiers: KeyModifiers) -> Event {
+        Event::Key(KeyEvent::new(code, modifiers))
+    }
+
+    fn app() -> (tempfile::TempDir, App<TestBackend>) {
+        let root = tempfile::tempdir().expect("input root should exist");
+        let app = App::new(
+            TestBackend::new(80, 24),
+            root.path().to_path_buf(),
+            false,
+            false,
+            128,
+            KeyPreset::Vim,
+            None,
+            false,
+        )
+        .expect("app should initialize");
+        (root, app)
+    }
+
+    #[test]
+    fn deletion_cancel_keys_defer_state_changes_to_runtime() {
+        let (_root, mut app) = app();
+        app.ui_mode = UiMode::DeletionCancel { planned_entries: 1 };
+
+        let command = handle_keypress(&key(KeyCode::Char('s'), KeyModifiers::NONE), &mut app);
+        assert!(matches!(command, InputCommand::SoftCancelDeletion));
+        assert!(matches!(
+            &app.ui_mode,
+            UiMode::DeletionCancel { planned_entries: 1 }
+        ));
+
+        let command = handle_keypress(&key(KeyCode::Char('b'), KeyModifiers::NONE), &mut app);
+        assert!(matches!(command, InputCommand::ResumeDeletion));
+        assert!(matches!(
+            &app.ui_mode,
+            UiMode::DeletionCancel { planned_entries: 1 }
+        ));
+    }
+
+    #[test]
+    fn deletion_cancel_hard_key_still_exits() {
+        let (_root, mut app) = app();
+        app.ui_mode = UiMode::DeletionCancel { planned_entries: 1 };
+
+        let command = handle_keypress(&key(KeyCode::Char('c'), KeyModifiers::CONTROL), &mut app);
+        assert!(matches!(command, InputCommand::HardCancel));
+        assert!(!app.is_running);
+    }
+
+    #[test]
+    fn planning_escape_cancels_pending_plan() {
+        use crate::model::{EntrySnapshot, NodeId, NodeKind};
+        use crate::state::FileToDelete;
+        use crate::state::tiles::FileType;
+
+        let (root, mut app) = app();
+        app.ui_mode = UiMode::PlanningDeletion(Box::new(FileToDelete {
+            node_id: NodeId(1),
+            synthetic: false,
+            path_in_filesystem: root.path().to_path_buf(),
+            path_to_file: vec!["target".into()],
+            file_type: FileType::File,
+            num_descendants: None,
+            size: 0,
+            expected_snapshot: EntrySnapshot {
+                identity: None,
+                kind: NodeKind::File,
+                apparent_bytes: 0,
+                allocated_bytes: None,
+                modified_nanos: None,
+            },
+            reviewed_entries: Vec::new(),
+        }));
+
+        let command = handle_keypress(&key(KeyCode::Esc, KeyModifiers::NONE), &mut app);
+        assert!(matches!(command, InputCommand::CancelDeletionPlan));
+        assert!(matches!(app.ui_mode, UiMode::Normal));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,8 +50,13 @@ pub(crate) fn start<B>(
 ) where
     B: ratatui::backend::Backend,
 {
+    let metadata = std::fs::symlink_metadata(&path).expect("test root metadata should exist");
+    let root_identity = crate::native_path::identity_for(&path, &metadata)
+        .expect("test root identity should be readable")
+        .expect("test root should not be a symbolic link");
     let settings = runtime::RuntimeSettings {
         root: path,
+        root_identity,
         scan_threads: 1,
         event_capacity: 256,
         cross_filesystems: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,7 @@ fn run_main() -> i32 {
     let monochrome_locked = config.monochrome && config.theme != excise::theme::ThemeId::Monochrome;
     let settings = RuntimeSettings {
         root: root.resolved.as_path().to_path_buf(),
+        root_identity: root.identity.clone(),
         scan_threads: config.scan_threads,
         event_capacity: config.event_buffer,
         cross_filesystems: config.cross_filesystems,

--- a/src/model/arena.rs
+++ b/src/model/arena.rs
@@ -20,6 +20,24 @@ const NODE_SLOT_BYTES: usize = size_of::<Option<Box<Node>>>();
 const NODE_OVERHEAD: usize = NODE_SLOT_BYTES + size_of::<Node>() + 96;
 const DUPLICATE_ID_OVERHEAD: usize = size_of::<FileId>() + 64;
 const DEFAULT_MAX_CHILDREN: usize = 4_096;
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct UntrackedMetrics {
+    allocated_bytes: ByteBounds,
+    reclaimable_bytes: ByteBounds,
+}
+
+impl UntrackedMetrics {
+    fn is_zero(self) -> bool {
+        self == Self::default()
+    }
+
+    fn add(&mut self, other: Self) {
+        self.allocated_bytes.add(other.allocated_bytes);
+        self.reclaimable_bytes.add(other.reclaimable_bytes);
+    }
+}
+
+const UNTRACKED_METRICS_OVERHEAD: usize = size_of::<NodeId>() + size_of::<UntrackedMetrics>() + 64;
 
 pub struct Arena {
     nodes: Vec<Option<Box<Node>>>,
@@ -30,6 +48,7 @@ pub struct Arena {
     budget: MemoryBudget,
     identities: IdentityStore,
     duplicate_identities: HashSet<FileId>,
+    untracked_metrics: HashMap<NodeId, UntrackedMetrics>,
     access_tick: u64,
     max_children_per_directory: usize,
 }
@@ -64,6 +83,7 @@ impl Arena {
             budget,
             identities: IdentityStore::new(identity_budget)?,
             duplicate_identities: HashSet::new(),
+            untracked_metrics: HashMap::new(),
             access_tick: 0,
             max_children_per_directory: DEFAULT_MAX_CHILDREN,
         };
@@ -82,6 +102,11 @@ impl Arena {
     #[must_use]
     pub const fn root(&self) -> NodeId {
         self.root
+    }
+    pub(crate) fn set_root_identity(&mut self, identity: NativeIdentity) {
+        if let Some(root) = self.node_mut(self.root) {
+            root.snapshot.identity = Some(identity);
+        }
     }
 
     #[must_use]
@@ -194,19 +219,19 @@ impl Arena {
             .last()
             .ok_or_else(|| ModelError::InvalidPath("entry had no filename".to_string()))?;
 
-        let kind = if metadata.is_dir() {
-            NodeKind::Directory
-        } else if metadata.file_type().is_symlink() {
+        let kind = if metadata.file_type().is_symlink() || identity.reparse_point {
             NodeKind::Link
+        } else if metadata.is_dir() {
+            NodeKind::Directory
         } else {
             NodeKind::File
         };
-        let apparent = if metadata.is_dir() {
+        let apparent = if kind == NodeKind::Directory {
             0
         } else {
             u128::from(metadata.len())
         };
-        let allocated = if metadata.is_dir() {
+        let allocated = if kind == NodeKind::Directory {
             ByteBounds::exact(0)
         } else {
             physical_size(path, metadata)
@@ -222,7 +247,7 @@ impl Arena {
             identity: Some(identity.clone()),
             kind,
             apparent_bytes: apparent,
-            allocated_bytes: if kind == NodeKind::File && !cfg!(windows) {
+            allocated_bytes: if matches!(kind, NodeKind::File | NodeKind::Link) {
                 allocated.upper
             } else {
                 None
@@ -259,7 +284,7 @@ impl Arena {
                 apparent,
                 allocated,
                 &identity,
-                Some(parent),
+                Some(other),
                 Some(other),
             )?;
             self.accumulate_other(parent, other, metrics);
@@ -276,7 +301,7 @@ impl Arena {
                 apparent,
                 allocated,
                 &identity,
-                Some(parent),
+                Some(other),
                 Some(other),
             )?;
             self.accumulate_other(parent, other, metrics);
@@ -366,6 +391,10 @@ impl Arena {
                 .is_some_and(|node| node.kind.is_synthetic())
             {
                 aggregate_at_parent = true;
+            } else if matches!(reason, UnscannedReason::Replacement(_)) {
+                let mut removed = Vec::new();
+                self.collect_subtree_ids(existing, &mut removed);
+                self.remove_nodes_with_accounting(removed)?;
             } else {
                 let unknown = matches!(reason, UnscannedReason::Metadata(_));
                 if let Some(node) = self.node_mut(existing) {
@@ -385,23 +414,31 @@ impl Arena {
             }
         }
         let metadata = fs::symlink_metadata(path).ok();
-        let kind = if metadata.as_ref().is_some_and(Metadata::is_dir) {
-            NodeKind::Directory
-        } else if metadata
+        let metadata_identity = metadata
+            .as_ref()
+            .and_then(|metadata| identity_for(path, metadata).ok().flatten());
+        let is_link = metadata
             .as_ref()
             .is_some_and(|metadata| metadata.file_type().is_symlink())
-        {
+            || metadata_identity
+                .as_ref()
+                .is_some_and(|identity| identity.reparse_point)
+            || matches!(reason, UnscannedReason::SymbolicLink);
+        let kind = if is_link {
             NodeKind::Link
+        } else if metadata.as_ref().is_some_and(Metadata::is_dir) {
+            NodeKind::Directory
         } else {
             NodeKind::File
         };
         let apparent = metadata
             .as_ref()
+            .filter(|_| kind != NodeKind::Directory)
             .map_or(0, |metadata| u128::from(metadata.len()));
         let allocated = metadata
             .as_ref()
             .map_or_else(ByteBounds::unknown, |metadata| {
-                if metadata.is_dir() {
+                if kind == NodeKind::Directory {
                     ByteBounds::exact(0)
                 } else {
                     physical_size(path, metadata)
@@ -410,11 +447,11 @@ impl Arena {
                 }
             });
 
-        let metrics = if scoped_zero {
-            NodeMetrics::default()
-        } else {
-            leaf_metrics(apparent, allocated, None)
-        };
+        let declared_links = metadata_identity
+            .as_ref()
+            .filter(|identity| identity.reparse_point)
+            .and_then(|identity| identity.link_count);
+        let metrics = unscanned_metrics(apparent, allocated, kind, &reason, declared_links);
         let at_child_limit = self.retained_child_count(parent) >= self.max_children_per_directory;
         let replacement = if !aggregate_at_parent && at_child_limit {
             self.smallest_retained_child(parent)
@@ -424,7 +461,7 @@ impl Arena {
         };
         if aggregate_at_parent || (at_child_limit && replacement.is_none()) {
             let other = self.ensure_other(parent)?;
-            self.accumulate_other(parent, other, metrics);
+            self.accumulate_untracked_other(parent, other, metrics)?;
             return Ok(());
         }
         if let Some(victim) = replacement {
@@ -433,7 +470,7 @@ impl Arena {
         }
         if self.reserve_child(&name).is_err() {
             let other = self.ensure_other(parent)?;
-            self.accumulate_other(parent, other, metrics);
+            self.accumulate_untracked_other(parent, other, metrics)?;
             return Ok(());
         }
         let id = self.next_id()?;
@@ -444,12 +481,10 @@ impl Arena {
             kind,
             unscanned_state(&reason),
             EntrySnapshot {
-                identity: metadata
-                    .as_ref()
-                    .and_then(|metadata| identity_for(path, metadata).ok().flatten()),
+                identity: metadata_identity,
                 kind,
                 apparent_bytes: apparent,
-                allocated_bytes: if kind == NodeKind::File && !cfg!(windows) {
+                allocated_bytes: if matches!(kind, NodeKind::File | NodeKind::Link) {
                     allocated.upper
                 } else {
                     None
@@ -471,12 +506,42 @@ impl Arena {
         Ok(())
     }
 
-    pub fn complete_directory(&mut self, path: &Path) -> Result<(), ModelError> {
+    pub fn complete_directory(
+        &mut self,
+        path: &Path,
+        expected_identity: Option<&NativeIdentity>,
+    ) -> Result<(), ModelError> {
         if let Some(id) = self.find_path(path) {
+            let metadata = fs::symlink_metadata(path).ok();
+            let identity = metadata
+                .as_ref()
+                .and_then(|metadata| identity_for(path, metadata).ok().flatten());
+            if let Some(expected) = expected_identity
+                && !identity.as_ref().is_some_and(|actual| {
+                    actual.file_id == expected.file_id
+                        && actual.reparse_point == expected.reparse_point
+                })
+            {
+                return self.record_unscanned(
+                    path,
+                    UnscannedReason::Replacement(
+                        "scanner directory task changed before completion".to_string(),
+                    ),
+                );
+            }
+            let modified_nanos = metadata
+                .as_ref()
+                .and_then(|metadata| metadata.modified().ok())
+                .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+                .map(|duration| duration.as_nanos());
             if let Some(node) = self.node_mut(id)
                 && node.state == NodeState::Scanning
             {
                 node.state = NodeState::Complete;
+                node.snapshot.modified_nanos = modified_nanos;
+                if let Some(identity) = identity {
+                    node.snapshot.identity = Some(identity);
+                }
             }
             return Ok(());
         }
@@ -616,12 +681,18 @@ impl Arena {
             .node(candidate)
             .map_or(NodeMetrics::default(), |node| node.metrics);
         metrics.descendants = metrics.descendants.saturating_add(1);
+        let untracked = self.untracked_metrics_for_subtree(candidate);
+        let reserved = self.reserve_untracked_slot(candidate, untracked)?;
         let mut removed = Vec::new();
         for child in children {
             self.collect_subtree_ids(child, &mut removed);
         }
-        self.identities
-            .remap_removed_nodes(&mut removed, candidate)?;
+        if let Err(error) = self.identities.remap_removed_nodes(&mut removed, candidate) {
+            if reserved {
+                self.remove_untracked_metrics(candidate);
+            }
+            return Err(error);
+        }
         self.remove_reusable_nodes(removed);
         if let Some(node) = self.node_mut(candidate) {
             node.children.clear();
@@ -631,14 +702,19 @@ impl Arena {
             node.metrics = metrics;
             node.unscanned_reason = Some(UnscannedReason::MemoryAggregation);
         }
+        self.insert_untracked_metrics(candidate, untracked);
         self.rebuild_metrics();
         Ok(true)
     }
 
     pub fn remove_subtree(&mut self, root: NodeId) {
+        let _ = self.try_remove_subtree(root);
+    }
+
+    pub fn try_remove_subtree(&mut self, root: NodeId) -> Result<(), ModelError> {
         let mut removed = Vec::new();
         self.collect_subtree_ids(root, &mut removed);
-        self.remove_nodes(removed);
+        self.remove_nodes_with_accounting(removed).map(|_| ())
     }
 
     fn collect_subtree_ids(&self, root: NodeId, removed: &mut Vec<NodeId>) {
@@ -651,6 +727,67 @@ impl Arena {
         }
     }
 
+    pub fn remove_paths(&mut self, paths: &[PathBuf]) -> usize {
+        self.try_remove_paths(paths).unwrap_or(0)
+    }
+
+    pub fn try_remove_paths(&mut self, paths: &[PathBuf]) -> Result<usize, ModelError> {
+        self.try_remove_paths_with_link_counts(paths, &HashMap::new())
+    }
+
+    pub(crate) fn try_remove_paths_with_link_counts(
+        &mut self,
+        paths: &[PathBuf],
+        link_counts: &HashMap<FileId, Option<u64>>,
+    ) -> Result<usize, ModelError> {
+        let mut removed = Vec::new();
+        for path in paths {
+            if let Some(id) = self.find_path(path)
+                && id != self.root
+            {
+                self.collect_subtree_ids(id, &mut removed);
+            }
+        }
+        self.remove_nodes_with_accounting_and_link_counts(removed, link_counts)
+    }
+
+    fn remove_nodes_with_accounting(&mut self, removed: Vec<NodeId>) -> Result<usize, ModelError> {
+        self.remove_nodes_with_accounting_and_link_counts(removed, &HashMap::new())
+    }
+
+    fn remove_nodes_with_accounting_and_link_counts(
+        &mut self,
+        mut removed: Vec<NodeId>,
+        link_counts: &HashMap<FileId, Option<u64>>,
+    ) -> Result<usize, ModelError> {
+        removed.sort_unstable();
+        removed.dedup();
+        if removed.is_empty() {
+            return Ok(0);
+        }
+        let shared = self
+            .nodes
+            .iter()
+            .filter_map(Option::as_deref)
+            .filter(|node| {
+                node.kind == NodeKind::Synthetic(SyntheticKind::Shared)
+                    && removed.binary_search(&node.id).is_err()
+            })
+            .map(|node| node.id)
+            .collect::<Vec<_>>();
+        let identities = self.rebuild_identities_without(&removed, link_counts)?;
+        let identity_scratch = IdentityStore::new(self.identities.memory_limit())?;
+        let mut removal_order = removed.clone();
+        removal_order.sort_by_key(|id| self.depth(*id));
+        self.remove_nodes(removal_order);
+        self.remove_nodes(shared);
+        self.identities = identities;
+        self.refresh_surviving_link_counts(link_counts)?;
+        self.prepare_identity_metrics();
+        self.rebuild_identity_metrics(identity_scratch)?;
+        Ok(removed.len())
+    }
+
     fn remove_nodes(&mut self, removed: Vec<NodeId>) {
         self.remove_nodes_with_reuse(removed, false);
     }
@@ -661,6 +798,7 @@ impl Arena {
 
     fn remove_nodes_with_reuse(&mut self, removed: Vec<NodeId>, reuse_ids: bool) {
         for id in removed.into_iter().rev() {
+            self.remove_untracked_metrics(id);
             if let Some(node) = self.nodes.get_mut(id.index()).and_then(Option::take) {
                 if let Some(parent) = node.parent {
                     self.lookup.remove(&(parent, node.name.clone()));
@@ -685,14 +823,19 @@ impl Arena {
     }
 
     pub fn remove_path(&mut self, path: &Path) -> bool {
+        self.try_remove_path(path).unwrap_or(false)
+    }
+
+    pub fn try_remove_path(&mut self, path: &Path) -> Result<bool, ModelError> {
         let Some(id) = self.find_path(path) else {
-            return false;
+            return Ok(false);
         };
         if id == self.root {
-            return false;
+            return Ok(false);
         }
-        self.remove_subtree(id);
-        true
+        let mut removed = Vec::new();
+        self.collect_subtree_ids(id, &mut removed);
+        self.remove_nodes_with_accounting(removed).map(|_| true)
     }
 
     pub fn mark_path_uncertain(&mut self, path: &Path, reason: UnscannedReason) -> bool {
@@ -747,6 +890,8 @@ impl Arena {
         let staged_state = staged_root.state;
         let staged_reason = staged_root.unscanned_reason.clone();
         let staged_children = staged_root.children.clone();
+        let staged_modified_nanos = staged_root.snapshot.modified_nanos;
+        let staged_identity = staged_root.snapshot.identity.clone();
 
         let mut removed = Vec::new();
         for child in self.children(target).to_vec() {
@@ -781,6 +926,11 @@ impl Arena {
                 continue;
             };
             let node = *node;
+            let untracked = staging.untracked_metrics.remove(&node.id);
+            if let Some(untracked) = untracked {
+                debug_assert!(!self.untracked_metrics.contains_key(&node.id));
+                self.untracked_metrics.insert(node.id, untracked);
+            }
             if consumed_reused_slots < reused_slots {
                 let reused = self
                     .free_nodes
@@ -814,11 +964,15 @@ impl Arena {
         target_node.metrics = NodeMetrics::default();
         target_node.snapshot.kind = replacement_kind;
         target_node.unscanned_reason = staged_reason;
+        target_node.snapshot.modified_nanos = staged_modified_nanos;
+        if let Some(identity) = staged_identity {
+            target_node.snapshot.identity = Some(identity);
+        }
 
         self.budget = planned_budget;
         self.identities = identities;
         self.prepare_identity_metrics();
-        self.rebuild_identity_metrics(identity_scratch);
+        self.rebuild_identity_metrics(identity_scratch)?;
         Ok(())
     }
 
@@ -844,11 +998,24 @@ impl Arena {
     ) -> Result<(MemoryBudget, usize), ModelError> {
         let mut budget = self.budget.clone();
         budget.release(released);
+        let released_untracked = removed
+            .iter()
+            .chain(shared.iter())
+            .filter(|id| self.untracked_metrics.contains_key(id))
+            .count()
+            .saturating_mul(UNTRACKED_METRICS_OVERHEAD);
+        budget.release(released_untracked);
+        let staged_untracked = staging
+            .untracked_metrics
+            .len()
+            .saturating_mul(UNTRACKED_METRICS_OVERHEAD);
+        budget.reserve(staged_untracked)?;
         let mut shared_ids = shared.iter().copied();
         let mut removed_ids = removed.iter().copied();
         let mut free_ids = self.free_nodes.iter().rev().copied();
         let mut next_append = self.nodes.len();
         let mut reused_slots = 0_usize;
+        let mut id_remaps = Vec::with_capacity(staging.nodes.len());
         for node in staging
             .nodes
             .iter_mut()
@@ -868,7 +1035,8 @@ impl Arena {
                 bytes
             };
             budget.reserve(bytes)?;
-            node.id = if let Some(id) = reusable {
+            let old_id = node.id;
+            let new_id = if let Some(id) = reusable {
                 reused_slots = reused_slots.saturating_add(1);
                 id
             } else {
@@ -886,7 +1054,16 @@ impl Arena {
                     })?;
                 id
             };
+            node.id = new_id;
+            id_remaps.push((old_id, new_id));
         }
+        let mut remapped_untracked = HashMap::with_capacity(staging.untracked_metrics.len());
+        for (old_id, new_id) in id_remaps {
+            if let Some(metrics) = staging.untracked_metrics.remove(&old_id) {
+                remapped_untracked.insert(new_id, metrics);
+            }
+        }
+        staging.untracked_metrics.extend(remapped_untracked);
         Ok((budget, reused_slots))
     }
 
@@ -915,11 +1092,92 @@ impl Arena {
         })?;
         Ok(rebuilt)
     }
+    fn rebuild_identities_without(
+        &mut self,
+        removed: &[NodeId],
+        link_counts: &HashMap<FileId, Option<u64>>,
+    ) -> Result<IdentityStore, ModelError> {
+        let identity_limit = self.identities.memory_limit().min(self.budget.headroom());
+        let mut rebuilt = IdentityStore::new(identity_limit)?;
+        self.identities.visit_records(|file_id, record| {
+            if let Some(mut record) = remove_deleted_participants(record, removed) {
+                if let Some(link_count) = link_counts.get(&file_id) {
+                    record.declared_links = *link_count;
+                }
+                merge_identity_record(&mut rebuilt, &file_id, record)?;
+            }
+            Ok(())
+        })?;
+        Ok(rebuilt)
+    }
+
+    fn refresh_surviving_link_counts(
+        &mut self,
+        link_counts: &HashMap<FileId, Option<u64>>,
+    ) -> Result<(), ModelError> {
+        if link_counts.is_empty() {
+            return Ok(());
+        }
+        let candidates = self
+            .nodes
+            .iter()
+            .filter_map(Option::as_deref)
+            .filter_map(|node| {
+                node.snapshot
+                    .identity
+                    .as_ref()
+                    .map(|identity| (node.id, identity.file_id))
+            })
+            .filter(|(_, file_id)| link_counts.contains_key(file_id))
+            .collect::<Vec<_>>();
+        let mut refreshed = HashMap::new();
+        for (id, file_id) in candidates {
+            let link_count = if let Some(link_count) = refreshed.get(&file_id) {
+                *link_count
+            } else {
+                let link_count = self
+                    .path_for(id)
+                    .and_then(|path| {
+                        fs::symlink_metadata(&path)
+                            .ok()
+                            .map(|metadata| (path, metadata))
+                    })
+                    .and_then(|(path, metadata)| identity_for(&path, &metadata).ok().flatten())
+                    .filter(|identity| identity.file_id == file_id)
+                    .and_then(|identity| identity.link_count);
+                refreshed.insert(file_id, link_count);
+                link_count
+            };
+            if let Some(node) = self.node_mut(id)
+                && let Some(identity) = node.snapshot.identity.as_mut()
+            {
+                identity.link_count = link_count;
+            }
+        }
+        for (file_id, link_count) in refreshed {
+            self.identities
+                .refresh_declared_links(&file_id, link_count)?;
+        }
+        Ok(())
+    }
 
     fn prepare_identity_metrics(&mut self) {
         for node in self.nodes.iter_mut().filter_map(Option::as_deref_mut) {
             match node.kind {
-                NodeKind::File if node.state == NodeState::Complete => {
+                NodeKind::File
+                    if node.state == NodeState::Complete && node.unscanned_reason.is_none() =>
+                {
+                    let links = node
+                        .snapshot
+                        .identity
+                        .as_ref()
+                        .and_then(|identity| identity.link_count);
+                    node.metrics =
+                        leaf_metrics(node.snapshot.apparent_bytes, ByteBounds::exact(0), links);
+                }
+                NodeKind::Link
+                    if node.state == NodeState::Complete && node.unscanned_reason.is_none() =>
+                {
                     let links = node
                         .snapshot
                         .identity
@@ -929,8 +1187,18 @@ impl Arena {
                         leaf_metrics(node.snapshot.apparent_bytes, ByteBounds::exact(0), links);
                 }
                 NodeKind::Synthetic(SyntheticKind::Other | SyntheticKind::Aggregate) => {
-                    node.metrics.allocated_bytes = ByteBounds::exact(0);
-                    node.metrics.reclaimable_bytes = ByteBounds::exact(0);
+                    let previous = node.metrics;
+                    let untracked = self
+                        .untracked_metrics
+                        .get(&node.id)
+                        .copied()
+                        .unwrap_or_default();
+                    node.metrics.allocated_bytes =
+                        preserve_unknown_upper(untracked.allocated_bytes, previous.allocated_bytes);
+                    node.metrics.reclaimable_bytes = preserve_unknown_upper(
+                        untracked.reclaimable_bytes,
+                        previous.reclaimable_bytes,
+                    );
                 }
                 NodeKind::File
                 | NodeKind::Root
@@ -940,7 +1208,8 @@ impl Arena {
             }
         }
     }
-    fn rebuild_identity_metrics(&mut self, replacement: IdentityStore) {
+
+    fn rebuild_identity_metrics(&mut self, replacement: IdentityStore) -> Result<(), ModelError> {
         let mut identities = std::mem::replace(&mut self.identities, replacement);
         let duplicate_bytes = self
             .duplicate_identities
@@ -948,19 +1217,18 @@ impl Arena {
             .saturating_mul(DUPLICATE_ID_OVERHEAD);
         self.budget.release(duplicate_bytes);
         self.duplicate_identities.clear();
-        identities
-            .visit_records(|file_id, record| {
-                self.restore_identity_allocation(&record);
-                if record.observed_links > 1 {
-                    self.track_duplicate(file_id);
-                }
-                Ok(())
-            })
-            .expect("preflighted identity records should remain readable");
+        let result = identities.visit_records(|file_id, record| {
+            self.restore_identity_allocation(&record);
+            if record.observed_links > 1 {
+                self.track_duplicate(file_id);
+            }
+            Ok(())
+        });
         self.identities = identities;
+        result?;
         self.rebuild_metrics();
-        self.finalize()
-            .expect("preflighted identity finalization should remain valid");
+        self.finalize()?;
+        Ok(())
     }
 
     fn restore_identity_allocation(&mut self, record: &IdentityRecord) {
@@ -1090,7 +1358,6 @@ impl Arena {
             std::cmp::Ordering::Equal => name.cmp(victim.name.as_ref()).is_lt(),
         }
     }
-
     fn aggregate_child_into_other(
         &mut self,
         child: NodeId,
@@ -1107,16 +1374,25 @@ impl Arena {
                 (node.metrics, identity)
             })
             .ok_or_else(|| ModelError::Invariant("retained child disappeared".to_string()))?;
+        let untracked = self.untracked_metrics_for_subtree(child);
+        let reserved = self.reserve_untracked_slot(other, untracked)?;
         let mut removed = Vec::new();
         self.collect_subtree_ids(child, &mut removed);
         removed.sort_unstable();
-        if let Some(identity) = leaf_identity {
+        let remap_result = if let Some(identity) = leaf_identity {
             self.identities
-                .remap_nodes_for_identity(&identity.file_id, &removed, other)?;
+                .remap_nodes_for_identity(&identity.file_id, &removed, other)
         } else {
-            self.identities.remap_removed_nodes(&mut removed, other)?;
+            self.identities.remap_removed_nodes(&mut removed, other)
+        };
+        if let Err(error) = remap_result {
+            if reserved {
+                self.remove_untracked_metrics(other);
+            }
+            return Err(error);
         }
         self.add_to_other(other, metrics);
+        self.insert_untracked_metrics(other, untracked);
         self.remove_reusable_nodes(removed);
         Ok(())
     }
@@ -1225,10 +1501,109 @@ impl Arena {
         }
     }
 
+    fn reserve_untracked_slot(
+        &mut self,
+        id: NodeId,
+        metrics: UntrackedMetrics,
+    ) -> Result<bool, ModelError> {
+        if metrics.is_zero() || self.untracked_metrics.contains_key(&id) {
+            return Ok(false);
+        }
+        self.budget.reserve(UNTRACKED_METRICS_OVERHEAD)?;
+        self.untracked_metrics
+            .insert(id, UntrackedMetrics::default());
+        Ok(true)
+    }
+
+    fn insert_untracked_metrics(&mut self, id: NodeId, metrics: UntrackedMetrics) {
+        if metrics.is_zero() {
+            return;
+        }
+        debug_assert!(self.untracked_metrics.contains_key(&id));
+        self.untracked_metrics
+            .entry(id)
+            .and_modify(|existing| existing.add(metrics))
+            .or_insert(metrics);
+    }
+
+    fn add_untracked_to_node(
+        &mut self,
+        id: NodeId,
+        allocated: ByteBounds,
+        reclaimable: ByteBounds,
+    ) -> Result<(), ModelError> {
+        let metrics = UntrackedMetrics {
+            allocated_bytes: allocated,
+            reclaimable_bytes: reclaimable,
+        };
+        if metrics.is_zero() {
+            return Ok(());
+        }
+        self.reserve_untracked_slot(id, metrics)?;
+        self.insert_untracked_metrics(id, metrics);
+        Ok(())
+    }
+
+    fn remove_untracked_metrics(&mut self, id: NodeId) {
+        if self.untracked_metrics.remove(&id).is_some() {
+            self.budget.release(UNTRACKED_METRICS_OVERHEAD);
+        }
+    }
+
+    fn untracked_metrics_for_subtree(&self, root: NodeId) -> UntrackedMetrics {
+        let mut total = UntrackedMetrics::default();
+        let mut stack = vec![root];
+        while let Some(id) = stack.pop() {
+            let Some(node) = self.node(id) else {
+                continue;
+            };
+            match node.kind {
+                NodeKind::Synthetic(SyntheticKind::Other | SyntheticKind::Aggregate) => {
+                    if let Some(metrics) = self.untracked_metrics.get(&id) {
+                        total.add(*metrics);
+                    }
+                }
+                NodeKind::Synthetic(SyntheticKind::Shared) => {}
+                _ if node.children.is_empty() && node.unscanned_reason.is_some() => {
+                    total.allocated_bytes.add(node.metrics.allocated_bytes);
+                    total.reclaimable_bytes.add(node.metrics.reclaimable_bytes);
+                }
+                _ => {
+                    if node.state == NodeState::Uncertain
+                        && node.unscanned_reason.as_ref().is_some_and(|reason| {
+                            matches!(
+                                reason,
+                                UnscannedReason::Metadata(_) | UnscannedReason::Replacement(_)
+                            )
+                        })
+                    {
+                        total.allocated_bytes.add(ByteBounds::unknown());
+                        total.reclaimable_bytes.add(ByteBounds::unknown());
+                    }
+                    stack.extend(node.children.iter().copied());
+                }
+            }
+        }
+        total
+    }
+
     fn accumulate_other(&mut self, parent: NodeId, other: NodeId, metrics: NodeMetrics) {
         self.add_to_other(other, metrics);
         self.propagate_add(parent, metrics);
         self.propagate_descendant(parent, 1);
+    }
+
+    fn accumulate_untracked_other(
+        &mut self,
+        parent: NodeId,
+        other: NodeId,
+        metrics: NodeMetrics,
+    ) -> Result<(), ModelError> {
+        self.add_untracked_to_node(other, metrics.allocated_bytes, metrics.reclaimable_bytes)?;
+        self.add_to_other(other, metrics);
+        self.propagate_add(parent, metrics);
+        self.propagate_descendant(parent, 1);
+        Ok(())
     }
 
     fn rebuild_metrics(&mut self) {
@@ -1243,7 +1618,7 @@ impl Arena {
                 node.metrics = if node.state == NodeState::Uncertain
                     && matches!(
                         node.unscanned_reason.as_ref(),
-                        Some(UnscannedReason::Metadata(_))
+                        Some(UnscannedReason::Metadata(_) | UnscannedReason::Replacement(_))
                     ) {
                     NodeMetrics {
                         allocated_bytes: ByteBounds::unknown(),
@@ -1499,10 +1874,10 @@ fn staged_live_id(
 fn remap_staged_nodes(staging: &mut Arena, target: NodeId) -> Result<(), ModelError> {
     let stage_root = staging.root;
     for index in 1..staging.nodes.len() {
+        let Some(node) = staging.nodes[index].as_deref() else {
+            continue;
+        };
         let (parent, children) = {
-            let node = staging.nodes[index].as_deref().ok_or_else(|| {
-                ModelError::Invariant("staged node mapping disappeared".to_string())
-            })?;
             let parent = node
                 .parent
                 .map(|id| staged_live_id(&staging.nodes, stage_root, id, target))
@@ -1514,12 +1889,12 @@ fn remap_staged_nodes(staging: &mut Arena, target: NodeId) -> Result<(), ModelEr
                 .copied()
                 .map(|id| staged_live_id(&staging.nodes, stage_root, id, target))
                 .collect::<Result<Vec<_>, _>>()?;
-            (Some(parent), children)
+            (parent, children)
         };
         let node = staging.nodes[index]
             .as_deref_mut()
             .ok_or_else(|| ModelError::Invariant("staged node mapping disappeared".to_string()))?;
-        node.parent = parent;
+        node.parent = Some(parent);
         node.children = children;
     }
     Ok(())
@@ -1564,6 +1939,30 @@ fn remove_replaced_participants(
     if record
         .allocation_node
         .is_some_and(|id| is_replaced_node(id, target, removed))
+    {
+        record.allocation_node = record.nodes.first().copied();
+    }
+    Some(record)
+}
+fn remove_deleted_participants(
+    mut record: IdentityRecord,
+    removed: &[NodeId],
+) -> Option<IdentityRecord> {
+    let removed_links = record
+        .nodes
+        .iter()
+        .filter(|id| removed.binary_search(id).is_ok())
+        .count();
+    record.nodes.retain(|id| removed.binary_search(id).is_err());
+    record.observed_links = record
+        .observed_links
+        .saturating_sub(u64::try_from(removed_links).unwrap_or(u64::MAX));
+    if record.nodes.is_empty() {
+        return None;
+    }
+    if record
+        .allocation_node
+        .is_some_and(|id| removed.binary_search(&id).is_ok())
     {
         record.allocation_node = record.nodes.first().copied();
     }
@@ -1628,7 +2027,8 @@ fn unscanned_state(reason: &UnscannedReason) -> NodeState {
         UnscannedReason::MemoryAggregation => NodeState::Aggregated,
         UnscannedReason::FilesystemBoundary
         | UnscannedReason::Excluded(_)
-        | UnscannedReason::Metadata(_) => NodeState::Uncertain,
+        | UnscannedReason::Metadata(_)
+        | UnscannedReason::Replacement(_) => NodeState::Uncertain,
     }
 }
 
@@ -1637,6 +2037,43 @@ fn has_zero_scoped_metrics(reason: &UnscannedReason) -> bool {
         reason,
         UnscannedReason::FilesystemBoundary | UnscannedReason::Excluded(_)
     )
+}
+
+fn unscanned_metrics(
+    apparent: u128,
+    allocated: ByteBounds,
+    kind: NodeKind,
+    reason: &UnscannedReason,
+    declared_links: Option<u64>,
+) -> NodeMetrics {
+    if has_zero_scoped_metrics(reason) {
+        return NodeMetrics::default();
+    }
+    if matches!(reason, UnscannedReason::Replacement(_)) {
+        return NodeMetrics {
+            apparent_bytes: apparent,
+            allocated_bytes: ByteBounds::unknown(),
+            reclaimable_bytes: ByteBounds::unknown(),
+            descendants: 0,
+        };
+    }
+    let mut metrics = leaf_metrics(apparent, allocated, declared_links);
+    if kind.is_directory() && matches!(reason, UnscannedReason::Metadata(_)) {
+        metrics.allocated_bytes.upper = None;
+        metrics.reclaimable_bytes.upper = None;
+    }
+    metrics
+}
+
+fn preserve_unknown_upper(rebuilt: ByteBounds, previous: ByteBounds) -> ByteBounds {
+    ByteBounds {
+        lower: rebuilt.lower,
+        upper: if rebuilt.upper.is_none() || previous.upper.is_none() {
+            None
+        } else {
+            rebuilt.upper
+        },
+    }
 }
 
 fn retention_rank(metrics: NodeMetrics) -> (bool, u128) {
@@ -1788,9 +2225,36 @@ mod tests {
         assert_eq!(cold_node.state, NodeState::Aggregated);
         assert!(cold_node.children.is_empty());
         arena
-            .complete_directory(&cold.join("nested"))
+            .complete_directory(&cold.join("nested"), None)
             .expect("completion below a compacted subtree should be harmless");
         assert_eq!(arena.children(pinned_id).len(), 1);
+    }
+
+    #[test]
+    fn staged_node_remap_tolerates_unreferenced_holes() {
+        let root = tempfile::tempdir().expect("model root should exist");
+        let removed = root.path().join("removed");
+        let retained = root.path().join("retained");
+        fs::write(&removed, b"removed").expect("removed fixture should be written");
+        fs::write(&retained, b"retained").expect("retained fixture should be written");
+
+        let mut staging = test_arena(root.path());
+        let removed_id = add_path(&mut staging, &removed).expect("removed node should be added");
+        let retained_id = add_path(&mut staging, &retained).expect("retained node should be added");
+        staging.remove_nodes_with_reuse(vec![removed_id], true);
+
+        assert!(staging.node(removed_id).is_none());
+        assert!(
+            remap_staged_nodes(&mut staging, NodeId(99)).is_ok(),
+            "unreferenced staging holes should be ignored"
+        );
+        assert_eq!(
+            staging
+                .node(retained_id)
+                .expect("retained node should remain")
+                .parent,
+            Some(NodeId(99))
+        );
     }
     #[test]
     fn compaction_rehomes_hard_link_allocation_before_finalization() {
@@ -1977,7 +2441,7 @@ mod tests {
         assert!(add_path(&mut arena, &file).is_none());
 
         arena
-            .complete_directory(&directory)
+            .complete_directory(&directory, None)
             .expect("completion of an aggregated directory should be harmless");
         let root_children = arena.children(arena.root());
         assert_eq!(root_children.len(), 1);
@@ -2122,6 +2586,55 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn deleting_materialized_hard_link_rehomes_allocation_to_other() {
+        let root = tempfile::tempdir().expect("model root should exist");
+        let first = root.path().join("first");
+        let second = root.path().join("second");
+        fs::write(&first, b"payload").expect("fixture should be written");
+        fs::hard_link(&first, &second).expect("hard link should be created");
+
+        let mut arena = test_arena(root.path());
+        arena.max_children_per_directory = 1;
+        let first_id = add_path(&mut arena, &first).expect("first link should be retained");
+        assert!(add_path(&mut arena, &second).is_none());
+        arena.finalize().expect("hard links should finalize");
+        let shared_allocation = arena
+            .children(arena.root())
+            .iter()
+            .filter_map(|id| arena.node(*id))
+            .find(|node| node.kind == NodeKind::Synthetic(SyntheticKind::Shared))
+            .expect("shared allocation should be represented")
+            .metrics
+            .allocated_bytes;
+
+        assert!(arena.remove_path(&first));
+
+        let other = arena
+            .children(arena.root())
+            .iter()
+            .filter_map(|id| arena.node(*id))
+            .find(|node| node.kind == NodeKind::Synthetic(SyntheticKind::Other))
+            .expect("remaining hard link should stay in Other");
+        assert_eq!(other.metrics.allocated_bytes, shared_allocation);
+        assert_eq!(other.metrics.reclaimable_bytes.lower, 0);
+        assert!(arena.children(arena.root()).iter().all(|id| {
+            arena
+                .node(*id)
+                .is_none_or(|node| node.kind != NodeKind::Synthetic(SyntheticKind::Shared))
+        }));
+        assert_eq!(
+            arena
+                .node(arena.root())
+                .expect("root should exist")
+                .metrics
+                .allocated_bytes,
+            shared_allocation
+        );
+        assert!(arena.node(first_id).is_none());
+    }
+
     #[test]
     fn unreadable_entry_preserves_unknown_upper_bounds() {
         let root = tempfile::tempdir().expect("model root should exist");
@@ -2138,6 +2651,119 @@ mod tests {
         assert_eq!(node.state, NodeState::Uncertain);
         assert_eq!(node.metrics.allocated_bytes, ByteBounds::unknown());
         assert_eq!(node.metrics.reclaimable_bytes, ByteBounds::unknown());
+    }
+    #[cfg(unix)]
+    #[test]
+    fn replacement_uncertainty_discards_old_occupant_bounds() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().expect("replacement root should exist");
+        let target = root.path().join("target");
+        let old_child = target.join("old-child");
+        let replacement_target = root.path().join("replacement-target");
+        let ordinary = root.path().join("ordinary");
+        fs::create_dir(&target).expect("target directory should be created");
+        fs::write(&old_child, b"old occupant").expect("old child should be written");
+        fs::create_dir(&replacement_target).expect("replacement target should be created");
+        fs::write(&ordinary, b"ordinary").expect("ordinary file should be written");
+
+        let mut arena = test_arena(root.path());
+        let target_id = add_path(&mut arena, &target).expect("target should be retained");
+        let old_child_id = add_path(&mut arena, &old_child).expect("old child should be retained");
+        let ordinary_id = add_path(&mut arena, &ordinary).expect("ordinary should be retained");
+        arena
+            .complete_directory(&target, None)
+            .expect("target directory should complete");
+        arena
+            .complete_directory(root.path(), None)
+            .expect("root directory should complete");
+        arena.finalize().expect("model should finalize");
+        let ordinary_lower = arena
+            .node(ordinary_id)
+            .expect("ordinary should exist")
+            .metrics
+            .allocated_bytes
+            .lower;
+
+        fs::rename(&target, root.path().join("displaced")).expect("old target should be displaced");
+        symlink(&replacement_target, &target).expect("replacement symlink should be created");
+        arena
+            .record_unscanned(
+                &target,
+                UnscannedReason::Replacement("directory identity changed".to_string()),
+            )
+            .expect("replacement should be represented");
+        arena.rebuild();
+
+        assert!(arena.node(old_child_id).is_none());
+        assert!(arena.node(target_id).is_none());
+        let replacement_id = arena
+            .find_child(arena.root(), OsStr::new("target"))
+            .expect("replacement should remain visible");
+        let replacement = arena
+            .node(replacement_id)
+            .expect("replacement node should exist");
+        assert_eq!(replacement.kind, NodeKind::Link);
+        assert_eq!(replacement.state, NodeState::Uncertain);
+        assert_eq!(replacement.metrics.allocated_bytes, ByteBounds::unknown());
+        assert_eq!(replacement.metrics.reclaimable_bytes, ByteBounds::unknown());
+
+        arena
+            .record_unscanned(&ordinary, UnscannedReason::Metadata("denied".to_string()))
+            .expect("ordinary unreadable entry should be represented");
+        let ordinary = arena.node(ordinary_id).expect("ordinary should remain");
+        assert_eq!(ordinary.metrics.allocated_bytes.lower, ordinary_lower);
+        assert_eq!(ordinary.metrics.allocated_bytes.upper, None);
+    }
+    #[cfg(unix)]
+    #[test]
+    fn symbolic_link_tracks_object_allocation_and_reclaimability() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().expect("link root should exist");
+        let target = root.path().join("target");
+        let link = root.path().join("link");
+        fs::write(&target, b"target").expect("link target should be written");
+        symlink(&target, &link).expect("symbolic link should be created");
+
+        let mut arena = test_arena(root.path());
+        arena
+            .record_unscanned(&link, UnscannedReason::SymbolicLink)
+            .expect("symbolic link should be represented");
+        let id = arena
+            .find_child(arena.root(), OsStr::new("link"))
+            .expect("symbolic link should remain visible");
+        let node = arena.node(id).expect("symbolic link node should exist");
+        assert!(node.snapshot.allocated_bytes.is_some());
+        assert_eq!(node.metrics.reclaimable_bytes, node.metrics.allocated_bytes);
+    }
+    #[test]
+    fn unreadable_directory_without_prior_node_stays_unknown_after_rebuild() {
+        let root = tempfile::tempdir().expect("model root should exist");
+        let directory = root.path().join("unreadable-directory");
+        fs::create_dir(&directory).expect("directory fixture should be created");
+        let mut arena = test_arena(root.path());
+        arena
+            .record_unscanned(&directory, UnscannedReason::Metadata("denied".to_string()))
+            .expect("unreadable directory should be represented");
+        let id = arena
+            .find_child(arena.root(), OsStr::new("unreadable-directory"))
+            .expect("unreadable directory should exist");
+        assert_eq!(
+            arena
+                .node(id)
+                .expect("unreadable directory should remain")
+                .metrics
+                .allocated_bytes
+                .upper,
+            None
+        );
+        arena.rebuild();
+        let node = arena
+            .node(id)
+            .expect("unreadable directory should survive rebuild");
+        assert_eq!(node.metrics.allocated_bytes.upper, None);
+        assert_eq!(node.metrics.reclaimable_bytes.upper, None);
     }
     #[test]
     fn excluded_and_boundary_entries_are_visible_without_scoped_bytes() {
@@ -2229,7 +2855,7 @@ mod tests {
             .record_unscanned(&directory, UnscannedReason::Metadata("denied".to_string()))
             .expect("directory failure should be recorded");
         arena
-            .complete_directory(&directory)
+            .complete_directory(&directory, None)
             .expect("directory completion should be accepted");
         arena.finalize().expect("model should finalize");
 
@@ -2434,7 +3060,7 @@ mod tests {
         let target_id = add_path(&mut live, &target).expect("target should be retained");
         let old_id = add_path(&mut live, &old).expect("old entry should be retained");
         for path in [&target, root.path()] {
-            live.complete_directory(path)
+            live.complete_directory(path, None)
                 .expect("fixture directory should complete");
         }
         live.finalize().expect("live arena should finalize");
@@ -2468,7 +3094,7 @@ mod tests {
         add_path(&mut stage, &first).expect("first replacement should be retained");
         add_path(&mut stage, &second).expect("second replacement should be retained");
         stage
-            .complete_directory(&target)
+            .complete_directory(&target, None)
             .expect("staging target should complete");
 
         let error = live
@@ -2493,5 +3119,499 @@ mod tests {
         assert_eq!(after, before);
         assert_eq!(live.path_for(old_id), Some(old));
         assert_eq!(live.memory_used(), memory_before);
+    }
+    #[test]
+    fn deletion_rebuild_preserves_unknown_other_bounds() {
+        let root = tempfile::tempdir().expect("model root should exist");
+        let unknown = root.path().join("unknown");
+        let removable = root.path().join("removable");
+        fs::write(&removable, b"remove").expect("removable fixture should be written");
+        let mut arena = test_arena(root.path());
+        arena.max_children_per_directory = 0;
+        arena
+            .record_unscanned(&unknown, UnscannedReason::Metadata("denied".to_string()))
+            .expect("unknown Other entry should be represented");
+        arena.max_children_per_directory = DEFAULT_MAX_CHILDREN;
+        let removable_id = add_path(&mut arena, &removable).expect("removable should be retained");
+        arena
+            .complete_directory(root.path(), None)
+            .expect("root should complete");
+        arena.finalize().expect("model should finalize");
+        let other_id = arena
+            .children(arena.root())
+            .iter()
+            .copied()
+            .find(|id| {
+                arena
+                    .node(*id)
+                    .is_some_and(|node| node.kind == NodeKind::Synthetic(SyntheticKind::Other))
+            })
+            .expect("Other entry should remain");
+        assert_eq!(
+            arena
+                .node(other_id)
+                .expect("Other entry should exist")
+                .metrics
+                .allocated_bytes,
+            ByteBounds::unknown()
+        );
+        assert!(
+            arena
+                .try_remove_path(&removable)
+                .expect("deletion rebuild should succeed")
+        );
+        assert!(arena.node(removable_id).is_none());
+        let other = arena.node(other_id).expect("Other entry should survive");
+        assert_eq!(other.metrics.allocated_bytes.upper, None);
+        assert_eq!(other.metrics.reclaimable_bytes.upper, None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deletion_rebuild_preserves_symbolic_link_metrics_in_other() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().expect("link root should exist");
+        let target = root.path().join("target");
+        let link = root.path().join("link");
+        let materialized = root.path().join("materialized");
+        let removable = root.path().join("removable");
+        fs::write(&target, b"target").expect("link target should be written");
+        symlink(&target, &link).expect("symbolic link should be created");
+        fs::write(&materialized, b"materialized").expect("materialized fixture should be written");
+        fs::write(&removable, b"remove").expect("removable fixture should be written");
+
+        let mut arena = test_arena(root.path());
+        arena.max_children_per_directory = 0;
+        arena
+            .record_unscanned(&link, UnscannedReason::SymbolicLink)
+            .expect("scanner link event should be represented");
+        assert_eq!(arena.identity_count(), 0);
+        arena.max_children_per_directory = DEFAULT_MAX_CHILDREN;
+        let materialized_metadata =
+            fs::symlink_metadata(&materialized).expect("materialized metadata should exist");
+        let materialized_identity = identity_for(&materialized, &materialized_metadata)
+            .expect("materialized identity should be readable")
+            .expect("materialized file should have an identity");
+        assert!(
+            arena
+                .add_entry_aggregated(&materialized, &materialized_metadata, materialized_identity)
+                .expect("materialized entry should be aggregated")
+                .is_none()
+        );
+        let removable_id = add_path(&mut arena, &removable).expect("removable should be retained");
+        arena
+            .complete_directory(root.path(), None)
+            .expect("root should complete");
+        arena.finalize().expect("model should finalize");
+
+        let other_id = arena
+            .children(arena.root())
+            .iter()
+            .copied()
+            .find(|id| {
+                arena
+                    .node(*id)
+                    .is_some_and(|node| node.kind == NodeKind::Synthetic(SyntheticKind::Other))
+            })
+            .expect("aggregated link should remain in Other");
+        let before = arena.node(other_id).expect("Other should exist").metrics;
+        assert!(before.allocated_bytes.upper.is_some());
+        assert!(before.reclaimable_bytes.lower > 0);
+
+        assert!(
+            arena
+                .try_remove_path(&removable)
+                .expect("deletion rebuild should succeed")
+        );
+        assert!(arena.node(removable_id).is_none());
+        let after = arena.node(other_id).expect("Other should survive").metrics;
+        assert_eq!(after.allocated_bytes, before.allocated_bytes);
+        assert_eq!(after.reclaimable_bytes, before.reclaimable_bytes);
+        let root_metrics = arena.node(arena.root()).expect("root should exist").metrics;
+        assert_eq!(root_metrics.allocated_bytes, before.allocated_bytes);
+        assert_eq!(root_metrics.reclaimable_bytes, before.reclaimable_bytes);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deletion_rebuild_preserves_symbolic_link_metrics_in_aggregate() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().expect("aggregate link root should exist");
+        let aggregate_path = root.path().join("aggregate");
+        let target = root.path().join("target");
+        let link = aggregate_path.join("link");
+        let removable = root.path().join("removable");
+        fs::create_dir(&aggregate_path).expect("aggregate directory should be created");
+        fs::write(&target, b"target").expect("link target should be written");
+        symlink(&target, &link).expect("symbolic link should be created");
+        fs::write(&removable, b"remove").expect("removable fixture should be written");
+
+        let mut arena = test_arena(root.path());
+        arena
+            .record_unscanned(&link, UnscannedReason::SymbolicLink)
+            .expect("scanner link event should be represented");
+        assert_eq!(arena.identity_count(), 0);
+        let removable_id = add_path(&mut arena, &removable).expect("removable should be retained");
+        arena
+            .complete_directory(&aggregate_path, None)
+            .expect("aggregate directory should complete");
+        arena
+            .complete_directory(root.path(), None)
+            .expect("root should complete");
+        arena.finalize().expect("model should finalize");
+        assert!(
+            arena
+                .aggregate_cold_subtree(&HashSet::from([arena.root()]))
+                .expect("aggregate conversion should succeed")
+        );
+
+        let aggregate_id = arena
+            .children(arena.root())
+            .iter()
+            .copied()
+            .find(|id| {
+                arena
+                    .node(*id)
+                    .is_some_and(|node| node.kind == NodeKind::Synthetic(SyntheticKind::Aggregate))
+            })
+            .expect("aggregated link should remain in Aggregate");
+        let before = arena
+            .node(aggregate_id)
+            .expect("Aggregate should exist")
+            .metrics;
+        assert!(before.allocated_bytes.upper.is_some());
+        assert_eq!(before.reclaimable_bytes.lower, 0);
+
+        assert!(
+            arena
+                .try_remove_path(&removable)
+                .expect("deletion rebuild should succeed")
+        );
+        assert!(arena.node(removable_id).is_none());
+        let after = arena
+            .node(aggregate_id)
+            .expect("Aggregate should survive")
+            .metrics;
+        assert_eq!(after.allocated_bytes, before.allocated_bytes);
+        assert_eq!(after.reclaimable_bytes, before.reclaimable_bytes);
+        let root_metrics = arena.node(arena.root()).expect("root should exist").metrics;
+        assert_eq!(root_metrics.allocated_bytes, before.allocated_bytes);
+        assert_eq!(root_metrics.reclaimable_bytes, before.reclaimable_bytes);
+    }
+    #[test]
+    fn aggregate_rebuild_preserves_unknown_non_leaf_bounds() {
+        let root = tempfile::tempdir().expect("aggregate root should exist");
+        let aggregate_path = root.path().join("aggregate");
+        let unknown_directory = aggregate_path.join("unknown-directory");
+        let known = unknown_directory.join("known");
+        let removable = root.path().join("removable");
+        fs::create_dir(&aggregate_path).expect("aggregate directory should be created");
+        fs::create_dir(&unknown_directory).expect("unknown directory should be created");
+        fs::write(&known, b"known").expect("known fixture should be written");
+        fs::write(&removable, b"remove").expect("removable fixture should be written");
+
+        let mut arena = test_arena(root.path());
+        add_path(&mut arena, &aggregate_path).expect("aggregate path should be retained");
+        add_path(&mut arena, &unknown_directory).expect("unknown directory should be retained");
+        add_path(&mut arena, &known).expect("known child should be retained");
+        arena
+            .record_unscanned(
+                &unknown_directory,
+                UnscannedReason::Metadata("denied".to_string()),
+            )
+            .expect("unknown directory should be marked uncertain");
+        let removable_id = add_path(&mut arena, &removable).expect("removable should be retained");
+        for path in [&unknown_directory, &aggregate_path, root.path()] {
+            arena
+                .complete_directory(path, None)
+                .expect("fixture directory should complete");
+        }
+        arena.finalize().expect("model should finalize");
+        assert!(
+            arena
+                .aggregate_cold_subtree(&HashSet::from([arena.root()]))
+                .expect("aggregate conversion should succeed")
+        );
+        let aggregate_id = arena
+            .children(arena.root())
+            .iter()
+            .copied()
+            .find(|id| {
+                arena
+                    .node(*id)
+                    .is_some_and(|node| node.kind == NodeKind::Synthetic(SyntheticKind::Aggregate))
+            })
+            .expect("Aggregate node should remain");
+        assert_eq!(
+            arena
+                .node(aggregate_id)
+                .expect("Aggregate node should exist")
+                .metrics
+                .allocated_bytes
+                .upper,
+            None
+        );
+
+        assert!(arena.remove_path(&removable));
+        assert!(arena.node(removable_id).is_none());
+        let aggregate = arena
+            .node(aggregate_id)
+            .expect("Aggregate node should survive rebuild");
+        assert_eq!(aggregate.metrics.allocated_bytes.upper, None);
+        assert_eq!(aggregate.metrics.reclaimable_bytes.upper, None);
+    }
+
+    #[test]
+    fn other_rebuild_preserves_unknown_non_leaf_bounds() {
+        let root = tempfile::tempdir().expect("Other root should exist");
+        let unknown_directory = root.path().join("unknown-directory");
+        let known = unknown_directory.join("known");
+        let removable = root.path().join("removable");
+        fs::create_dir(&unknown_directory).expect("unknown directory should be created");
+        fs::write(&known, b"known").expect("known fixture should be written");
+        fs::write(&removable, b"remove").expect("removable fixture should be written");
+
+        let mut arena = test_arena(root.path());
+        arena.max_children_per_directory = 0;
+        arena
+            .record_unscanned(
+                &unknown_directory,
+                UnscannedReason::Metadata("denied".to_string()),
+            )
+            .expect("unknown directory should be retained in Other");
+        let other_id = arena
+            .children(arena.root())
+            .iter()
+            .copied()
+            .find(|id| {
+                arena
+                    .node(*id)
+                    .is_some_and(|node| node.kind == NodeKind::Synthetic(SyntheticKind::Other))
+            })
+            .expect("Other node should exist");
+        assert_eq!(
+            arena
+                .node(other_id)
+                .expect("Other node should remain")
+                .metrics
+                .allocated_bytes
+                .upper,
+            None
+        );
+        arena.max_children_per_directory = DEFAULT_MAX_CHILDREN;
+        let removable_id = add_path(&mut arena, &removable).expect("removable should be retained");
+        arena
+            .complete_directory(root.path(), None)
+            .expect("root should complete");
+        arena.finalize().expect("model should finalize");
+
+        assert!(arena.remove_path(&removable));
+        assert!(arena.node(removable_id).is_none());
+        let other = arena
+            .node(other_id)
+            .expect("Other node should survive rebuild");
+        assert_eq!(other.metrics.allocated_bytes.upper, None);
+        assert_eq!(other.metrics.reclaimable_bytes.upper, None);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn deletion_rebuild_preserves_unscanned_reparse_metrics() {
+        let root = tempfile::tempdir().expect("reparse root should exist");
+        let reparse = root.path().join("reparse");
+        let removable = root.path().join("removable");
+        fs::write(&reparse, b"reparse fixture").expect("reparse fixture should be written");
+        fs::write(&removable, b"remove").expect("removable fixture should be written");
+
+        let mut arena = test_arena(root.path());
+        arena.max_children_per_directory = 0;
+        arena
+            .record_unscanned(&reparse, UnscannedReason::SymbolicLink)
+            .expect("scanner reparse event should be represented");
+        assert_eq!(arena.identity_count(), 0);
+        arena.max_children_per_directory = DEFAULT_MAX_CHILDREN;
+        let removable_id = add_path(&mut arena, &removable).expect("removable should be retained");
+        arena
+            .complete_directory(root.path(), None)
+            .expect("root should complete");
+        arena.finalize().expect("model should finalize");
+
+        let other_id = arena
+            .children(arena.root())
+            .iter()
+            .copied()
+            .find(|id| {
+                arena
+                    .node(*id)
+                    .is_some_and(|node| node.kind == NodeKind::Synthetic(SyntheticKind::Other))
+            })
+            .expect("aggregated reparse should remain in Other");
+        let before = arena.node(other_id).expect("Other should exist").metrics;
+        assert!(before.allocated_bytes.upper.is_some());
+        assert_eq!(before.reclaimable_bytes.lower, 0);
+
+        assert!(
+            arena
+                .try_remove_path(&removable)
+                .expect("deletion rebuild should succeed")
+        );
+        assert!(arena.node(removable_id).is_none());
+        let after = arena.node(other_id).expect("Other should survive").metrics;
+        assert_eq!(after.allocated_bytes, before.allocated_bytes);
+        assert_eq!(after.reclaimable_bytes, before.reclaimable_bytes);
+    }
+
+    #[test]
+    fn deletion_rebuild_preserves_unknown_aggregate_bounds() {
+        let root = tempfile::tempdir().expect("aggregate root should exist");
+        let aggregate_path = root.path().join("aggregate");
+        let aggregate_unknown = aggregate_path.join("unknown");
+        let removable = root.path().join("removable");
+        fs::create_dir(&aggregate_path).expect("aggregate directory should be created");
+        fs::write(&removable, b"remove").expect("removable fixture should be written");
+        let mut arena = test_arena(root.path());
+        arena
+            .record_unscanned(
+                &aggregate_unknown,
+                UnscannedReason::Metadata("denied".to_string()),
+            )
+            .expect("unknown aggregate entry should be represented");
+        let removable_id = add_path(&mut arena, &removable).expect("removable should be retained");
+        arena
+            .complete_directory(&aggregate_path, None)
+            .expect("aggregate directory should complete");
+        arena
+            .complete_directory(root.path(), None)
+            .expect("aggregate root should complete");
+        arena.finalize().expect("aggregate model should finalize");
+        assert!(
+            arena
+                .aggregate_cold_subtree(&HashSet::from([arena.root()]))
+                .expect("aggregate conversion should succeed")
+        );
+        let aggregate_id = arena
+            .children(arena.root())
+            .iter()
+            .copied()
+            .find(|id| {
+                arena
+                    .node(*id)
+                    .is_some_and(|node| node.kind == NodeKind::Synthetic(SyntheticKind::Aggregate))
+            })
+            .expect("Aggregate entry should remain");
+        assert_eq!(
+            arena
+                .node(aggregate_id)
+                .expect("Aggregate entry should exist")
+                .metrics
+                .allocated_bytes
+                .upper,
+            None
+        );
+        assert!(
+            arena
+                .try_remove_path(&removable)
+                .expect("aggregate deletion rebuild should succeed")
+        );
+        assert!(arena.node(removable_id).is_none());
+        let aggregate = arena
+            .node(aggregate_id)
+            .expect("Aggregate entry should survive");
+        assert_eq!(aggregate.metrics.allocated_bytes.upper, None);
+        assert_eq!(aggregate.metrics.reclaimable_bytes.upper, None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deletion_rebuild_does_not_double_count_surviving_reparse_objects() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().expect("model root should exist");
+        let target = root.path().join("target");
+        let link = root.path().join("link");
+        let removable = root.path().join("removable");
+        fs::write(&target, b"target").expect("link target should be written");
+        symlink(&target, &link).expect("symlink should be created");
+        fs::write(&removable, b"remove").expect("removable fixture should be written");
+        let mut arena = test_arena(root.path());
+        let link_metadata = fs::symlink_metadata(&link).expect("link metadata should exist");
+        let link_identity = identity_for(&link, &link_metadata)
+            .expect("link identity should be readable")
+            .expect("link identity should be available");
+        let link_id = arena
+            .add_entry(&link, &link_metadata, link_identity)
+            .expect("link should be added")
+            .expect("link should be retained");
+        let removable_id = add_path(&mut arena, &removable).expect("removable should be added");
+        arena
+            .complete_directory(root.path(), None)
+            .expect("root should complete");
+        arena.finalize().expect("model should finalize");
+        let before = arena
+            .node(link_id)
+            .expect("link should exist")
+            .metrics
+            .allocated_bytes;
+
+        assert!(
+            arena
+                .try_remove_path(&removable)
+                .expect("deletion rebuild should succeed")
+        );
+        assert!(arena.node(removable_id).is_none());
+        assert_eq!(
+            arena
+                .node(link_id)
+                .expect("surviving link should exist")
+                .metrics
+                .allocated_bytes,
+            before
+        );
+    }
+    #[test]
+    fn corrupt_identity_spill_returns_error_without_panicking() {
+        let root = tempfile::tempdir().expect("model root should exist");
+        let path = root.path().join("target");
+        fs::write(&path, b"payload").expect("target fixture should be written");
+        let mut arena = test_arena(root.path());
+        let target_id = add_path(&mut arena, &path).expect("target should be retained");
+        arena
+            .complete_directory(root.path(), None)
+            .expect("root should complete");
+        arena.finalize().expect("model should finalize");
+
+        let mut corrupt = IdentityStore::new(1).expect("spill store should initialize");
+        let file_id = FileId::new_inode(17, 1);
+        corrupt
+            .observe(
+                &file_id,
+                Some(1),
+                ByteBounds::exact(4096),
+                Some(NodeId(1)),
+                Some(NodeId(1)),
+            )
+            .expect("identity should spill");
+        #[cfg(windows)]
+        corrupt
+            .corrupt_spill_record_for_test(&file_id)
+            .expect("spill record should be corruptible through the database");
+        #[cfg(not(windows))]
+        {
+            let spill_path = corrupt
+                .spill_path()
+                .expect("spilled store should expose its path")
+                .to_path_buf();
+            std::fs::write(spill_path.join("identities.redb"), b"corrupt")
+                .expect("spill database should be corruptible");
+        }
+        arena.identities = corrupt;
+
+        let error = arena
+            .try_remove_path(&path)
+            .expect_err("corrupt identity spill should be reported");
+        assert!(error.to_string().contains("identity"));
+        assert!(arena.node(target_id).is_some());
     }
 }

--- a/src/model/identity_store.rs
+++ b/src/model/identity_store.rs
@@ -226,6 +226,27 @@ impl IdentityStore {
     pub fn spill_path(&self) -> Option<&Path> {
         self.is_spilled().then(|| self.session.path())
     }
+    #[cfg(all(test, windows))]
+    pub(crate) fn corrupt_spill_record_for_test(
+        &mut self,
+        file_id: &FileId,
+    ) -> Result<(), ModelError> {
+        self.flush_pending()?;
+        let Storage::Disk { database, .. } = &mut self.storage else {
+            return Err(ModelError::Invariant(
+                "identity store did not spill".to_string(),
+            ));
+        };
+        let key = serde_json::to_vec(file_id).map_err(identity_error)?;
+        let transaction = database.begin_write().map_err(identity_error)?;
+        {
+            let mut table = transaction.open_table(IDENTITIES).map_err(identity_error)?;
+            table
+                .insert(key.as_slice(), &b"corrupt"[..])
+                .map_err(identity_error)?;
+        }
+        transaction.commit().map_err(identity_error)
+    }
 
     #[must_use]
     pub fn internal_scan_paths(&self) -> Vec<PathBuf> {
@@ -310,6 +331,17 @@ impl IdentityStore {
         self.insert_by_key(&key, record, existing.is_none())?;
         Ok(existing)
     }
+    pub(crate) fn refresh_declared_links(
+        &mut self,
+        file_id: &FileId,
+        declared_links: Option<u64>,
+    ) -> Result<(), ModelError> {
+        let Some(mut record) = self.get(file_id)? else {
+            return Ok(());
+        };
+        record.declared_links = declared_links;
+        self.upsert_record(file_id, &record).map(|_| ())
+    }
 
     /// Repoints only one identity's participants using a caller-sorted removal set.
     ///
@@ -387,9 +419,14 @@ impl IdentityStore {
                             }
                             last_key = Some(key);
                         }
-                        let has_more = match entries.next() {
-                            Some(Ok(_)) => true,
-                            Some(Err(error)) => return Err(identity_error(error)),
+                        let has_more = match last_key.as_deref() {
+                            Some(last_key) => table
+                                .range::<&[u8]>((Bound::Excluded(last_key), Bound::Unbounded))
+                                .map_err(identity_error)?
+                                .next()
+                                .transpose()
+                                .map_err(identity_error)?
+                                .is_some(),
                             None => false,
                         };
                         (updates, last_key, has_more)
@@ -1093,6 +1130,39 @@ mod tests {
             .expect("identity should remain");
         assert_eq!(record.nodes, vec![NodeId(12), NodeId(5)]);
         assert_eq!(record.allocation_node, Some(NodeId(12)));
+    }
+
+    #[test]
+    fn remapping_spilled_participants_preserves_page_boundary_records() {
+        const RECORDS: u32 = 600;
+        let mut store = IdentityStore::new(1).expect("private session should initialize");
+        for index in 0..RECORDS {
+            let node = NodeId(index);
+            store
+                .observe(
+                    &FileId::new_inode(10, u64::from(index)),
+                    Some(1),
+                    ByteBounds::exact(4096),
+                    Some(node),
+                    Some(node),
+                )
+                .expect("spilled identity should be stored");
+        }
+
+        let mut removed = (0..RECORDS).map(NodeId).collect::<Vec<_>>();
+        let replacement = NodeId(RECORDS + 1);
+        store
+            .remap_removed_nodes(&mut removed, replacement)
+            .expect("all spilled records should be remapped");
+
+        for index in 0..RECORDS {
+            let record = store
+                .get(&FileId::new_inode(10, u64::from(index)))
+                .expect("identity lookup should succeed")
+                .expect("identity should remain");
+            assert_eq!(record.nodes, vec![replacement]);
+            assert_eq!(record.allocation_node, Some(replacement));
+        }
     }
 
     #[test]

--- a/src/model/types.rs
+++ b/src/model/types.rs
@@ -132,6 +132,7 @@ pub enum UnscannedReason {
     FilesystemBoundary,
     Excluded(String),
     Metadata(String),
+    Replacement(String),
     MemoryAggregation,
 }
 

--- a/src/native_path.rs
+++ b/src/native_path.rs
@@ -58,6 +58,38 @@ pub struct SafeDisplayPath {
     pub text: String,
     pub deceptive: bool,
 }
+/// Prefix shown whenever a display value contains deceptive native text.
+pub const DECEPTIVE_DISPLAY_MARKER: &str = "[deceptive]";
+
+fn marked(displayed: SafeDisplayPath) -> String {
+    if displayed.deceptive {
+        format!("{DECEPTIVE_DISPLAY_MARKER} {}", displayed.text)
+    } else {
+        displayed.text
+    }
+}
+
+#[must_use]
+pub fn safe_display_path_text(path: &Path) -> String {
+    marked(safe_display_path(path))
+}
+
+#[must_use]
+pub fn safe_display_os_str_text(value: &OsStr) -> String {
+    marked(safe_display_os_str(value))
+}
+
+#[must_use]
+pub fn safe_display_text(value: &str) -> String {
+    let displayed = safe_display_os_str(OsStr::new(value));
+    if displayed.deceptive {
+        marked(displayed)
+    } else if value.contains(DECEPTIVE_DISPLAY_MARKER) {
+        value.to_string()
+    } else {
+        displayed.text
+    }
+}
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(tag = "encoding", content = "data", rename_all = "kebab-case")]
@@ -245,7 +277,7 @@ const fn is_bidi_control(ch: char) -> bool {
             | '\u{200e}'
             | '\u{200f}'
             | '\u{202a}'..='\u{202e}'
-            | '\u{2066}'..='\u{2069}'
+            | '\u{2066}'..='\u{206f}'
     )
 }
 

--- a/src/os/disk_usage.rs
+++ b/src/os/disk_usage.rs
@@ -1,9 +1,70 @@
+#[cfg(windows)]
+use std::fs::File;
 use std::fs::Metadata;
 use std::io;
 use std::path::Path;
 
+#[cfg(not(windows))]
 use filesize::PathExt;
 
 pub(crate) fn physical_size(path: &Path, metadata: &Metadata) -> io::Result<u64> {
+    #[cfg(windows)]
+    {
+        let _ = metadata;
+        let handle = open_nofollow(path)?;
+        physical_size_from_handle(&handle)
+    }
+    #[cfg(not(windows))]
     path.size_on_disk_fast(metadata)
+}
+
+#[cfg(windows)]
+pub(crate) fn physical_size_from_handle(handle: &File) -> io::Result<u64> {
+    windows_allocation_size(handle)
+}
+
+#[cfg(windows)]
+fn open_nofollow(path: &Path) -> io::Result<File> {
+    use cap_primitives::ambient_authority;
+    use cap_primitives::fs::OpenOptionsExt as _;
+    use cap_primitives::fs::{self as cap_fs, FollowSymlinks};
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_READ_ATTRIBUTES,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+    };
+
+    let mut options = cap_fs::OpenOptions::new();
+    options
+        .access_mode(FILE_READ_ATTRIBUTES)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
+        ._cap_fs_ext_follow(FollowSymlinks::No);
+    cap_fs::open_ambient(path, &options, ambient_authority())
+}
+
+#[cfg(windows)]
+#[allow(unsafe_code)]
+fn windows_allocation_size(handle: &File) -> io::Result<u64> {
+    use std::mem::size_of;
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_STANDARD_INFO, FileStandardInfo, GetFileInformationByHandleEx,
+    };
+
+    let mut information = FILE_STANDARD_INFO::default();
+    // SAFETY: the handle is borrowed and valid for this call; `information`
+    // is an aligned writable output value whose size is passed exactly.
+    if unsafe {
+        GetFileInformationByHandleEx(
+            handle.as_raw_handle(),
+            FileStandardInfo,
+            (&raw mut information).cast(),
+            u32::try_from(size_of::<FILE_STANDARD_INFO>()).unwrap_or(u32::MAX),
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    u64::try_from(information.AllocationSize)
+        .map_err(|_| io::Error::other("Windows allocation size was negative"))
 }

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -2,6 +2,9 @@ mod disk_usage;
 
 pub(crate) use disk_usage::physical_size;
 
+#[cfg(windows)]
+pub(crate) use disk_usage::physical_size_from_handle;
+
 #[cfg(target_os = "windows")]
 pub mod windows;
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -18,7 +18,7 @@ use crate::animation::AnimationScheduler;
 use crate::config::{CustomKeyBindings, KeyPreset, SafePreferences, save_safe_preferences};
 use crate::error::{AppError, ExitClass};
 use crate::input::{InputCommand, InputEvent, InputSource, handle_keypress};
-use crate::native_path::safe_display_path;
+use crate::native_path::{NativeIdentity, safe_display_path};
 use crate::outcome::{OperationOutcome, RunSummary};
 use crate::report::{ScanReport, ScanReportState, scan_report_state};
 use crate::state::files::FileTree;
@@ -35,6 +35,7 @@ const MAX_WORKER_BATCH: usize = 128;
 #[allow(clippy::struct_excessive_bools)]
 pub struct RuntimeSettings {
     pub root: PathBuf,
+    pub root_identity: NativeIdentity,
     pub scan_threads: usize,
     pub event_capacity: usize,
     pub cross_filesystems: bool,
@@ -99,9 +100,10 @@ where
     B: Backend,
 {
     let now = clock.now();
-    let app = App::new(
+    let app = App::new_with_root_identity(
         terminal_backend,
         settings.root.clone(),
+        settings.root_identity.clone(),
         settings.apparent_size,
         settings.disable_delete_confirmation,
         settings.memory_mib,
@@ -112,6 +114,7 @@ where
     let workers = WorkerPool::start(
         scanner::ScannerOptions {
             root: settings.root.clone(),
+            root_identity: Some(settings.root_identity.clone()),
             threads: settings.scan_threads,
             cross_filesystems: settings.cross_filesystems,
             exclusions: settings.exclusions.clone(),
@@ -277,10 +280,12 @@ where
                 if self.scan_active || self.deletion_active {
                     return Ok(());
                 }
+                let root_identity = self.app.identity_for_path(&target);
                 self.app.begin_rescan(target.clone())?;
                 self.reset_scan_summary();
                 self.workers()?.request_rescan(scanner::ScannerOptions {
                     root: target,
+                    root_identity,
                     threads: self.settings.scan_threads,
                     cross_filesystems: self.settings.cross_filesystems,
                     exclusions: self.settings.exclusions.clone(),
@@ -297,13 +302,21 @@ where
                 }
             }
             InputCommand::PlanDeletion(target) => {
-                if self.deletion_active {
+                if self.scan_active || self.deletion_active {
                     return Ok(());
                 }
                 let reduced_guardrails = self.app.reduced_deletion_guardrails();
                 let maximum_bytes = self.app.maximum_deletion_plan_bytes();
                 self.workers()?
                     .request_deletion_plan(target, reduced_guardrails, maximum_bytes)?;
+                self.deletion_active = true;
+            }
+            InputCommand::CancelDeletionPlan => self.workers()?.cancel_deletion_plan(),
+            InputCommand::RevalidateDeletion(plan) => {
+                if self.deletion_active {
+                    return Ok(());
+                }
+                self.workers()?.revalidate_deletion(plan)?;
                 self.deletion_active = true;
             }
             InputCommand::ExportScan => {
@@ -390,14 +403,14 @@ where
                 }
             }
             InputCommand::DiscardPreferencesAndExit => self.app.exit(),
-            InputCommand::ExecuteDeletion(plan) => {
-                if self.deletion_active {
-                    return Ok(());
-                }
-                self.workers()?.execute_deletion(plan)?;
-                self.deletion_active = true;
+            InputCommand::SoftCancelDeletion => {
+                self.workers()?.soft_cancel_deletion();
+                self.app.resume_deletion(true);
             }
-            InputCommand::SoftCancelDeletion => self.workers()?.soft_cancel_deletion(),
+            InputCommand::ResumeDeletion => {
+                self.workers()?.resume_deletion();
+                self.app.resume_deletion(false);
+            }
             InputCommand::HardCancel => self.hard_cancelled = true,
         }
         if !self.app.ui_mode.allows_motion() {
@@ -443,8 +456,8 @@ where
                     u64::try_from(self.app.identity_count()).unwrap_or(u64::MAX);
                 self.animation.schedule_scan_progress();
             }
-            WorkerEvent::ScanDirectoryComplete { path } => {
-                self.app.complete_directory(&path)?;
+            WorkerEvent::ScanDirectoryComplete { path, identity } => {
+                self.app.complete_directory(&path, identity.as_ref())?;
                 self.animation.schedule_state_change();
             }
             WorkerEvent::ScanUnscanned { path, reason } => {
@@ -461,7 +474,8 @@ where
                     crate::model::UnscannedReason::SymbolicLink => {
                         self.summary.link_entries += 1;
                     }
-                    crate::model::UnscannedReason::Metadata(message) => {
+                    crate::model::UnscannedReason::Metadata(message)
+                    | crate::model::UnscannedReason::Replacement(message) => {
                         self.summary.unreadable_entries += 1;
                         self.summary.last_unreadable_path =
                             self.summary.last_unscanned_path.clone();
@@ -495,13 +509,27 @@ where
                 if self.rescan_active {
                     self.rescan_active = false;
                     if cancelled {
-                        self.summary.unreadable_entries =
-                            self.summary.unreadable_entries.saturating_add(1);
-                        self.summary.last_worker_error =
-                            Some("focused rescan cancelled".to_string());
                         self.app.cancel_rescan()?;
                     } else {
                         self.app.finish_rescan()?;
+                        match self.app.rebuild_deletion_replan() {
+                            Some(crate::app::DeletionReplanResult::Ready(target)) => {
+                                let reduced_guardrails = self.app.reduced_deletion_guardrails();
+                                let maximum_bytes = self.app.maximum_deletion_plan_bytes();
+                                self.workers()?.request_deletion_plan(
+                                    *target,
+                                    reduced_guardrails,
+                                    maximum_bytes,
+                                )?;
+                                self.deletion_active = true;
+                            }
+                            Some(crate::app::DeletionReplanResult::Missing) => {
+                                self.summary.deletion_missing_entries =
+                                    self.summary.deletion_missing_entries.saturating_add(1);
+                                self.app.complete_missing_deletion();
+                            }
+                            None => {}
+                        }
                     }
                     let (used, limit, spilled) = self.app.model_stats();
                     self.summary.model_bytes = used;
@@ -526,10 +554,53 @@ where
                 result,
             } => {
                 self.deletion_active = false;
-                if result.is_err() {
-                    self.animation.schedule_error();
+                match result {
+                    Ok(plan) => self.app.deletion_plan_ready(target_node_id, Ok(plan)),
+                    Err(error) if error.is_stale() => {
+                        if let Some(target) =
+                            self.app.begin_pending_deletion_replan(target_node_id)?
+                        {
+                            self.start_deletion_rescan(target)?;
+                        }
+                    }
+                    Err(error) if error.is_missing() => {
+                        self.summary.deletion_missing_entries =
+                            self.summary.deletion_missing_entries.saturating_add(1);
+                        self.app.complete_missing_deletion();
+                    }
+                    Err(error) => {
+                        self.animation.schedule_error();
+                        self.app
+                            .deletion_plan_ready(target_node_id, Err(error.to_string()));
+                    }
                 }
-                self.app.deletion_plan_ready(target_node_id, result);
+            }
+            WorkerEvent::DeletionRevalidated {
+                target_node_id,
+                result,
+            } => {
+                self.deletion_active = false;
+                match result {
+                    Ok(plan) => {
+                        self.workers()?.execute_deletion(*plan)?;
+                        self.deletion_active = true;
+                    }
+                    Err((_plan, error)) if error.is_cancelled() => {
+                        self.app.normal_mode();
+                    }
+                    Err((plan, error)) if error.is_missing_target(&plan) => {
+                        self.summary.deletion_missing_entries =
+                            self.summary.deletion_missing_entries.saturating_add(1);
+                        self.app.complete_missing_deletion();
+                    }
+                    Err((plan, _error)) => {
+                        let Some(target) = self.app.begin_deletion_replan(target_node_id, *plan)?
+                        else {
+                            return Ok(());
+                        };
+                        self.start_deletion_rescan(target)?;
+                    }
+                }
             }
             WorkerEvent::DeletionFinished { report } => {
                 self.deletion_active = false;
@@ -551,17 +622,44 @@ where
                     .summary
                     .deletion_unattempted_entries
                     .saturating_add(report.unattempted_entries());
-                self.animation.schedule_deletion_result();
-                if self.app.complete_deletion(report) && deleted > 0 {
-                    self.app.flash_space_freed();
-                    self.schedule(
-                        self.clock.now(),
-                        TimedAction::UnflashSpace,
-                        TRANSIENT_STATUS_DURATION,
-                    );
+                match self.app.try_complete_deletion(report) {
+                    Ok(true) => {
+                        self.animation.schedule_deletion_result();
+                        self.app.flash_space_freed();
+                        self.schedule(
+                            self.clock.now(),
+                            TimedAction::UnflashSpace,
+                            TRANSIENT_STATUS_DURATION,
+                        );
+                    }
+                    Ok(false) => self.animation.schedule_deletion_result(),
+                    Err(error) => {
+                        self.summary.unreadable_entries =
+                            self.summary.unreadable_entries.saturating_add(1);
+                        self.summary.last_worker_error = Some(error.to_string());
+                        self.animation.schedule_error();
+                    }
                 }
             }
         }
+        Ok(())
+    }
+
+    fn start_deletion_rescan(&mut self, target: PathBuf) -> Result<(), AppError> {
+        let root_identity = self.app.identity_for_path(&target);
+        self.reset_scan_summary();
+        self.workers()?.request_rescan(scanner::ScannerOptions {
+            root: target,
+            root_identity,
+            threads: self.settings.scan_threads,
+            cross_filesystems: self.settings.cross_filesystems,
+            exclusions: self.settings.exclusions.clone(),
+            internal_paths: self.app.internal_scan_paths(),
+        })?;
+        self.scan_active = true;
+        self.rescan_active = true;
+        self.next_loading_frame = self.clock.now().saturating_add(LOADING_FRAME_INTERVAL);
+        self.animation.schedule_aggregation();
         Ok(())
     }
 
@@ -704,8 +802,9 @@ where
 /// Returns a scanner, model, or worker error after all owned workers stop.
 #[allow(clippy::too_many_lines, clippy::needless_pass_by_value)]
 pub fn scan_headless(settings: RuntimeSettings) -> Result<OperationOutcome<ScanReport>, AppError> {
-    let mut tree = FileTree::new(
+    let mut tree = FileTree::new_with_root_identity(
         settings.root.clone(),
+        settings.root_identity.clone(),
         settings.apparent_size,
         settings.memory_mib,
     )
@@ -713,6 +812,7 @@ pub fn scan_headless(settings: RuntimeSettings) -> Result<OperationOutcome<ScanR
     let workers = WorkerPool::start(
         scanner::ScannerOptions {
             root: settings.root.clone(),
+            root_identity: Some(settings.root_identity.clone()),
             threads: settings.scan_threads,
             cross_filesystems: settings.cross_filesystems,
             exclusions: settings.exclusions.clone(),
@@ -738,8 +838,8 @@ pub fn scan_headless(settings: RuntimeSettings) -> Result<OperationOutcome<ScanR
                     summary.identified_entries =
                         u64::try_from(tree.identity_count()).unwrap_or(u64::MAX);
                 }
-                WorkerEvent::ScanDirectoryComplete { path } => tree
-                    .complete_directory(&path)
+                WorkerEvent::ScanDirectoryComplete { path, identity } => tree
+                    .complete_directory(&path, identity.as_ref())
                     .map_err(|error| AppError::Model(error.to_string()))?,
                 WorkerEvent::ScanUnscanned { path, reason } => {
                     summary.unscanned_entries = summary.unscanned_entries.saturating_add(1);
@@ -756,7 +856,8 @@ pub fn scan_headless(settings: RuntimeSettings) -> Result<OperationOutcome<ScanR
                         crate::model::UnscannedReason::SymbolicLink => {
                             summary.link_entries = summary.link_entries.saturating_add(1);
                         }
-                        crate::model::UnscannedReason::Metadata(message) => {
+                        crate::model::UnscannedReason::Metadata(message)
+                        | crate::model::UnscannedReason::Replacement(message) => {
                             summary.unreadable_entries =
                                 summary.unreadable_entries.saturating_add(1);
                             summary
@@ -790,7 +891,9 @@ pub fn scan_headless(settings: RuntimeSettings) -> Result<OperationOutcome<ScanR
                     tree.failed_to_read = tree.failed_to_read.saturating_add(1);
                 }
                 WorkerEvent::ScanFinished { cancelled } => return Ok(cancelled),
-                WorkerEvent::DeletionPlanned { .. } | WorkerEvent::DeletionFinished { .. } => {}
+                WorkerEvent::DeletionPlanned { .. }
+                | WorkerEvent::DeletionRevalidated { .. }
+                | WorkerEvent::DeletionFinished { .. } => {}
             }
         }
     })();

--- a/src/runtime/scanner.rs
+++ b/src/runtime/scanner.rs
@@ -1,21 +1,21 @@
 use std::collections::VecDeque;
 #[cfg(windows)]
 use std::ffi::OsString;
-use std::fs;
-#[cfg(not(windows))]
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{self, Read, Seek, SeekFrom, Write};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 
+use cap_primitives::ambient_authority;
+use cap_primitives::fs::{self as cap_fs};
 use crossbeam_channel::Sender;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 
 use super::worker::{ScannedEntry, WorkerEvent, send_event};
 use crate::model::UnscannedReason;
-use crate::native_path::{EncodedNativePath, NativePath, identity_for};
+use crate::native_path::{EncodedNativePath, NativeIdentity, NativePath, identity_for};
 
 const BATCH_SIZE: usize = 128;
 const TASK_QUEUE_PER_WORKER: usize = 8;
@@ -29,6 +29,7 @@ type TaskSpillFile = File;
 #[derive(Clone, Debug)]
 pub struct ScannerOptions {
     pub root: PathBuf,
+    pub root_identity: Option<NativeIdentity>,
     pub threads: usize,
     pub cross_filesystems: bool,
     pub exclusions: Vec<String>,
@@ -38,12 +39,14 @@ pub struct ScannerOptions {
 #[derive(Clone)]
 struct DirectoryTask {
     path: PathBuf,
+    identity: Option<NativeIdentity>,
 }
 
 struct TaskQueue {
     state: Mutex<QueueState>,
     ready: Condvar,
     capacity: usize,
+    root: PathBuf,
 }
 
 struct QueueState {
@@ -85,7 +88,7 @@ impl TaskSpill {
 
     fn push(&mut self, task: DirectoryTask) -> io::Result<()> {
         let encoded = NativePath::new(task.path).encode();
-        let payload = serde_json::to_vec(&encoded).map_err(io::Error::other)?;
+        let payload = serde_json::to_vec(&(encoded, task.identity)).map_err(io::Error::other)?;
         if payload.len() > MAX_SPILLED_TASK_BYTES {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -138,7 +141,7 @@ impl TaskSpill {
         }
         let mut payload = vec![0_u8; payload_len];
         self.file.read_exact(&mut payload)?;
-        let encoded: EncodedNativePath =
+        let (encoded, identity): (EncodedNativePath, Option<NativeIdentity>) =
             serde_json::from_slice(&payload).map_err(io::Error::other)?;
         let path = NativePath::decode(&encoded)
             .map_err(io::Error::other)?
@@ -163,7 +166,7 @@ impl TaskSpill {
             #[cfg(not(windows))]
             let _ = self.file.set_len(0);
         }
-        Ok(Some(DirectoryTask { path }))
+        Ok(Some(DirectoryTask { path, identity }))
     }
 }
 
@@ -173,30 +176,45 @@ impl TaskQueue {
         Ok((
             Self {
                 state: Mutex::new(QueueState {
-                    tasks: VecDeque::from([DirectoryTask { path: root }]),
+                    tasks: VecDeque::from([DirectoryTask {
+                        path: root.clone(),
+                        identity: None,
+                    }]),
                     spill,
                     pending: 1,
                 }),
                 ready: Condvar::new(),
                 capacity,
+                root,
             },
             spill_path,
         ))
     }
 
-    fn take(&self, cancelled: &AtomicBool) -> io::Result<Option<DirectoryTask>> {
+    fn take(
+        &self,
+        cancelled: &AtomicBool,
+        failed: &AtomicBool,
+        root_invalid: &AtomicBool,
+    ) -> io::Result<Option<DirectoryTask>> {
         let mut state = self
             .state
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         loop {
-            if cancelled.load(Ordering::Acquire) || state.pending == 0 {
+            if cancelled.load(Ordering::Acquire)
+                || failed.load(Ordering::Acquire)
+                || root_invalid.load(Ordering::Acquire)
+                || state.pending == 0
+            {
                 return Ok(None);
             }
             if let Some(task) = state.tasks.pop_front() {
+                validate_task_path(&self.root, &task.path)?;
                 return Ok(Some(task));
             }
             if let Some(task) = state.spill.take()? {
+                validate_task_path(&self.root, &task.path)?;
                 return Ok(Some(task));
             }
             state = self
@@ -207,6 +225,7 @@ impl TaskQueue {
     }
 
     fn schedule(&self, task: DirectoryTask) -> io::Result<()> {
+        validate_task_path(&self.root, &task.path)?;
         let mut state = self
             .state
             .lock()
@@ -237,6 +256,10 @@ impl TaskQueue {
     fn cancel(&self) {
         self.ready.notify_all();
     }
+}
+
+fn validate_task_path(root: &Path, path: &Path) -> io::Result<()> {
+    task_relative_path(root, path).map(|_| ())
 }
 
 struct Exclusions {
@@ -319,11 +342,28 @@ pub fn spawn(
 pub(super) fn run(options: ScannerOptions, sender: &Sender<WorkerEvent>, cancelled: &AtomicBool) {
     let ScannerOptions {
         root,
+        root_identity,
         threads,
         cross_filesystems,
         exclusions: exclusion_patterns,
         internal_paths,
     } = options;
+    if let Err(message) = validate_scan_root(&root, root_identity.as_ref()) {
+        let _ = send_event(
+            sender,
+            WorkerEvent::ScanFailed {
+                path: Some(root.clone()),
+                message,
+            },
+            cancelled,
+        );
+        let _ = send_event(
+            sender,
+            WorkerEvent::ScanFinished { cancelled: false },
+            cancelled,
+        );
+        return;
+    }
     let mut exclusions = match Exclusions::new(&root, exclusion_patterns, internal_paths) {
         Ok(exclusions) => exclusions,
         Err(message) => {
@@ -366,6 +406,41 @@ pub(super) fn run(options: ScannerOptions, sender: &Sender<WorkerEvent>, cancell
             }
         }
     };
+    let root_directory = match cap_fs::open_ambient_dir(&root, ambient_authority()) {
+        Ok(directory) => directory,
+        Err(error) => {
+            let _ = send_event(
+                sender,
+                WorkerEvent::ScanFailed {
+                    path: Some(root.clone()),
+                    message: format!("could not open scan root: {error}"),
+                },
+                cancelled,
+            );
+            let _ = send_event(
+                sender,
+                WorkerEvent::ScanFinished { cancelled: false },
+                cancelled,
+            );
+            return;
+        }
+    };
+    if let Err(error) = validate_root_handle(&root_directory, root_identity.as_ref()) {
+        let _ = send_event(
+            sender,
+            WorkerEvent::ScanFailed {
+                path: Some(root.clone()),
+                message: format!("could not validate opened scan root: {error}"),
+            },
+            cancelled,
+        );
+        let _ = send_event(
+            sender,
+            WorkerEvent::ScanFinished { cancelled: false },
+            cancelled,
+        );
+        return;
+    }
     let (queue, task_spill_path) = match TaskQueue::new(
         root.clone(),
         threads.saturating_mul(TASK_QUEUE_PER_WORKER).max(1),
@@ -407,13 +482,20 @@ pub(super) fn run(options: ScannerOptions, sender: &Sender<WorkerEvent>, cancell
         }
         exclusions.internal_paths.push(task_spill_path);
     }
+    let root_invalid = AtomicBool::new(false);
+    let scan_failed = AtomicBool::new(false);
     thread::scope(|scope| {
         for index in 0..threads {
             let worker_queue = &queue;
             let worker_sender = sender;
             let worker_cancelled = cancelled;
+            let worker_failed = &scan_failed;
+            let worker_root_invalid = &root_invalid;
+            let worker_root_directory = &root_directory;
             let worker_exclusions = &exclusions;
             let worker_root_filesystem = root_filesystem.as_ref();
+            let worker_root = &root;
+            let worker_root_identity = root_identity.as_ref();
             if let Err(error) = thread::Builder::new()
                 .name(format!("excise-scan-{index}"))
                 .spawn_scoped(scope, move || {
@@ -421,12 +503,18 @@ pub(super) fn run(options: ScannerOptions, sender: &Sender<WorkerEvent>, cancell
                         worker_queue,
                         worker_sender,
                         worker_cancelled,
+                        worker_failed,
+                        worker_root_invalid,
+                        worker_root_directory,
+                        worker_root,
+                        worker_root_identity,
                         worker_exclusions,
                         worker_root_filesystem,
                         cross_filesystems,
                     );
                 })
             {
+                scan_failed.store(true, Ordering::Release);
                 let _ = send_event(
                     sender,
                     WorkerEvent::ScanFailed {
@@ -443,7 +531,9 @@ pub(super) fn run(options: ScannerOptions, sender: &Sender<WorkerEvent>, cancell
     let _ = send_event(
         sender,
         WorkerEvent::ScanFinished {
-            cancelled: cancelled.load(Ordering::Acquire),
+            cancelled: cancelled.load(Ordering::Acquire)
+                && !scan_failed.load(Ordering::Acquire)
+                && !root_invalid.load(Ordering::Acquire),
         },
         &completion_delivery,
     );
@@ -451,21 +541,31 @@ pub(super) fn run(options: ScannerOptions, sender: &Sender<WorkerEvent>, cancell
 
 struct ScanFrame {
     task: DirectoryTask,
-    entries: fs::ReadDir,
+    _directory: File,
+    identity: Option<NativeIdentity>,
+    entries: cap_fs::ReadDir,
     batch: Vec<ScannedEntry>,
     directories: Vec<DirectoryTask>,
 }
-
+#[allow(
+    clippy::too_many_arguments,
+    reason = "The worker receives its bounded queue, cancellation state, root identity, and scan policy explicitly."
+)]
 fn scan_worker(
     queue: &TaskQueue,
     sender: &Sender<WorkerEvent>,
     cancelled: &AtomicBool,
+    failed: &AtomicBool,
+    root_invalid: &AtomicBool,
+    root_directory: &File,
+    root: &Path,
+    root_identity: Option<&NativeIdentity>,
     exclusions: &Exclusions,
     root_filesystem: Option<&FilesystemKey>,
     cross_filesystems: bool,
 ) {
     loop {
-        let task = match queue.take(cancelled) {
+        let task = match queue.take(cancelled, failed, root_invalid) {
             Ok(Some(task)) => task,
             Ok(None) => return,
             Err(error) => {
@@ -477,7 +577,7 @@ fn scan_worker(
                     },
                     cancelled,
                 );
-                cancelled.store(true, Ordering::Release);
+                failed.store(true, Ordering::Release);
                 queue.cancel();
                 return;
             }
@@ -487,55 +587,95 @@ fn scan_worker(
             queue,
             sender,
             cancelled,
+            failed,
+            root_invalid,
+            root_directory,
+            root,
+            root_identity,
             exclusions,
             root_filesystem,
             cross_filesystems,
         );
         queue.complete();
         if !completed {
-            cancelled.store(true, Ordering::Release);
+            if !root_invalid.load(Ordering::Acquire)
+                && !failed.load(Ordering::Acquire)
+                && !cancelled.load(Ordering::Acquire)
+            {
+                cancelled.store(true, Ordering::Release);
+            }
             queue.cancel();
             return;
         }
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn scan_directory(
     task: DirectoryTask,
     queue: &TaskQueue,
     sender: &Sender<WorkerEvent>,
     cancelled: &AtomicBool,
+    failed: &AtomicBool,
+    root_invalid: &AtomicBool,
+    root_directory: &File,
+    root: &Path,
+    root_identity: Option<&NativeIdentity>,
     exclusions: &Exclusions,
     root_filesystem: Option<&FilesystemKey>,
     cross_filesystems: bool,
 ) -> bool {
-    if cancelled.load(Ordering::Acquire) {
+    if cancelled.load(Ordering::Acquire)
+        || failed.load(Ordering::Acquire)
+        || root_invalid.load(Ordering::Acquire)
+    {
         return false;
     }
-    let mut frame = match open_frame(task) {
+    if !validate_root_for_traversal(root, root_identity, sender, cancelled, root_invalid) {
+        return false;
+    }
+    let mut frame = match open_frame(root_directory, root, task) {
         Ok(frame) => frame,
-        Err((task, error)) => {
-            let _ = send_event(
-                sender,
-                WorkerEvent::ScanFailed {
-                    path: Some(task.path),
-                    message: error.to_string(),
-                },
-                cancelled,
-            );
+        Err(error) => {
+            let (task, error) = *error;
+            report_directory_task_error(task.path, error, sender, cancelled);
             return true;
         }
     };
+    if let Err(error) = validate_directory_task(root_directory, root, &frame.task) {
+        report_directory_task_error(frame.task.path.clone(), error, sender, cancelled);
+        return true;
+    }
+    if !validate_root_for_traversal(root, root_identity, sender, cancelled, root_invalid) {
+        return false;
+    }
     loop {
-        if cancelled.load(Ordering::Acquire) {
+        if cancelled.load(Ordering::Acquire)
+            || failed.load(Ordering::Acquire)
+            || !validate_root_for_traversal(root, root_identity, sender, cancelled, root_invalid)
+        {
             return false;
         }
-        if frame.batch.len() == BATCH_SIZE && !flush_frame(&mut frame, queue, sender, cancelled) {
-            return false;
+        if frame.batch.len() == BATCH_SIZE {
+            if !flush_frame(&mut frame, queue, sender, cancelled, failed) {
+                return false;
+            }
+            if let Err(error) = validate_directory_task(root_directory, root, &frame.task) {
+                report_directory_task_error(frame.task.path.clone(), error, sender, cancelled);
+                return true;
+            }
         }
         match frame.entries.next() {
             Some(Ok(entry)) => {
+                if !validate_root_for_traversal(
+                    root,
+                    root_identity,
+                    sender,
+                    cancelled,
+                    root_invalid,
+                ) {
+                    return false;
+                }
                 process_entry(
                     &mut frame,
                     &entry,
@@ -559,44 +699,447 @@ fn scan_directory(
             None => break,
         }
     }
-    if !frame.batch.is_empty() && !flush_frame(&mut frame, queue, sender, cancelled) {
+    if !validate_root_for_traversal(root, root_identity, sender, cancelled, root_invalid) {
         return false;
+    }
+    if let Err(error) = validate_directory_task(root_directory, root, &frame.task) {
+        report_directory_task_error(frame.task.path.clone(), error, sender, cancelled);
+        return true;
+    }
+    if !frame.batch.is_empty() && !flush_frame(&mut frame, queue, sender, cancelled, failed) {
+        return false;
+    }
+    if let Err(error) = validate_directory_task(root_directory, root, &frame.task) {
+        report_directory_task_error(frame.task.path.clone(), error, sender, cancelled);
+        return true;
+    }
+    if !validate_root_for_traversal(root, root_identity, sender, cancelled, root_invalid) {
+        return false;
+    }
+    if let Err(error) = validate_directory_task(root_directory, root, &frame.task) {
+        report_directory_task_error(frame.task.path.clone(), error, sender, cancelled);
+        return true;
     }
     send_event(
         sender,
         WorkerEvent::ScanDirectoryComplete {
             path: frame.task.path,
+            identity: frame.identity,
         },
         cancelled,
     )
 }
 
-fn open_frame(task: DirectoryTask) -> Result<ScanFrame, (DirectoryTask, std::io::Error)> {
-    match fs::read_dir(&task.path) {
-        Ok(entries) => Ok(ScanFrame {
-            task,
-            entries,
-            batch: Vec::with_capacity(BATCH_SIZE),
-            directories: Vec::with_capacity(BATCH_SIZE),
-        }),
-        Err(error) => Err((task, error)),
+fn validate_root_for_traversal(
+    root: &Path,
+    root_identity: Option<&NativeIdentity>,
+    sender: &Sender<WorkerEvent>,
+    cancelled: &AtomicBool,
+    root_invalid: &AtomicBool,
+) -> bool {
+    if root_invalid.load(Ordering::Acquire) {
+        return false;
     }
+    let Err(message) = validate_scan_root(root, root_identity) else {
+        return true;
+    };
+    let message = if message == "scan root identity changed before scanning" {
+        "scan root identity changed during traversal".to_string()
+    } else {
+        format!("scan root became invalid during traversal: {message}")
+    };
+    if root_invalid
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_ok()
+    {
+        let _ = send_event(
+            sender,
+            WorkerEvent::ScanFailed {
+                path: Some(root.to_path_buf()),
+                message,
+            },
+            cancelled,
+        );
+    }
+    false
+}
+
+enum DirectoryTaskError {
+    Replaced(String),
+    Io(io::Error),
+}
+
+fn validate_directory_task(
+    root_directory: &File,
+    root: &Path,
+    task: &DirectoryTask,
+) -> Result<(), DirectoryTaskError> {
+    let Some(expected) = task.identity.as_ref() else {
+        return Ok(());
+    };
+    let directory = open_scan_directory(root_directory, root, &task.path)
+        .map_err(|error| classify_directory_open_error(&task.path, error))?;
+    let metadata = cap_fs::Metadata::from_file(&directory).map_err(DirectoryTaskError::Io)?;
+    if !metadata.is_dir() || metadata.is_symlink() {
+        return Err(DirectoryTaskError::Replaced(
+            "scanner directory task was replaced by a symbolic link or non-directory".to_string(),
+        ));
+    }
+    let actual = identity_from_entry_metadata(&metadata)
+        .map_err(DirectoryTaskError::Io)?
+        .ok_or_else(|| {
+            DirectoryTaskError::Replaced(
+                "scanner directory task identity is unavailable".to_string(),
+            )
+        })?;
+    if !same_identity(expected, &actual) || actual.reparse_point {
+        return Err(DirectoryTaskError::Replaced(
+            "scanner directory task identity changed before traversal".to_string(),
+        ));
+    }
+    #[cfg(test)]
+    maybe_replace_after_validation(&task.path);
+    Ok(())
+}
+
+#[cfg(all(test, unix))]
+static VALIDATION_REPLACEMENT: std::sync::OnceLock<Mutex<Option<(PathBuf, PathBuf, PathBuf)>>> =
+    std::sync::OnceLock::new();
+
+#[cfg(test)]
+fn maybe_replace_after_validation(path: &Path) {
+    #[cfg(unix)]
+    {
+        let replacement = VALIDATION_REPLACEMENT.get_or_init(|| Mutex::new(None));
+        let Some((expected_path, displaced_path, target_path)) = replacement
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
+        else {
+            return;
+        };
+        if expected_path != path {
+            let mut pending = replacement
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            *pending = Some((expected_path, displaced_path, target_path));
+            return;
+        }
+        fs::rename(path, displaced_path).expect("original directory should be displaced");
+        std::os::unix::fs::symlink(target_path, path)
+            .expect("replacement symlink should be created");
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+}
+
+#[cfg(all(test, unix))]
+fn replace_after_next_validation(path: PathBuf, displaced: PathBuf, target: PathBuf) {
+    *VALIDATION_REPLACEMENT
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some((path, displaced, target));
+}
+fn report_directory_task_error(
+    path: PathBuf,
+    error: DirectoryTaskError,
+    sender: &Sender<WorkerEvent>,
+    cancelled: &AtomicBool,
+) {
+    match error {
+        DirectoryTaskError::Replaced(message) => {
+            let _ = send_event(
+                sender,
+                WorkerEvent::ScanUnscanned {
+                    path,
+                    reason: UnscannedReason::Replacement(message),
+                },
+                cancelled,
+            );
+        }
+        DirectoryTaskError::Io(error) => {
+            let _ = send_event(
+                sender,
+                WorkerEvent::ScanFailed {
+                    path: Some(path),
+                    message: error.to_string(),
+                },
+                cancelled,
+            );
+        }
+    }
+}
+
+fn validate_root_handle(
+    root_directory: &File,
+    expected: Option<&NativeIdentity>,
+) -> io::Result<()> {
+    let metadata = cap_fs::Metadata::from_file(root_directory)?;
+    if !metadata.is_dir() || metadata.is_symlink() {
+        return Err(io::Error::other("opened scan root is not a real directory"));
+    }
+    let Some(expected) = expected else {
+        return Ok(());
+    };
+    let actual = identity_from_entry_metadata(&metadata)?
+        .ok_or_else(|| io::Error::other("opened scan root identity is unavailable"))?;
+    if !same_identity(expected, &actual) || actual.reparse_point {
+        return Err(io::Error::other("opened scan root identity changed"));
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn cap_metadata_is_reparse(metadata: &cap_fs::Metadata) -> bool {
+    use cap_primitives::fs::_WindowsByHandle as _;
+
+    metadata.file_attributes() & 0x0000_0400 != 0
+}
+
+#[cfg(not(windows))]
+fn cap_metadata_is_reparse(metadata: &cap_fs::Metadata) -> bool {
+    metadata.is_symlink()
+}
+
+fn open_scan_directory(root_directory: &File, root: &Path, path: &Path) -> io::Result<File> {
+    let relative = task_relative_path(root, path)?;
+    let mut directory = root_directory.try_clone()?;
+    for component in relative.components() {
+        let Component::Normal(name) = component else {
+            continue;
+        };
+        directory = cap_fs::open_dir_nofollow(&directory, Path::new(name))?;
+        let metadata = cap_fs::Metadata::from_file(&directory)?;
+        if cap_metadata_is_reparse(&metadata) {
+            return Err(io::Error::other(
+                "scanner path component is a symbolic link or reparse point",
+            ));
+        }
+    }
+    Ok(directory)
+}
+
+fn task_relative_path(root: &Path, path: &Path) -> io::Result<PathBuf> {
+    let relative = path.strip_prefix(root).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "scanner task path is outside the scan root",
+        )
+    })?;
+    if relative.components().any(|component| {
+        matches!(
+            component,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        )
+    }) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "scanner task path is not a safe relative path",
+        ));
+    }
+    Ok(relative.to_path_buf())
+}
+
+#[cfg(windows)]
+fn metadata_is_reparse(metadata: &fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt as _;
+
+    metadata.file_type().is_symlink() || metadata.file_attributes() & 0x0000_0400 != 0
+}
+
+#[cfg(not(windows))]
+fn metadata_is_reparse(metadata: &fs::Metadata) -> bool {
+    metadata.file_type().is_symlink()
+}
+
+fn path_has_reparse_component(path: &Path) -> bool {
+    let mut current = PathBuf::new();
+    path.components().any(|component| {
+        current.push(component);
+        fs::symlink_metadata(&current).is_ok_and(|metadata| metadata_is_reparse(&metadata))
+    })
+}
+
+fn classify_directory_open_error(path: &Path, error: io::Error) -> DirectoryTaskError {
+    let is_non_directory = fs::symlink_metadata(path).is_ok_and(|metadata| !metadata.is_dir());
+    if is_non_directory || path_has_reparse_component(path) {
+        DirectoryTaskError::Replaced(
+            "scanner directory task was replaced by a symbolic link or non-directory".to_string(),
+        )
+    } else {
+        DirectoryTaskError::Io(error)
+    }
+}
+
+fn same_identity(left: &NativeIdentity, right: &NativeIdentity) -> bool {
+    left.file_id == right.file_id && left.reparse_point == right.reparse_point
+}
+
+fn open_frame(
+    root_directory: &File,
+    root: &Path,
+    task: DirectoryTask,
+) -> Result<ScanFrame, Box<(DirectoryTask, DirectoryTaskError)>> {
+    let directory = match open_scan_directory(root_directory, root, &task.path) {
+        Ok(directory) => directory,
+        Err(error) => {
+            return Err(Box::new((
+                task.clone(),
+                classify_directory_open_error(&task.path, error),
+            )));
+        }
+    };
+    let metadata = match cap_fs::Metadata::from_file(&directory) {
+        Ok(metadata) => metadata,
+        Err(error) => return Err(Box::new((task, DirectoryTaskError::Io(error)))),
+    };
+    if !metadata.is_dir() || metadata.is_symlink() {
+        return Err(Box::new((
+            task,
+            DirectoryTaskError::Replaced(
+                "scanner directory task was replaced by a symbolic link or non-directory"
+                    .to_string(),
+            ),
+        )));
+    }
+    let actual = match identity_from_entry_metadata(&metadata) {
+        Ok(Some(identity)) => identity,
+        Ok(None) => {
+            return Err(Box::new((
+                task,
+                DirectoryTaskError::Replaced(
+                    "scanner directory task identity is unavailable".to_string(),
+                ),
+            )));
+        }
+        Err(error) => return Err(Box::new((task, DirectoryTaskError::Io(error)))),
+    };
+    if actual.reparse_point
+        || task
+            .identity
+            .as_ref()
+            .is_some_and(|expected| !same_identity(expected, &actual))
+    {
+        return Err(Box::new((
+            task,
+            DirectoryTaskError::Replaced(
+                "scanner directory task identity changed before traversal".to_string(),
+            ),
+        )));
+    }
+    let entries = match cap_fs::read_base_dir(&directory) {
+        Ok(entries) => entries,
+        Err(error) => return Err(Box::new((task, DirectoryTaskError::Io(error)))),
+    };
+    Ok(ScanFrame {
+        task,
+        _directory: directory,
+        identity: Some(actual),
+        entries,
+        batch: Vec::with_capacity(BATCH_SIZE),
+        directories: Vec::with_capacity(BATCH_SIZE),
+    })
+}
+
+fn entry_metadata(entry: &cap_fs::DirEntry) -> io::Result<cap_fs::Metadata> {
+    #[cfg(windows)]
+    {
+        use cap_primitives::fs::_WindowsDirEntryExt as _;
+        entry.full_metadata()
+    }
+    #[cfg(not(windows))]
+    {
+        entry.metadata()
+    }
+}
+
+#[allow(clippy::unnecessary_wraps)]
+fn identity_from_entry_metadata(metadata: &cap_fs::Metadata) -> io::Result<Option<NativeIdentity>> {
+    #[cfg(unix)]
+    {
+        use cap_primitives::fs::MetadataExt as _;
+        Ok(Some(NativeIdentity {
+            file_id: file_id::FileId::new_inode(metadata.dev(), metadata.ino()),
+            link_count: Some(metadata.nlink()),
+            reparse_point: metadata.is_symlink(),
+        }))
+    }
+    #[cfg(windows)]
+    {
+        use cap_primitives::fs::_WindowsByHandle as _;
+        let volume = metadata.volume_serial_number().ok_or_else(|| {
+            io::Error::other("directory entry did not expose a volume serial number")
+        })?;
+        let index = metadata
+            .file_index()
+            .ok_or_else(|| io::Error::other("directory entry did not expose a file index"))?;
+        Ok(Some(NativeIdentity {
+            file_id: file_id::FileId::new_low_res(volume, index),
+            link_count: metadata.number_of_links().map(u64::from),
+            reparse_point: metadata.file_attributes() & 0x0000_0400 != 0,
+        }))
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = metadata;
+        Ok(None)
+    }
+}
+
+fn report_symbolic_link(path: PathBuf, sender: &Sender<WorkerEvent>, cancelled: &AtomicBool) {
+    let _ = send_event(
+        sender,
+        WorkerEvent::ScanUnscanned {
+            path,
+            reason: UnscannedReason::SymbolicLink,
+        },
+        cancelled,
+    );
 }
 
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn process_entry(
     frame: &mut ScanFrame,
-    entry: &fs::DirEntry,
+    entry: &cap_fs::DirEntry,
     sender: &Sender<WorkerEvent>,
     cancelled: &AtomicBool,
     exclusions: &Exclusions,
     root_filesystem: Option<&FilesystemKey>,
     cross_filesystems: bool,
 ) {
-    let path = entry.path();
+    let name = entry.file_name();
+    let path = frame.task.path.join(&name);
     if exclusions.is_internal(&path) {
         return;
     }
+    let entry_metadata = match entry_metadata(entry) {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            let _ = send_event(
+                sender,
+                WorkerEvent::ScanFailed {
+                    path: Some(path),
+                    message: error.to_string(),
+                },
+                cancelled,
+            );
+            return;
+        }
+    };
+    let entry_identity = match identity_from_entry_metadata(&entry_metadata) {
+        Ok(identity) => identity,
+        Err(error) => {
+            let _ = send_event(
+                sender,
+                WorkerEvent::ScanFailed {
+                    path: Some(path),
+                    message: error.to_string(),
+                },
+                cancelled,
+            );
+            return;
+        }
+    };
     let metadata = match fs::symlink_metadata(&path) {
         Ok(metadata) => metadata,
         Err(error) => {
@@ -611,6 +1154,43 @@ fn process_entry(
             return;
         }
     };
+    let identity = match identity_for(&path, &metadata) {
+        Ok(Some(identity)) => identity,
+        Ok(None) => return,
+        Err(error) => {
+            let message = format!(
+                "{}: {error}",
+                path.parent()
+                    .unwrap_or_else(|| Path::new("."))
+                    .to_string_lossy()
+            );
+            let _ = send_event(
+                sender,
+                WorkerEvent::ScanFailed {
+                    path: Some(path),
+                    message,
+                },
+                cancelled,
+            );
+            return;
+        }
+    };
+    if entry_identity
+        .as_ref()
+        .is_some_and(|expected| !same_identity(expected, &identity))
+    {
+        let _ = send_event(
+            sender,
+            WorkerEvent::ScanUnscanned {
+                path,
+                reason: UnscannedReason::Replacement(
+                    "scanner entry identity changed before metadata collection".to_string(),
+                ),
+            },
+            cancelled,
+        );
+        return;
+    }
     let is_dir = metadata.is_dir();
     if let Some(pattern) = exclusions.reason(&path, is_dir) {
         let _ = send_event(
@@ -623,15 +1203,8 @@ fn process_entry(
         );
         return;
     }
-    if metadata.file_type().is_symlink() {
-        let _ = send_event(
-            sender,
-            WorkerEvent::ScanUnscanned {
-                path,
-                reason: UnscannedReason::SymbolicLink,
-            },
-            cancelled,
-        );
+    if metadata.file_type().is_symlink() || identity.reparse_point {
+        report_symbolic_link(path, sender, cancelled);
         return;
     }
     if is_dir && !cross_filesystems {
@@ -650,35 +1223,17 @@ fn process_entry(
             return;
         }
     }
-    match identity_for(&path, &metadata) {
-        Ok(Some(identity)) => {
-            let directory = is_dir.then(|| DirectoryTask { path: path.clone() });
-            frame.batch.push(ScannedEntry {
-                metadata,
-                path,
-                identity,
-            });
-            if let Some(directory) = directory {
-                frame.directories.push(directory);
-            }
-        }
-        Ok(None) => {}
-        Err(error) => {
-            let message = format!(
-                "{}: {error}",
-                path.parent()
-                    .unwrap_or_else(|| Path::new("."))
-                    .to_string_lossy()
-            );
-            let _ = send_event(
-                sender,
-                WorkerEvent::ScanFailed {
-                    path: Some(path),
-                    message,
-                },
-                cancelled,
-            );
-        }
+    let directory = is_dir.then(|| DirectoryTask {
+        path: path.clone(),
+        identity: Some(entry_identity.unwrap_or_else(|| identity.clone())),
+    });
+    frame.batch.push(ScannedEntry {
+        metadata,
+        path,
+        identity,
+    });
+    if let Some(directory) = directory {
+        frame.directories.push(directory);
     }
 }
 
@@ -687,6 +1242,7 @@ fn flush_frame(
     queue: &TaskQueue,
     sender: &Sender<WorkerEvent>,
     cancelled: &AtomicBool,
+    failed: &AtomicBool,
 ) -> bool {
     let entries = std::mem::replace(&mut frame.batch, Vec::with_capacity(BATCH_SIZE));
     if !send_event(sender, WorkerEvent::ScanBatch { entries }, cancelled) {
@@ -695,6 +1251,7 @@ fn flush_frame(
     }
     for task in std::mem::take(&mut frame.directories) {
         if let Err(error) = queue.schedule(task) {
+            failed.store(true, Ordering::Release);
             let _ = send_event(
                 sender,
                 WorkerEvent::ScanFailed {
@@ -707,6 +1264,30 @@ fn flush_frame(
         }
     }
     true
+}
+
+fn validate_scan_root(path: &Path, expected: Option<&NativeIdentity>) -> Result<(), String> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| {
+        format!(
+            "could not inspect scan root {}: {error}",
+            path.to_string_lossy()
+        )
+    })?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Err("scan root was replaced by a symbolic link or non-directory".to_string());
+    }
+    let actual = identity_for(path, &metadata)
+        .map_err(|error| format!("could not identify scan root: {error}"))?
+        .ok_or_else(|| "scan root identity is unavailable".to_string())?;
+    if actual.reparse_point {
+        return Err("scan root was replaced by a reparse point".to_string());
+    }
+    if expected.is_some_and(|expected| {
+        actual.file_id != expected.file_id || actual.reparse_point != expected.reparse_point
+    }) {
+        return Err("scan root identity changed before scanning".to_string());
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -740,6 +1321,7 @@ mod tests {
             queue
                 .schedule(DirectoryTask {
                     path: PathBuf::from(format!("/scan-root/entry-{index}")),
+                    identity: None,
                 })
                 .expect("scanner task should spill when the resident queue is full");
         }
@@ -750,6 +1332,406 @@ mod tests {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         assert_eq!(state.tasks.len(), 1);
         assert_eq!(state.spill.pending, BATCH_SIZE);
+    }
+
+    #[test]
+    fn task_queue_rejects_corrupt_spill_paths_outside_root() {
+        let root = PathBuf::from("/scan-root");
+        let (queue, _) = TaskQueue::new(root.clone(), 1).expect("scanner task queue should open");
+        let cancelled = AtomicBool::new(false);
+        let failed = AtomicBool::new(false);
+        let root_invalid = AtomicBool::new(false);
+
+        assert!(
+            queue
+                .take(&cancelled, &failed, &root_invalid)
+                .expect("initial scanner task should be available")
+                .is_some()
+        );
+        queue.complete();
+        {
+            let mut state = queue
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            state
+                .spill
+                .push(DirectoryTask {
+                    path: PathBuf::from("/outside-root/secret"),
+                    identity: None,
+                })
+                .expect("corrupt spill fixture should be writable");
+            state.pending = 1;
+        }
+
+        let error = match queue.take(&cancelled, &failed, &root_invalid) {
+            Ok(_) => panic!("out-of-root spill path should be rejected"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    }
+    #[cfg(any(unix, windows))]
+    fn replace_directory_with_link(path: &Path, displaced: &Path, target: &Path) {
+        fs::rename(path, displaced).expect("original directory should be displaced");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(target, path).expect("replacement symlink should be created");
+        #[cfg(windows)]
+        {
+            let quote =
+                |value: &Path| format!("'{}'", value.display().to_string().replace('\'', "''"));
+            let command = format!(
+                "$ErrorActionPreference='Stop'; New-Item -ItemType Junction -Path {} -Target {} | Out-Null",
+                quote(path),
+                quote(target)
+            );
+            let output = std::process::Command::new("pwsh")
+                .args([
+                    "-NoLogo",
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-Command",
+                    &command,
+                ])
+                .output()
+                .expect("junction command should start");
+            assert!(
+                output.status.success(),
+                "junction command failed with {}: stdout={:?} stderr={:?}",
+                output.status,
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn scanner_marks_replaced_descendant_link_uncertain() {
+        use crossbeam_channel::bounded;
+        use std::sync::atomic::AtomicBool;
+        use std::time::Duration;
+
+        let root = tempfile::tempdir().expect("scan root should exist");
+        let outside = tempfile::tempdir().expect("outside root should exist");
+        fs::write(outside.path().join("secret"), b"outside")
+            .expect("outside fixture should be written");
+        let descendant = root.path().join("descendant");
+        let displaced = root.path().join("displaced-descendant");
+        fs::create_dir(&descendant).expect("descendant should be created");
+        fs::write(descendant.join("original"), b"inside")
+            .expect("descendant fixture should be written");
+        let metadata = fs::symlink_metadata(&descendant).expect("descendant metadata should exist");
+        let identity = identity_for(&descendant, &metadata)
+            .expect("descendant identity should be readable")
+            .expect("descendant identity should be available");
+        replace_directory_with_link(&descendant, &displaced, outside.path());
+
+        let (queue, _) = TaskQueue::new(root.path().to_path_buf(), 1)
+            .expect("scanner task queue should be available");
+        let (sender, events) = bounded(4);
+        let cancelled = AtomicBool::new(false);
+        let root_invalid = AtomicBool::new(false);
+        let failed = AtomicBool::new(false);
+        let root_directory = cap_fs::open_ambient_dir(root.path(), ambient_authority())
+            .expect("scan root handle should open");
+        let exclusions = Exclusions::new(root.path(), Vec::new(), Vec::new())
+            .expect("scanner exclusions should compile");
+        assert!(scan_directory(
+            DirectoryTask {
+                path: descendant.clone(),
+                identity: Some(identity),
+            },
+            &queue,
+            &sender,
+            &cancelled,
+            &failed,
+            &root_invalid,
+            &root_directory,
+            root.path(),
+            None,
+            &exclusions,
+            None,
+            true,
+        ));
+
+        match events
+            .recv_timeout(Duration::from_secs(5))
+            .expect("replaced descendant should be reported")
+        {
+            WorkerEvent::ScanUnscanned { path, reason } => {
+                assert_eq!(path, descendant);
+                assert!(matches!(reason, UnscannedReason::Replacement(_)));
+            }
+            _ => panic!("replaced descendant should not be traversed"),
+        }
+        assert!(
+            events.try_recv().is_err(),
+            "replacement must not be traversed"
+        );
+    }
+    #[cfg(unix)]
+    #[test]
+    fn scanner_does_not_follow_replacement_after_identity_validation() {
+        use crossbeam_channel::bounded;
+        use std::sync::atomic::AtomicBool;
+        use std::time::Duration;
+
+        let root = tempfile::tempdir().expect("scan root should exist");
+        let outside = tempfile::tempdir().expect("outside root should exist");
+        let outside_secret = outside.path().join("secret");
+        fs::write(&outside_secret, b"outside").expect("outside fixture should be written");
+        let descendant = root.path().join("descendant");
+        let displaced = root.path().join("displaced-descendant");
+        fs::create_dir(&descendant).expect("descendant should be created");
+        fs::write(descendant.join("original"), b"inside")
+            .expect("descendant fixture should be written");
+        let metadata = fs::symlink_metadata(&descendant).expect("descendant metadata should exist");
+        let identity = identity_for(&descendant, &metadata)
+            .expect("descendant identity should be readable")
+            .expect("descendant identity should be available");
+        replace_after_next_validation(descendant.clone(), displaced, outside.path().to_path_buf());
+
+        let (queue, _) = TaskQueue::new(root.path().to_path_buf(), 1)
+            .expect("scanner task queue should be available");
+        let (sender, events) = bounded(8);
+        let cancelled = AtomicBool::new(false);
+        let root_invalid = AtomicBool::new(false);
+        let failed = AtomicBool::new(false);
+        let root_directory = cap_fs::open_ambient_dir(root.path(), ambient_authority())
+            .expect("scan root handle should open");
+        let exclusions = Exclusions::new(root.path(), Vec::new(), Vec::new())
+            .expect("scanner exclusions should compile");
+        assert!(scan_directory(
+            DirectoryTask {
+                path: descendant.clone(),
+                identity: Some(identity),
+            },
+            &queue,
+            &sender,
+            &cancelled,
+            &failed,
+            &root_invalid,
+            &root_directory,
+            root.path(),
+            None,
+            &exclusions,
+            None,
+            true,
+        ));
+
+        let mut saw_replacement = false;
+        while let Ok(event) = events.recv_timeout(Duration::from_secs(1)) {
+            match event {
+                WorkerEvent::ScanUnscanned { path, reason } => {
+                    assert_eq!(path, descendant);
+                    assert!(matches!(reason, UnscannedReason::Replacement(_)));
+                    saw_replacement = true;
+                    break;
+                }
+                WorkerEvent::ScanBatch { entries } => {
+                    assert!(
+                        !entries
+                            .iter()
+                            .any(|entry| entry.path == descendant.join("secret")),
+                        "scanner must not enumerate the replacement target"
+                    );
+                }
+                WorkerEvent::ScanDirectoryComplete { .. } => {
+                    panic!("replaced directory must not be reported complete")
+                }
+                WorkerEvent::ScanFailed { .. }
+                | WorkerEvent::ScanFinished { .. }
+                | WorkerEvent::DeletionPlanned { .. }
+                | WorkerEvent::DeletionRevalidated { .. }
+                | WorkerEvent::DeletionFinished { .. } => {}
+            }
+        }
+        assert!(
+            saw_replacement,
+            "replacement should be reported as unscanned"
+        );
+        assert!(
+            outside_secret.exists(),
+            "outside target should remain untouched"
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn scanner_rejects_replaced_ancestor_before_traversal() {
+        use crossbeam_channel::bounded;
+        use std::sync::atomic::AtomicBool;
+        use std::time::Duration;
+
+        let root = tempfile::tempdir().expect("scan root should exist");
+        let outside = tempfile::tempdir().expect("outside root should exist");
+        let ancestor = root.path().join("ancestor");
+        let descendant = ancestor.join("descendant");
+        fs::create_dir_all(&descendant).expect("descendant should be created");
+        fs::write(descendant.join("original"), b"inside")
+            .expect("descendant fixture should be written");
+        let metadata = fs::symlink_metadata(&descendant).expect("descendant metadata should exist");
+        let identity = identity_for(&descendant, &metadata)
+            .expect("descendant identity should be readable")
+            .expect("descendant identity should be available");
+
+        let moved = outside.path().join("moved-ancestor");
+        replace_directory_with_link(&ancestor, &moved, &moved);
+        let outside_only = moved.join("descendant").join("outside-only");
+        let escaped_path = descendant.join("outside-only");
+        fs::write(&outside_only, b"outside").expect("outside fixture should be written");
+
+        let (queue, _) = TaskQueue::new(root.path().to_path_buf(), 1)
+            .expect("scanner task queue should be available");
+        let (sender, events) = bounded(8);
+        let cancelled = AtomicBool::new(false);
+        let root_invalid = AtomicBool::new(false);
+        let failed = AtomicBool::new(false);
+        let root_directory = cap_fs::open_ambient_dir(root.path(), ambient_authority())
+            .expect("scan root handle should open");
+        let exclusions = Exclusions::new(root.path(), Vec::new(), Vec::new())
+            .expect("scanner exclusions should compile");
+        assert!(scan_directory(
+            DirectoryTask {
+                path: descendant.clone(),
+                identity: Some(identity),
+            },
+            &queue,
+            &sender,
+            &cancelled,
+            &failed,
+            &root_invalid,
+            &root_directory,
+            root.path(),
+            None,
+            &exclusions,
+            None,
+            true,
+        ));
+
+        let mut saw_replacement = false;
+        while let Ok(event) = events.recv_timeout(Duration::from_secs(1)) {
+            match event {
+                WorkerEvent::ScanUnscanned { path, reason } => {
+                    assert_eq!(path, descendant);
+                    assert!(matches!(reason, UnscannedReason::Replacement(_)));
+                    saw_replacement = true;
+                    break;
+                }
+                WorkerEvent::ScanBatch { entries } => {
+                    assert!(
+                        !entries.iter().any(|entry| entry.path == escaped_path),
+                        "scanner must not enumerate the moved ancestor"
+                    );
+                }
+                WorkerEvent::ScanDirectoryComplete { .. } => {
+                    panic!("replaced ancestor must not be reported complete")
+                }
+                WorkerEvent::ScanFailed { .. }
+                | WorkerEvent::ScanFinished { .. }
+                | WorkerEvent::DeletionPlanned { .. }
+                | WorkerEvent::DeletionRevalidated { .. }
+                | WorkerEvent::DeletionFinished { .. } => {}
+            }
+        }
+        assert!(
+            saw_replacement,
+            "replaced ancestor should be reported as unscanned"
+        );
+        assert!(
+            outside_only.exists(),
+            "outside target should remain untouched"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replaced_directory_is_not_completed_after_scan_event() {
+        use crate::model::{MIN_PROCESS_MIB, NodeKind, NodeState};
+        use crate::state::files::FileTree;
+        use crossbeam_channel::bounded;
+
+        let root = tempfile::tempdir().expect("scan root should exist");
+        let outside = tempfile::tempdir().expect("outside root should exist");
+        fs::write(outside.path().join("secret"), b"outside")
+            .expect("outside fixture should be written");
+        let descendant = root.path().join("descendant");
+        let displaced = root.path().join("displaced-descendant");
+        fs::create_dir(&descendant).expect("descendant should be created");
+        fs::write(descendant.join("original"), b"inside")
+            .expect("descendant fixture should be written");
+        let metadata = fs::symlink_metadata(&descendant).expect("descendant metadata should exist");
+        let identity = identity_for(&descendant, &metadata)
+            .expect("descendant identity should be readable")
+            .expect("descendant identity should be available");
+
+        let mut tree = FileTree::new(root.path().to_path_buf(), true, MIN_PROCESS_MIB)
+            .expect("file tree should be created");
+        tree.add_entry(&metadata, &descendant, identity.clone())
+            .expect("descendant should be represented");
+
+        let (queue, _) = TaskQueue::new(root.path().to_path_buf(), 1)
+            .expect("scanner task queue should be available");
+        let (sender, events) = bounded(8);
+        let cancelled = AtomicBool::new(false);
+        let root_invalid = AtomicBool::new(false);
+        let failed = AtomicBool::new(false);
+        let root_directory = cap_fs::open_ambient_dir(root.path(), ambient_authority())
+            .expect("scan root handle should open");
+        let exclusions = Exclusions::new(root.path(), Vec::new(), Vec::new())
+            .expect("scanner exclusions should compile");
+        assert!(scan_directory(
+            DirectoryTask {
+                path: descendant.clone(),
+                identity: Some(identity.clone()),
+            },
+            &queue,
+            &sender,
+            &cancelled,
+            &failed,
+            &root_invalid,
+            &root_directory,
+            root.path(),
+            None,
+            &exclusions,
+            None,
+            true,
+        ));
+
+        replace_directory_with_link(&descendant, &displaced, outside.path());
+
+        let mut saw_completion = false;
+        for event in events.try_iter() {
+            match event {
+                WorkerEvent::ScanBatch { entries } => {
+                    for entry in entries {
+                        tree.add_entry(&entry.metadata, &entry.path, entry.identity)
+                            .expect("scanned entry should be represented");
+                    }
+                }
+                WorkerEvent::ScanDirectoryComplete { path, identity } => {
+                    assert_eq!(path, descendant);
+                    assert!(identity.is_some());
+                    tree.complete_directory(&path, identity.as_ref())
+                        .expect("completion should be represented");
+                    saw_completion = true;
+                }
+                WorkerEvent::ScanUnscanned { .. }
+                | WorkerEvent::ScanFailed { .. }
+                | WorkerEvent::ScanFinished { .. }
+                | WorkerEvent::DeletionPlanned { .. }
+                | WorkerEvent::DeletionRevalidated { .. }
+                | WorkerEvent::DeletionFinished { .. } => {}
+            }
+        }
+        assert!(saw_completion, "scan should emit a completion event");
+        let node = tree
+            .nodes()
+            .find(|node| tree.path_for_id(node.id).as_deref() == Some(descendant.as_path()))
+            .expect("replaced directory should remain represented");
+        assert_eq!(node.kind, NodeKind::Link);
+        assert_eq!(node.state, NodeState::Uncertain);
+        assert!(outside.path().join("secret").exists());
     }
 }
 

--- a/src/runtime/worker.rs
+++ b/src/runtime/worker.rs
@@ -7,7 +7,10 @@ use std::time::Duration;
 
 use crossbeam_channel::{Receiver, RecvTimeoutError, SendTimeoutError, Sender, bounded};
 
-use crate::deletion::{DeletionPlan, DeletionReport, build_plan_cancellable, execute_plan};
+use crate::deletion::{
+    DeletionPlan, DeletionPlanError, DeletionReport, build_plan_cancellable,
+    build_plan_cancellable_with_root_identity, execute_plan, revalidate_plan_cancellable,
+};
 use crate::error::AppError;
 use crate::native_path::NativeIdentity;
 use crate::state::FileToDelete;
@@ -28,6 +31,7 @@ pub(super) enum WorkerEvent {
     },
     ScanDirectoryComplete {
         path: PathBuf,
+        identity: Option<NativeIdentity>,
     },
     ScanUnscanned {
         path: PathBuf,
@@ -42,7 +46,11 @@ pub(super) enum WorkerEvent {
     },
     DeletionPlanned {
         target_node_id: crate::model::NodeId,
-        result: Result<Box<DeletionPlan>, String>,
+        result: Result<Box<DeletionPlan>, DeletionPlanError>,
+    },
+    DeletionRevalidated {
+        target_node_id: crate::model::NodeId,
+        result: Result<Box<DeletionPlan>, (Box<DeletionPlan>, DeletionPlanError)>,
     },
     DeletionFinished {
         report: DeletionReport,
@@ -55,6 +63,7 @@ enum WorkerCommand {
         target: FileToDelete,
         reduced_guardrails: bool,
     },
+    RevalidateDeletion(DeletionPlan),
     Rescan(ScannerOptions),
     ExecuteDeletion(DeletionPlan),
 }
@@ -63,6 +72,7 @@ pub struct WorkerPool {
     events: Receiver<WorkerEvent>,
     commands: Sender<WorkerCommand>,
     cancelled: Arc<AtomicBool>,
+    deletion_plan_cancelled: Arc<AtomicBool>,
     deletion_soft_cancelled: Arc<AtomicBool>,
     rescan_cancelled: Arc<AtomicBool>,
     scanner_handle: thread::JoinHandle<()>,
@@ -74,14 +84,17 @@ impl WorkerPool {
         let (event_sender, events) = bounded(event_capacity);
         let (commands, command_receiver) = bounded(1);
         let cancelled = Arc::new(AtomicBool::new(false));
+        let deletion_plan_cancelled = Arc::new(AtomicBool::new(false));
         let rescan_cancelled = Arc::new(AtomicBool::new(false));
         let deletion_soft_cancelled = Arc::new(AtomicBool::new(false));
         let scan_root = scanner_options.root.clone();
+        let scan_root_identity = scanner_options.root_identity.clone();
 
         let scanner = scanner::spawn(scanner_options, event_sender.clone(), cancelled.clone())
             .map_err(|error| AppError::io("could not spawn scanner worker", error))?;
 
         let worker_cancelled = cancelled.clone();
+        let worker_plan_cancelled = deletion_plan_cancelled.clone();
         let worker_rescan_cancelled = rescan_cancelled.clone();
         let worker_soft_cancelled = deletion_soft_cancelled.clone();
         let deletion = match thread::Builder::new()
@@ -89,8 +102,10 @@ impl WorkerPool {
             .spawn(move || {
                 deletion_worker(
                     &scan_root,
+                    scan_root_identity.as_ref(),
                     &command_receiver,
                     &event_sender,
+                    &worker_plan_cancelled,
                     &worker_soft_cancelled,
                     &worker_rescan_cancelled,
                     &worker_cancelled,
@@ -111,6 +126,7 @@ impl WorkerPool {
             events,
             commands,
             cancelled,
+            deletion_plan_cancelled,
             deletion_soft_cancelled,
             rescan_cancelled,
             scanner_handle: scanner,
@@ -129,7 +145,7 @@ impl WorkerPool {
         reduced_guardrails: bool,
         maximum_bytes: usize,
     ) -> Result<(), AppError> {
-        self.deletion_soft_cancelled.store(false, Ordering::Release);
+        self.deletion_plan_cancelled.store(false, Ordering::Release);
         self.commands
             .send(WorkerCommand::PlanDeletion {
                 target,
@@ -140,14 +156,26 @@ impl WorkerPool {
     }
 
     pub fn execute_deletion(&self, plan: DeletionPlan) -> Result<(), AppError> {
-        self.deletion_soft_cancelled.store(false, Ordering::Release);
         self.commands
             .send(WorkerCommand::ExecuteDeletion(plan))
             .map_err(|_| AppError::Worker("deletion worker disconnected".to_string()))
     }
 
+    pub fn revalidate_deletion(&self, plan: DeletionPlan) -> Result<(), AppError> {
+        self.deletion_soft_cancelled.store(false, Ordering::Release);
+        self.commands
+            .send(WorkerCommand::RevalidateDeletion(plan))
+            .map_err(|_| AppError::Worker("deletion worker disconnected".to_string()))
+    }
+
     pub fn soft_cancel_deletion(&self) {
         self.deletion_soft_cancelled.store(true, Ordering::Release);
+    }
+    pub fn cancel_deletion_plan(&self) {
+        self.deletion_plan_cancelled.store(true, Ordering::Release);
+    }
+    pub fn resume_deletion(&self) {
+        self.deletion_soft_cancelled.store(false, Ordering::Release);
     }
 
     pub fn request_rescan(&self, options: ScannerOptions) -> Result<(), AppError> {
@@ -171,6 +199,7 @@ impl WorkerPool {
 
     fn stop(self, detach_deletion: bool) -> Result<(), AppError> {
         self.cancelled.store(true, Ordering::Release);
+        self.deletion_plan_cancelled.store(true, Ordering::Release);
         self.deletion_soft_cancelled.store(true, Ordering::Release);
         self.rescan_cancelled.store(true, Ordering::Release);
         drop(self.events);
@@ -188,11 +217,16 @@ impl WorkerPool {
             .map_err(|_| AppError::Worker("deletion thread panicked".to_string()))
     }
 }
-
+#[allow(
+    clippy::too_many_arguments,
+    reason = "The worker receives each independent bounded command, cancellation, and filesystem capability explicitly."
+)]
 fn deletion_worker(
     scan_root: &std::path::Path,
+    scan_root_identity: Option<&NativeIdentity>,
     commands: &Receiver<WorkerCommand>,
     sender: &Sender<WorkerEvent>,
+    plan_cancelled: &AtomicBool,
     soft_cancelled: &AtomicBool,
     rescan_cancelled: &Arc<AtomicBool>,
     cancelled: &AtomicBool,
@@ -213,16 +247,37 @@ fn deletion_worker(
                 maximum_bytes,
             } => {
                 let target_node_id = target.node_id;
-                let result = build_plan_cancellable(
-                    scan_root,
-                    target,
-                    reduced_guardrails,
-                    cancelled,
-                    maximum_bytes,
-                )
-                .map(Box::new)
-                .map_err(|error| error.to_string());
+                let result = if let Some(identity) = scan_root_identity {
+                    build_plan_cancellable_with_root_identity(
+                        scan_root,
+                        identity.clone(),
+                        target,
+                        reduced_guardrails,
+                        plan_cancelled,
+                        maximum_bytes,
+                    )
+                } else {
+                    build_plan_cancellable(
+                        scan_root,
+                        target,
+                        reduced_guardrails,
+                        plan_cancelled,
+                        maximum_bytes,
+                    )
+                }
+                .map(Box::new);
                 WorkerEvent::DeletionPlanned {
+                    target_node_id,
+                    result,
+                }
+            }
+            WorkerCommand::RevalidateDeletion(plan) => {
+                let target_node_id = plan.target.node_id;
+                let result = match revalidate_plan_cancellable(scan_root, &plan, soft_cancelled) {
+                    Ok(()) => Ok(Box::new(plan)),
+                    Err(error) => Err((Box::new(plan), error)),
+                };
+                WorkerEvent::DeletionRevalidated {
                     target_node_id,
                     result,
                 }
@@ -272,11 +327,148 @@ mod tests {
     fn options(root: &std::path::Path, threads: usize) -> ScannerOptions {
         ScannerOptions {
             root: root.to_path_buf(),
+            root_identity: None,
             threads,
             cross_filesystems: false,
             exclusions: Vec::new(),
             internal_paths: Vec::new(),
         }
+    }
+
+    #[cfg(unix)]
+    fn single_file_plan(root: &std::path::Path) -> (std::path::PathBuf, DeletionPlan) {
+        use std::os::unix::fs::MetadataExt as _;
+        use std::time::UNIX_EPOCH;
+
+        use crate::deletion::{PlannedKind, PlannedSnapshot, ReviewedEntry, build_plan};
+        use crate::native_path::identity_for;
+        use crate::state::tiles::FileType;
+
+        let path = root.join("target");
+        std::fs::write(&path, b"payload").expect("target should be written");
+        let metadata = std::fs::symlink_metadata(&path).expect("target metadata should exist");
+        let identity = identity_for(&path, &metadata)
+            .expect("target identity should be readable")
+            .expect("target identity should be available");
+        let snapshot = PlannedSnapshot {
+            identity: identity.clone(),
+            kind: PlannedKind::File,
+            apparent_bytes: u128::from(metadata.len()),
+            allocated_bytes: Some(u128::from(metadata.blocks()).saturating_mul(512)),
+            modified_nanos: metadata
+                .modified()
+                .ok()
+                .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+                .map(|duration| duration.as_nanos()),
+        };
+        let target = FileToDelete {
+            node_id: crate::model::NodeId(1),
+            synthetic: false,
+            path_in_filesystem: root.to_path_buf(),
+            path_to_file: vec![std::ffi::OsString::from("target")],
+            file_type: FileType::File,
+            num_descendants: None,
+            size: snapshot.apparent_bytes,
+            expected_snapshot: crate::model::EntrySnapshot {
+                identity: Some(identity),
+                kind: crate::model::NodeKind::File,
+                apparent_bytes: snapshot.apparent_bytes,
+                allocated_bytes: snapshot.allocated_bytes,
+                modified_nanos: snapshot.modified_nanos,
+            },
+            reviewed_entries: vec![ReviewedEntry {
+                relative_path: std::path::PathBuf::from("target"),
+                snapshot: snapshot.clone(),
+            }],
+        };
+        let plan = build_plan(root, target, false).expect("deletion plan should build");
+        (path, plan)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn soft_cancel_wins_over_queued_revalidation_success() {
+        let root = tempfile::tempdir().expect("deletion root should exist");
+        let (path, plan) = single_file_plan(root.path());
+        let workers = WorkerPool::start(options(root.path(), 1), 16).expect("workers should start");
+        workers
+            .revalidate_deletion(plan)
+            .expect("revalidation should be queued");
+
+        let plan = loop {
+            match workers
+                .events()
+                .recv_timeout(Duration::from_secs(5))
+                .expect("worker should report revalidation")
+            {
+                WorkerEvent::DeletionRevalidated {
+                    result: Ok(plan), ..
+                } => break *plan,
+                WorkerEvent::DeletionRevalidated { result: Err(_), .. } => {
+                    panic!("revalidation should succeed")
+                }
+                _ => {}
+            }
+        };
+
+        workers.soft_cancel_deletion();
+        workers
+            .execute_deletion(plan)
+            .expect("execution should be queued after cancellation");
+        let report = loop {
+            match workers
+                .events()
+                .recv_timeout(Duration::from_secs(5))
+                .expect("worker should report deletion")
+            {
+                WorkerEvent::DeletionFinished { report } => break report,
+                WorkerEvent::ScanBatch { .. }
+                | WorkerEvent::ScanDirectoryComplete { .. }
+                | WorkerEvent::ScanUnscanned { .. }
+                | WorkerEvent::ScanFailed { .. }
+                | WorkerEvent::ScanFinished { .. }
+                | WorkerEvent::DeletionPlanned { .. }
+                | WorkerEvent::DeletionRevalidated { .. } => {}
+            }
+        };
+        assert!(report.soft_cancelled);
+        assert_eq!(report.unattempted_entries(), 1);
+        assert!(path.exists());
+        workers.shutdown().expect("workers should stop");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resume_deletion_clears_soft_cancel_before_execution() {
+        let root = tempfile::tempdir().expect("deletion root should exist");
+        let (path, plan) = single_file_plan(root.path());
+        let workers = WorkerPool::start(options(root.path(), 1), 16).expect("workers should start");
+        workers.soft_cancel_deletion();
+        workers.resume_deletion();
+        workers
+            .execute_deletion(plan)
+            .expect("execution should be queued after resuming");
+
+        let report = loop {
+            match workers
+                .events()
+                .recv_timeout(Duration::from_secs(5))
+                .expect("worker should report deletion")
+            {
+                WorkerEvent::DeletionFinished { report } => break report,
+                WorkerEvent::ScanBatch { .. }
+                | WorkerEvent::ScanDirectoryComplete { .. }
+                | WorkerEvent::ScanUnscanned { .. }
+                | WorkerEvent::ScanFailed { .. }
+                | WorkerEvent::ScanFinished { .. }
+                | WorkerEvent::DeletionPlanned { .. }
+                | WorkerEvent::DeletionRevalidated { .. } => {}
+            }
+        };
+        assert!(!report.soft_cancelled);
+        assert_eq!(report.deleted_entries(), 1);
+        assert!(!path.exists());
+        workers.shutdown().expect("workers should stop");
     }
 
     #[test]
@@ -310,6 +502,7 @@ mod tests {
                 WorkerEvent::ScanDirectoryComplete { .. }
                 | WorkerEvent::ScanUnscanned { .. }
                 | WorkerEvent::DeletionPlanned { .. }
+                | WorkerEvent::DeletionRevalidated { .. }
                 | WorkerEvent::DeletionFinished { .. } => {}
             }
         }
@@ -349,6 +542,7 @@ mod tests {
                     WorkerEvent::ScanDirectoryComplete { .. }
                     | WorkerEvent::ScanUnscanned { .. }
                     | WorkerEvent::DeletionPlanned { .. }
+                    | WorkerEvent::DeletionRevalidated { .. }
                     | WorkerEvent::DeletionFinished { .. } => {}
                 }
             }
@@ -388,6 +582,7 @@ mod tests {
                 WorkerEvent::ScanDirectoryComplete { .. }
                 | WorkerEvent::ScanUnscanned { .. }
                 | WorkerEvent::DeletionPlanned { .. }
+                | WorkerEvent::DeletionRevalidated { .. }
                 | WorkerEvent::DeletionFinished { .. } => {}
             }
         }
@@ -425,6 +620,7 @@ mod tests {
                 WorkerEvent::ScanDirectoryComplete { .. }
                 | WorkerEvent::ScanUnscanned { .. }
                 | WorkerEvent::DeletionPlanned { .. }
+                | WorkerEvent::DeletionRevalidated { .. }
                 | WorkerEvent::DeletionFinished { .. } => {}
             }
         }
@@ -474,6 +670,7 @@ mod tests {
                 WorkerEvent::ScanFailed { message, .. } => panic!("scan failed: {message}"),
                 WorkerEvent::ScanDirectoryComplete { .. }
                 | WorkerEvent::DeletionPlanned { .. }
+                | WorkerEvent::DeletionRevalidated { .. }
                 | WorkerEvent::DeletionFinished { .. } => {}
             }
         }
@@ -519,6 +716,7 @@ mod tests {
                 WorkerEvent::ScanDirectoryComplete { .. }
                 | WorkerEvent::ScanUnscanned { .. }
                 | WorkerEvent::DeletionPlanned { .. }
+                | WorkerEvent::DeletionRevalidated { .. }
                 | WorkerEvent::DeletionFinished { .. } => {}
             }
         }
@@ -562,11 +760,234 @@ mod tests {
                 WorkerEvent::ScanFailed { message, .. } => panic!("scan failed: {message}"),
                 WorkerEvent::ScanDirectoryComplete { .. }
                 | WorkerEvent::DeletionPlanned { .. }
+                | WorkerEvent::DeletionRevalidated { .. }
                 | WorkerEvent::DeletionFinished { .. } => {}
             }
         }
         assert!(skipped_link);
         assert!(!traversed_secret);
+        workers.shutdown().expect("workers should stop");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn scanner_rejects_replaced_root_before_traversal() {
+        use crate::native_path::identity_for;
+        use std::os::unix::fs::symlink;
+
+        let parent = tempfile::tempdir().expect("scan parent should exist");
+        let scan_root = parent.path().join("scan-root");
+        let original = parent.path().join("original-root");
+        let outside = parent.path().join("outside-root");
+        std::fs::create_dir(&scan_root).expect("scan root should be created");
+        std::fs::write(scan_root.join("original"), b"original")
+            .expect("original fixture should be written");
+        let metadata = std::fs::symlink_metadata(&scan_root).expect("root metadata should exist");
+        let identity = identity_for(&scan_root, &metadata)
+            .expect("root identity should be readable")
+            .expect("root should not be a symbolic link");
+        std::fs::rename(&scan_root, &original).expect("original root should be displaced");
+        std::fs::create_dir(&outside).expect("replacement root should be created");
+        std::fs::write(outside.join("replacement"), b"replacement")
+            .expect("replacement fixture should be written");
+        symlink(&outside, &scan_root).expect("replacement symlink should be created");
+
+        let mut scanner_options = options(&scan_root, 1);
+        scanner_options.root_identity = Some(identity);
+        let workers = WorkerPool::start(scanner_options, 16).expect("workers should start");
+        let mut failed = false;
+        loop {
+            match workers
+                .events()
+                .recv_timeout(Duration::from_secs(5))
+                .expect("scanner should produce completion")
+            {
+                WorkerEvent::ScanFailed { message, .. } => {
+                    failed = message.contains("replaced") || message.contains("changed");
+                }
+                WorkerEvent::ScanFinished { cancelled: false } => break,
+                WorkerEvent::ScanFinished { cancelled: true } => {
+                    panic!("replaced root should be rejected, not cancelled")
+                }
+                WorkerEvent::ScanBatch { .. }
+                | WorkerEvent::ScanDirectoryComplete { .. }
+                | WorkerEvent::ScanUnscanned { .. }
+                | WorkerEvent::DeletionPlanned { .. }
+                | WorkerEvent::DeletionRevalidated { .. }
+                | WorkerEvent::DeletionFinished { .. } => {}
+            }
+        }
+        assert!(failed);
+        workers.shutdown().expect("workers should stop");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn scanner_stops_before_following_a_replaced_root() {
+        use crate::native_path::identity_for;
+        use std::os::unix::fs::symlink;
+
+        let parent = tempfile::tempdir().expect("scan parent should exist");
+        let scan_root = parent.path().join("scan-root");
+        let original = parent.path().join("original-root");
+        let outside = parent.path().join("outside-root");
+        std::fs::create_dir(&scan_root).expect("scan root should be created");
+        std::fs::create_dir(&outside).expect("replacement root should be created");
+        for index in 0..256 {
+            std::fs::write(scan_root.join(format!("original-{index}")), b"original")
+                .expect("original fixture should be written");
+        }
+        std::fs::write(outside.join("replacement"), b"replacement")
+            .expect("replacement fixture should be written");
+        let metadata = std::fs::symlink_metadata(&scan_root).expect("root metadata should exist");
+        let identity = identity_for(&scan_root, &metadata)
+            .expect("root identity should be readable")
+            .expect("root should not be a symbolic link");
+
+        let mut scanner_options = options(&scan_root, 1);
+        scanner_options.root_identity = Some(identity);
+        let workers = WorkerPool::start(scanner_options, 1).expect("workers should start");
+        let mut replaced = false;
+        let mut saw_root_change = false;
+        let mut saw_replacement = false;
+        loop {
+            match workers
+                .events()
+                .recv_timeout(Duration::from_secs(5))
+                .expect("scanner should produce completion")
+            {
+                WorkerEvent::ScanBatch { entries } => {
+                    saw_replacement |= entries
+                        .iter()
+                        .any(|entry| entry.path == outside.join("replacement"));
+                    if !replaced {
+                        std::fs::rename(&scan_root, &original)
+                            .expect("original root should be displaced");
+                        symlink(&outside, &scan_root)
+                            .expect("replacement symlink should be created");
+                        replaced = true;
+                    }
+                }
+                WorkerEvent::ScanFailed { message, .. } => {
+                    saw_root_change |= message.contains("during traversal");
+                }
+                WorkerEvent::ScanFinished { cancelled: false } => break,
+                WorkerEvent::ScanFinished { cancelled: true } => {
+                    panic!("root replacement should be uncertain, not cancellation")
+                }
+                WorkerEvent::ScanDirectoryComplete { .. }
+                | WorkerEvent::ScanUnscanned { .. }
+                | WorkerEvent::DeletionPlanned { .. }
+                | WorkerEvent::DeletionRevalidated { .. }
+                | WorkerEvent::DeletionFinished { .. } => {}
+            }
+        }
+        assert!(replaced, "test must replace root after the first batch");
+        assert!(
+            saw_root_change,
+            "root replacement should emit an explicit failure"
+        );
+        assert!(
+            !saw_replacement,
+            "scanner must not follow the replacement root"
+        );
+        workers.shutdown().expect("workers should stop");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn final_plan_revalidation_runs_in_cancellable_worker() {
+        use std::os::unix::fs::MetadataExt as _;
+        use std::time::UNIX_EPOCH;
+
+        use crate::deletion::{
+            ConfirmationChallenge, DeletionPlan, PlannedEntry, PlannedKind, PlannedSnapshot,
+            ReviewedEntry, current_scan_root_identity,
+        };
+        use crate::native_path::identity_for;
+        use crate::state::FileToDelete;
+        use crate::state::tiles::FileType;
+
+        let root = tempfile::tempdir().expect("scan root should exist");
+        let path = root.path().join("target");
+        std::fs::write(&path, b"original").expect("target should be written");
+        let metadata = std::fs::symlink_metadata(&path).expect("target metadata should exist");
+        let identity = identity_for(&path, &metadata)
+            .expect("target identity should be readable")
+            .expect("target identity should be available");
+        let snapshot = PlannedSnapshot {
+            identity: identity.clone(),
+            kind: PlannedKind::File,
+            apparent_bytes: u128::from(metadata.len()),
+            allocated_bytes: Some(u128::from(metadata.blocks()).saturating_mul(512)),
+            modified_nanos: metadata
+                .modified()
+                .ok()
+                .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+                .map(|duration| duration.as_nanos()),
+        };
+        let target = FileToDelete {
+            node_id: crate::model::NodeId(1),
+            synthetic: false,
+            path_in_filesystem: root.path().to_path_buf(),
+            path_to_file: vec![std::ffi::OsString::from("target")],
+            file_type: FileType::File,
+            num_descendants: None,
+            size: snapshot.apparent_bytes,
+            expected_snapshot: crate::model::EntrySnapshot {
+                identity: Some(identity),
+                kind: crate::model::NodeKind::File,
+                apparent_bytes: snapshot.apparent_bytes,
+                allocated_bytes: snapshot.allocated_bytes,
+                modified_nanos: snapshot.modified_nanos,
+            },
+            reviewed_entries: vec![ReviewedEntry {
+                relative_path: std::path::PathBuf::from("target"),
+                snapshot: snapshot.clone(),
+            }],
+        };
+        let root_identity =
+            current_scan_root_identity(root.path()).expect("scan root identity should be readable");
+        let plan = DeletionPlan {
+            target,
+            root_relative_path: std::path::PathBuf::from("target"),
+            scan_root_identity: root_identity.clone(),
+            entries: vec![PlannedEntry {
+                relative_path: std::path::PathBuf::from("target"),
+                snapshot,
+            }],
+            challenge: ConfirmationChallenge::ConfirmFile,
+            apparent_bytes: 8,
+            estimated_bytes: 1,
+        };
+        let mut scanner_options = options(root.path(), 1);
+        scanner_options.root_identity = Some(root_identity);
+        let workers = WorkerPool::start(scanner_options, 16).expect("workers should start");
+        std::fs::write(&path, b"replacement-after-confirmation")
+            .expect("replacement should be written");
+        workers
+            .revalidate_deletion(plan)
+            .expect("revalidation should be queued");
+
+        let result = loop {
+            match workers
+                .events()
+                .recv_timeout(Duration::from_secs(5))
+                .expect("worker should report revalidation")
+            {
+                WorkerEvent::DeletionRevalidated { result, .. } => break result,
+                WorkerEvent::ScanBatch { .. }
+                | WorkerEvent::ScanDirectoryComplete { .. }
+                | WorkerEvent::ScanUnscanned { .. }
+                | WorkerEvent::ScanFailed { .. }
+                | WorkerEvent::ScanFinished { .. }
+                | WorkerEvent::DeletionPlanned { .. }
+                | WorkerEvent::DeletionFinished { .. } => {}
+            }
+        };
+        let (returned, error) = result.expect_err("changed confirmation should be rejected");
+        assert_eq!(returned.entries.len(), 1);
+        assert!(error.is_stale());
         workers.shutdown().expect("workers should stop");
     }
     #[test]
@@ -583,6 +1004,7 @@ mod tests {
             events,
             commands,
             cancelled: cancelled.clone(),
+            deletion_plan_cancelled: Arc::new(AtomicBool::new(false)),
             deletion_soft_cancelled,
             rescan_cancelled,
             scanner_handle,

--- a/src/state/files/file_tree.rs
+++ b/src/state/files/file_tree.rs
@@ -1,9 +1,11 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::ffi::OsStr;
 use std::fs::Metadata;
 use std::path::{Path, PathBuf};
 
 use crate::deletion::{
     DeletionEntryOutcome, DeletionReport, PlannedKind, PlannedSnapshot, ReviewedEntry,
+    validate_scan_root_identity,
 };
 use crate::filter::FilterPattern;
 use crate::model::{
@@ -12,6 +14,7 @@ use crate::model::{
 };
 use crate::native_path::NativeIdentity;
 use crate::state::tiles::{FileMetadata, files_in_folder};
+use file_id::FileId;
 
 struct RescanStage {
     target_id: NodeId,
@@ -26,6 +29,7 @@ pub struct FileTree {
     pub failed_to_read: u64,
     pub path_in_filesystem: PathBuf,
     arena: Arena,
+    root_identity: Option<NativeIdentity>,
     show_apparent_size: bool,
     filter: Option<FilterPattern>,
     filter_root: Option<PathBuf>,
@@ -43,6 +47,7 @@ impl FileTree {
         Ok(Self {
             current_path: vec![arena.root()],
             arena,
+            root_identity: None,
             path_in_filesystem,
             space_freed: 0,
             failed_to_read: 0,
@@ -51,6 +56,20 @@ impl FileTree {
             filter_root: None,
             rescan: None,
         })
+    }
+
+    pub fn new_with_root_identity(
+        path_in_filesystem: PathBuf,
+        root_identity: NativeIdentity,
+        show_apparent_size: bool,
+        process_memory_mib: usize,
+    ) -> Result<Self, ModelError> {
+        validate_scan_root_identity(&path_in_filesystem, &root_identity)
+            .map_err(|error| ModelError::Invariant(error.to_string()))?;
+        let mut tree = Self::new(path_in_filesystem, show_apparent_size, process_memory_mib)?;
+        tree.root_identity = Some(root_identity.clone());
+        tree.arena.set_root_identity(root_identity);
+        Ok(tree)
     }
 
     #[must_use]
@@ -106,6 +125,72 @@ impl FileTree {
     #[must_use]
     pub fn entry_snapshot(&self, id: NodeId) -> Option<crate::model::EntrySnapshot> {
         self.arena.node(id).map(|node| node.snapshot.clone())
+    }
+
+    #[must_use]
+    pub fn identity_for_path(&self, path: &Path) -> Option<NativeIdentity> {
+        let id = self.arena.path_ids(path)?.last().copied()?;
+        self.arena.node(id)?.snapshot.identity.clone()
+    }
+    pub fn deletion_target_for_path(
+        &self,
+        path: &Path,
+    ) -> Result<crate::state::FileToDelete, ModelError> {
+        let ids = self
+            .arena
+            .path_ids(path)
+            .ok_or_else(|| ModelError::InvalidPath(path.to_string_lossy().into_owned()))?;
+        let node_id = *ids
+            .last()
+            .ok_or_else(|| ModelError::InvalidPath(path.to_string_lossy().into_owned()))?;
+        if ids.iter().any(|id| {
+            self.arena
+                .node(*id)
+                .is_none_or(|node| node.state != NodeState::Complete)
+        }) {
+            return Err(ModelError::Invariant(
+                "deletion requires a fully materialized path".to_string(),
+            ));
+        }
+        let node = self
+            .arena
+            .node(node_id)
+            .ok_or_else(|| ModelError::InvalidPath(path.to_string_lossy().into_owned()))?;
+        if node.kind.is_synthetic() {
+            return Err(ModelError::Invariant(
+                "deletion requires a fully materialized subtree".to_string(),
+            ));
+        }
+        let relative = path
+            .strip_prefix(&self.path_in_filesystem)
+            .map_err(|_| ModelError::InvalidPath(path.to_string_lossy().into_owned()))?;
+        let (file_type, num_descendants) = match node.kind {
+            NodeKind::Directory => (
+                crate::state::tiles::FileType::Folder,
+                Some(node.metrics.descendants),
+            ),
+            NodeKind::File | NodeKind::Link => (crate::state::tiles::FileType::File, None),
+            NodeKind::Root | NodeKind::Synthetic(_) => {
+                return Err(ModelError::Invariant(
+                    "scan roots and synthetic nodes cannot be deleted".to_string(),
+                ));
+            }
+        };
+        Ok(crate::state::FileToDelete {
+            node_id,
+            synthetic: false,
+            path_in_filesystem: self.path_in_filesystem.clone(),
+            path_to_file: relative.iter().map(OsStr::to_os_string).collect(),
+            file_type,
+            num_descendants,
+            size: if self.show_apparent_size {
+                node.metrics.apparent_bytes
+            } else {
+                node.metrics.allocated_bytes.lower
+            },
+            expected_snapshot: node.snapshot.clone(),
+            reviewed_entries: Vec::new(),
+        })
     }
 
     pub fn reviewed_subtree(
@@ -209,17 +294,51 @@ impl FileTree {
         }
     }
 
+    #[allow(dead_code)]
     pub fn apply_deletion_report(&mut self, report: &DeletionReport) {
+        let _ = self.try_apply_deletion_report(report);
+    }
+
+    pub fn try_apply_deletion_report(&mut self, report: &DeletionReport) -> Result<(), ModelError> {
+        let mut affected_link_counts: HashMap<FileId, Option<u64>> = HashMap::new();
         for result in &report.entries {
-            if matches!(
+            if !matches!(
                 result.outcome,
                 DeletionEntryOutcome::Deleted | DeletionEntryOutcome::Missing
+            ) || !matches!(
+                result.entry.snapshot.kind,
+                PlannedKind::File | PlannedKind::Link
             ) {
-                let path = self.path_in_filesystem.join(&result.entry.relative_path);
-                self.arena.remove_path(&path);
+                continue;
             }
+            let file_id = result.entry.snapshot.identity.file_id;
+            let post_delete = matches!(result.outcome, DeletionEntryOutcome::Deleted)
+                .then(|| result.entry.snapshot.identity.link_count)
+                .flatten()
+                .map(|count| count.saturating_sub(1));
+            affected_link_counts
+                .entry(file_id)
+                .and_modify(|current| {
+                    *current = match (*current, post_delete) {
+                        (Some(_), Some(next)) => Some(next),
+                        _ => None,
+                    };
+                })
+                .or_insert(post_delete);
         }
-        self.arena.rebuild();
+        let removed_paths = report
+            .entries
+            .iter()
+            .filter(|result| {
+                matches!(
+                    result.outcome,
+                    DeletionEntryOutcome::Deleted | DeletionEntryOutcome::Missing
+                )
+            })
+            .map(|result| self.path_in_filesystem.join(&result.entry.relative_path))
+            .collect::<Vec<_>>();
+        self.arena
+            .try_remove_paths_with_link_counts(&removed_paths, &affected_link_counts)?;
         if report.changed_entries() > 0
             || report.failed_entries() > 0
             || report.unattempted_entries() > 0
@@ -233,15 +352,10 @@ impl FileTree {
         let freed = if self.show_apparent_size {
             report.deleted_apparent_bytes()
         } else {
-            report.entries.iter().fold(0_u128, |total, result| {
-                if matches!(result.outcome, DeletionEntryOutcome::Deleted) {
-                    total.saturating_add(result.entry.snapshot.allocated_bytes.unwrap_or(0))
-                } else {
-                    total
-                }
-            })
+            report.deleted_allocated_bytes()
         };
         self.space_freed = self.space_freed.saturating_add(freed);
+        Ok(())
     }
 
     #[allow(clippy::needless_pass_by_value)]
@@ -289,11 +403,15 @@ impl FileTree {
         record_unscanned_to(&mut self.arena, &pinned, path, &reason)
     }
 
-    pub fn complete_directory(&mut self, path: &Path) -> Result<(), ModelError> {
+    pub fn complete_directory(
+        &mut self,
+        path: &Path,
+        expected_identity: Option<&NativeIdentity>,
+    ) -> Result<(), ModelError> {
         if let Some(stage) = self.rescan.as_mut() {
-            stage.arena.complete_directory(path)
+            stage.arena.complete_directory(path, expected_identity)
         } else {
-            self.arena.complete_directory(path)
+            self.arena.complete_directory(path, expected_identity)
         }
     }
 
@@ -453,7 +571,7 @@ impl FileTree {
                 .filter(|node| {
                     matches!(
                         node.unscanned_reason.as_ref(),
-                        Some(UnscannedReason::Metadata(_))
+                        Some(UnscannedReason::Metadata(_) | UnscannedReason::Replacement(_))
                     )
                 })
                 .count(),
@@ -514,11 +632,24 @@ fn record_unscanned_to(
 #[cfg(test)]
 mod tests {
     use std::ffi::OsStr;
+    #[cfg(any(unix, windows))]
+    use std::ffi::OsString;
     use std::fs;
 
-    use super::*;
-    use crate::model::SyntheticKind;
+    #[cfg(any(unix, windows))]
+    use crate::deletion::{
+        DeletionEntryOutcome, DeletionEntryResult, DeletionReport, build_plan, execute_plan,
+    };
+    #[cfg(any(unix, windows))]
+    use crate::model::ByteBounds;
+    use crate::model::{NodeKind, SyntheticKind};
     use crate::native_path::identity_for;
+    #[cfg(any(unix, windows))]
+    use crate::state::FileToDelete;
+    #[cfg(any(unix, windows))]
+    use crate::state::tiles::FileType;
+
+    use super::*;
 
     fn add(tree: &mut FileTree, path: &Path) {
         let metadata = fs::symlink_metadata(path).expect("fixture metadata should exist");
@@ -624,7 +755,7 @@ mod tests {
         add(&mut tree, &target);
         add(&mut tree, &old);
         for path in [&target, root.path()] {
-            tree.complete_directory(path)
+            tree.complete_directory(path, None)
                 .expect("fixture directory should complete");
         }
         tree.finalize().expect("fixture tree should finalize");
@@ -668,7 +799,7 @@ mod tests {
             add(&mut tree, path);
         }
         for path in [&target, &sibling, root.path()] {
-            tree.complete_directory(path)
+            tree.complete_directory(path, None)
                 .expect("fixture directory should complete");
         }
         tree.finalize().expect("fixture tree should finalize");
@@ -681,7 +812,7 @@ mod tests {
         tree.begin_rescan(target.clone(), None)
             .expect("focused rescan should stage");
         add(&mut tree, &replacement);
-        tree.complete_directory(&target)
+        tree.complete_directory(&target, None)
             .expect("staged target should complete");
         tree.increment_failed_to_read();
         assert_eq!(tree.failed_to_read, 0);
@@ -715,7 +846,7 @@ mod tests {
             add(&mut tree, path);
         }
         for path in [&target, &sibling, root.path()] {
-            tree.complete_directory(path)
+            tree.complete_directory(path, None)
                 .expect("fixture directory should complete");
         }
         tree.finalize().expect("fixture tree should finalize");
@@ -730,7 +861,7 @@ mod tests {
         tree.begin_rescan(target.clone(), None)
             .expect("focused rescan should stage");
         add(&mut tree, &replacement);
-        tree.complete_directory(&target)
+        tree.complete_directory(&target, None)
             .expect("staged target should complete");
         tree.finish_rescan().expect("staged target should merge");
 
@@ -781,7 +912,7 @@ mod tests {
             &outside,
             root.path(),
         ] {
-            tree.complete_directory(path)
+            tree.complete_directory(path, None)
                 .expect("fixture directory should complete");
         }
         tree.finalize().expect("fixture tree should finalize");
@@ -841,7 +972,7 @@ mod tests {
             add(&mut tree, path);
         }
         for path in [&target, &sibling, root.path()] {
-            tree.complete_directory(path)
+            tree.complete_directory(path, None)
                 .expect("fixture directory should complete");
         }
         tree.finalize().expect("fixture tree should finalize");
@@ -851,12 +982,212 @@ mod tests {
         tree.begin_rescan(target.clone(), None)
             .expect("focused rescan should stage");
         add(&mut tree, &inside);
-        tree.complete_directory(&target)
+        tree.complete_directory(&target, None)
             .expect("staged target should complete");
         tree.finish_rescan().expect("staged target should merge");
 
         assert_eq!(node_id_at(&tree, &outside), outside_id);
         assert_eq!(tree.identity_count(), 1);
         assert_eq!(tree.total_node().metrics.allocated_bytes, allocated_before);
+    }
+    #[cfg(unix)]
+    #[test]
+    fn replaced_root_directory_is_rejected_before_model_creation() {
+        let parent = tempfile::tempdir().expect("scan parent should exist");
+        let scan_root = parent.path().join("scan-root");
+        let original = parent.path().join("original-root");
+        fs::create_dir(&scan_root).expect("scan root should be created");
+        let metadata = fs::symlink_metadata(&scan_root).expect("root metadata should exist");
+        let identity = identity_for(&scan_root, &metadata)
+            .expect("root identity should be readable")
+            .expect("root should not be a symbolic link");
+        fs::rename(&scan_root, &original).expect("original root should be displaced");
+        fs::create_dir(&scan_root).expect("replacement root should be created");
+
+        assert!(
+            FileTree::new_with_root_identity(
+                scan_root,
+                identity,
+                false,
+                crate::model::MIN_PROCESS_MIB,
+            )
+            .is_err()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replaced_root_symlink_is_rejected_before_model_creation() {
+        use std::os::unix::fs::symlink;
+
+        let parent = tempfile::tempdir().expect("scan parent should exist");
+        let scan_root = parent.path().join("scan-root");
+        let outside = parent.path().join("outside-root");
+        fs::create_dir(&scan_root).expect("scan root should be created");
+        fs::create_dir(&outside).expect("outside root should be created");
+        let metadata = fs::symlink_metadata(&scan_root).expect("root metadata should exist");
+        let identity = identity_for(&scan_root, &metadata)
+            .expect("root identity should be readable")
+            .expect("root should not be a symbolic link");
+        fs::remove_dir(&scan_root).expect("original root should be removed");
+        symlink(&outside, &scan_root).expect("replacement symlink should be created");
+
+        assert!(
+            FileTree::new_with_root_identity(
+                scan_root,
+                identity,
+                false,
+                crate::model::MIN_PROCESS_MIB,
+            )
+            .is_err()
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn partial_hard_link_deletion_rebuilds_identity_metrics() {
+        let root = tempfile::tempdir().expect("deletion root should exist");
+        let first = root.path().join("first");
+        let second = root.path().join("second");
+        fs::write(&first, b"payload").expect("hard-link source should be written");
+        fs::hard_link(&first, &second).expect("hard link should be created");
+
+        let mut tree = FileTree::new(
+            root.path().to_path_buf(),
+            false,
+            crate::model::MIN_PROCESS_MIB,
+        )
+        .expect("file tree should be created");
+        add(&mut tree, &first);
+        add(&mut tree, &second);
+        tree.complete_directory(root.path(), None)
+            .expect("root should complete");
+        tree.finalize().expect("tree should finalize");
+        let first_id = node_id_at(&tree, &first);
+        let snapshot = tree
+            .entry_snapshot(first_id)
+            .expect("first snapshot should exist");
+        let target = FileToDelete {
+            node_id: first_id,
+            synthetic: false,
+            path_in_filesystem: root.path().to_path_buf(),
+            path_to_file: vec![OsString::from("first")],
+            file_type: FileType::File,
+            num_descendants: None,
+            size: snapshot.apparent_bytes,
+            expected_snapshot: snapshot.clone(),
+            reviewed_entries: tree
+                .reviewed_subtree(first_id, 1 << 20)
+                .expect("first subtree should be reviewable"),
+        };
+        let plan = build_plan(root.path(), target, false).expect("deletion plan should build");
+        let report = execute_plan(
+            root.path(),
+            plan,
+            &std::sync::atomic::AtomicBool::new(false),
+            &std::sync::atomic::AtomicBool::new(false),
+        );
+        assert_eq!(report.deleted_entries(), 1);
+        assert_eq!(report.deleted_allocated_bytes(), 0);
+        tree.apply_deletion_report(&report);
+
+        let second_id = node_id_at(&tree, &second);
+        let second_node = tree.node(second_id).expect("remaining link should exist");
+        let allocated = snapshot
+            .allocated_bytes
+            .map_or(ByteBounds::unknown(), ByteBounds::exact);
+        assert_eq!(second_node.metrics.allocated_bytes, allocated);
+        assert_eq!(
+            second_node
+                .snapshot
+                .identity
+                .as_ref()
+                .and_then(|identity| identity.link_count),
+            Some(1)
+        );
+        assert_eq!(second_node.metrics.reclaimable_bytes, allocated);
+        assert!(
+            tree.nodes()
+                .all(|node| { node.kind != NodeKind::Synthetic(SyntheticKind::Shared) })
+        );
+        assert_eq!(tree.identity_count(), 1);
+        assert_eq!(tree.space_freed, 0);
+    }
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn missing_hard_link_refreshes_survivor_metadata() {
+        let root = tempfile::tempdir().expect("deletion root should exist");
+        let first = root.path().join("first");
+        let second = root.path().join("second");
+        fs::write(&first, b"payload").expect("hard-link source should be written");
+        fs::hard_link(&first, &second).expect("hard link should be created");
+
+        let mut tree = FileTree::new(
+            root.path().to_path_buf(),
+            false,
+            crate::model::MIN_PROCESS_MIB,
+        )
+        .expect("file tree should be created");
+        add(&mut tree, &first);
+        add(&mut tree, &second);
+        tree.complete_directory(root.path(), None)
+            .expect("root should complete");
+        tree.finalize().expect("tree should finalize");
+        let first_id = node_id_at(&tree, &first);
+        let snapshot = tree
+            .entry_snapshot(first_id)
+            .expect("first snapshot should exist");
+        let target = FileToDelete {
+            node_id: first_id,
+            synthetic: false,
+            path_in_filesystem: root.path().to_path_buf(),
+            path_to_file: vec![OsString::from("first")],
+            file_type: FileType::File,
+            num_descendants: None,
+            size: snapshot.apparent_bytes,
+            expected_snapshot: snapshot.clone(),
+            reviewed_entries: tree
+                .reviewed_subtree(first_id, 1 << 20)
+                .expect("first subtree should be reviewable"),
+        };
+        let plan = build_plan(root.path(), target, false).expect("deletion plan should build");
+        let entry = plan
+            .entries
+            .first()
+            .cloned()
+            .expect("deletion plan should contain the target");
+        let report = DeletionReport {
+            target_node_id: first_id,
+            root_relative_path: std::path::PathBuf::from("first"),
+            scan_root: root.path().to_path_buf(),
+            entries: vec![DeletionEntryResult {
+                entry,
+                outcome: DeletionEntryOutcome::Missing,
+            }],
+            soft_cancelled: false,
+            precise: true,
+            estimated_bytes: plan.estimated_bytes,
+        };
+        fs::remove_file(&first).expect("planned path should become missing");
+        assert_eq!(report.missing_entries(), 1);
+        tree.apply_deletion_report(&report);
+
+        let second_id = node_id_at(&tree, &second);
+        let second_node = tree.node(second_id).expect("remaining link should exist");
+        let allocated = snapshot
+            .allocated_bytes
+            .map_or(ByteBounds::unknown(), ByteBounds::exact);
+        assert_eq!(second_node.metrics.allocated_bytes, allocated);
+        assert_eq!(
+            second_node
+                .snapshot
+                .identity
+                .as_ref()
+                .and_then(|identity| identity.link_count),
+            Some(1)
+        );
+        assert_eq!(second_node.metrics.reclaimable_bytes, allocated);
+        assert_eq!(tree.identity_count(), 1);
+        assert_eq!(tree.space_freed, 0);
     }
 }

--- a/src/tests/cases/native_path.rs
+++ b/src/tests/cases/native_path.rs
@@ -6,12 +6,14 @@ use crate::native_path::{NativePath, ResolvedRoot, identity_for, safe_display_pa
 
 #[test]
 fn safe_display_escapes_terminal_and_bidi_controls() {
-    let displayed = safe_display_path(Path::new("safe/\u{1b}[31m/\u{202e}name"));
+    let displayed = safe_display_path(Path::new("safe/\u{1b}[31m/\u{202e}\u{206a}name"));
     assert!(displayed.deceptive);
     assert!(!displayed.text.contains('\u{1b}'));
     assert!(!displayed.text.contains('\u{202e}'));
+    assert!(!displayed.text.contains('\u{206a}'));
     assert!(displayed.text.contains("\\x1b"));
     assert!(displayed.text.contains("\\u{202e}"));
+    assert!(displayed.text.contains("\\u{206a}"));
 }
 
 #[test]

--- a/src/tests/cases/runtime.rs
+++ b/src/tests/cases/runtime.rs
@@ -10,8 +10,13 @@ use crate::tests::cases::test_utils::test_backend_factory;
 use crate::tests::fakes::{BackendOperation, TerminalEvent, TerminalEvents};
 
 fn settings(root: &std::path::Path) -> RuntimeSettings {
+    let metadata = std::fs::symlink_metadata(root).expect("runtime root metadata should exist");
+    let root_identity = crate::native_path::identity_for(root, &metadata)
+        .expect("runtime root identity should be readable")
+        .expect("runtime root should not be a symbolic link");
     RuntimeSettings {
         root: root.to_path_buf(),
+        root_identity,
         scan_threads: 1,
         event_capacity: 16,
         cross_filesystems: false,
@@ -146,6 +151,487 @@ fn graceful_quit_during_scan_is_precise_cancellation() {
     assert!(
         matches!(outcome, OperationOutcome::Cancelled { precise: true, .. }),
         "unexpected outcome: {outcome:?}"
+    );
+}
+
+#[cfg(unix)]
+struct DelayedSoftCancelInput {
+    events: Vec<Option<Event>>,
+}
+
+#[cfg(unix)]
+impl DelayedSoftCancelInput {
+    fn new(mut events: Vec<Option<Event>>) -> Self {
+        events.reverse();
+        Self { events }
+    }
+}
+
+#[cfg(unix)]
+impl InputSource for DelayedSoftCancelInput {
+    fn poll(&mut self, _timeout: Duration) -> Result<bool, AppError> {
+        Ok(!self.events.is_empty())
+    }
+
+    fn read(&mut self) -> Result<InputEvent, AppError> {
+        let event = self
+            .events
+            .pop()
+            .ok_or_else(|| AppError::Invariant("fake input exhausted after poll".to_string()))?;
+        if matches!(
+            &event,
+            Some(Event::Key(KeyEvent {
+                code: KeyCode::Char('s'),
+                modifiers: KeyModifiers::NONE,
+                ..
+            }))
+        ) {
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        Ok(event.map_or(InputEvent::Barrier, InputEvent::Terminal))
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn soft_cancel_wins_when_revalidation_event_follows_input() {
+    let root = tempfile::tempdir().expect("runtime root should exist");
+    let target = root.path().join("target");
+    std::fs::write(&target, b"payload").expect("deletion target should be written");
+    let (_, _, backend) = test_backend_factory(80, 24);
+    let input = DelayedSoftCancelInput::new(vec![
+        None,
+        Some(key(KeyCode::Down, KeyModifiers::NONE)),
+        Some(key(KeyCode::Backspace, KeyModifiers::NONE)),
+        None,
+        Some(key(KeyCode::Char('y'), KeyModifiers::NONE)),
+        Some(key(KeyCode::Char('q'), KeyModifiers::NONE)),
+        Some(key(KeyCode::Char('s'), KeyModifiers::NONE)),
+        None,
+        Some(key(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+        Some(key(KeyCode::Char('y'), KeyModifiers::NONE)),
+    ]);
+    let outcome = run(
+        backend,
+        Box::new(input),
+        settings(root.path()),
+        Box::new(VirtualClock::new()),
+    )
+    .expect("soft cancellation should restore cleanly");
+    let OperationOutcome::Partial {
+        completed_entries,
+        failed_entries,
+        ..
+    } = outcome
+    else {
+        panic!("expected a partial cancellation result, got {outcome:?}");
+    };
+    assert_eq!(completed_entries, 0);
+    assert_eq!(failed_entries, 1);
+    assert!(target.exists(), "soft-cancelled target must remain");
+}
+
+#[allow(clippy::struct_excessive_bools)]
+#[cfg(any(unix, windows))]
+struct ReplanInput {
+    events: Vec<Option<Event>>,
+    target: std::path::PathBuf,
+    changed: bool,
+    remove_on_confirm: bool,
+    change_on_plan: bool,
+    remove_on_plan: bool,
+    replace_directory_on_trigger: bool,
+}
+
+#[cfg(any(unix, windows))]
+impl ReplanInput {
+    fn new(events: Vec<Option<Event>>, target: std::path::PathBuf) -> Self {
+        let mut events = events;
+        events.reverse();
+        Self {
+            events,
+            target,
+            changed: false,
+            remove_on_confirm: false,
+            change_on_plan: false,
+            remove_on_plan: false,
+            replace_directory_on_trigger: false,
+        }
+    }
+    fn missing(events: Vec<Option<Event>>, target: std::path::PathBuf) -> Self {
+        let mut input = Self::new(events, target);
+        input.remove_on_confirm = true;
+        input
+    }
+    fn planning_change(events: Vec<Option<Event>>, target: std::path::PathBuf) -> Self {
+        let mut input = Self::new(events, target);
+        input.change_on_plan = true;
+        input
+    }
+
+    fn planning_missing(events: Vec<Option<Event>>, target: std::path::PathBuf) -> Self {
+        let mut input = Self::new(events, target);
+        input.change_on_plan = true;
+        input.remove_on_plan = true;
+        input
+    }
+
+    #[cfg(unix)]
+    fn planning_directory_replacement(
+        events: Vec<Option<Event>>,
+        target: std::path::PathBuf,
+    ) -> Self {
+        let mut input = Self::new(events, target);
+        input.change_on_plan = true;
+        input.replace_directory_on_trigger = true;
+        input
+    }
+
+    #[cfg(unix)]
+    fn directory_replacement(events: Vec<Option<Event>>, target: std::path::PathBuf) -> Self {
+        let mut input = Self::new(events, target);
+        input.replace_directory_on_trigger = true;
+        input
+    }
+}
+
+#[cfg(any(unix, windows))]
+impl InputSource for ReplanInput {
+    fn poll(&mut self, _timeout: Duration) -> Result<bool, AppError> {
+        Ok(!self.events.is_empty())
+    }
+
+    fn read(&mut self) -> Result<InputEvent, AppError> {
+        let event = self
+            .events
+            .pop()
+            .ok_or_else(|| AppError::Invariant("fake input exhausted after poll".to_string()))?;
+        let trigger = if self.change_on_plan {
+            KeyCode::Backspace
+        } else {
+            KeyCode::Char('y')
+        };
+        if !self.changed
+            && matches!(
+                &event,
+                Some(Event::Key(KeyEvent {
+                    code,
+                    modifiers: KeyModifiers::NONE,
+                    ..
+                })) if *code == trigger
+            )
+        {
+            if self.replace_directory_on_trigger {
+                let displaced = self.target.with_file_name("displaced-target");
+                std::fs::rename(&self.target, displaced)
+                    .expect("original directory should be displaced");
+                std::fs::create_dir(&self.target).expect("replacement directory should be created");
+                std::fs::write(self.target.join("replacement"), b"replacement")
+                    .expect("replacement child should be written");
+            } else if self.remove_on_confirm || self.remove_on_plan {
+                std::fs::remove_file(&self.target).expect("post-plan target should be removed");
+            } else {
+                std::fs::write(&self.target, b"changed-after-plan")
+                    .expect("post-plan replacement should be written");
+            }
+            self.changed = true;
+        }
+        Ok(event.map_or(InputEvent::Barrier, InputEvent::Terminal))
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn changed_plan_rescans_before_reprompting_and_does_not_reuse_stale_review() {
+    let root = tempfile::tempdir().expect("runtime root should exist");
+    let target = root.path().join("target");
+    std::fs::write(&target, b"payload").expect("deletion target should be written");
+    let (_, _, backend) = test_backend_factory(80, 24);
+    let input = ReplanInput::new(
+        vec![
+            None,
+            Some(key(KeyCode::Down, KeyModifiers::NONE)),
+            Some(key(KeyCode::Backspace, KeyModifiers::NONE)),
+            None,
+            Some(key(KeyCode::Char('y'), KeyModifiers::NONE)),
+            None,
+            Some(key(KeyCode::Char('y'), KeyModifiers::NONE)),
+            None,
+            Some(key(KeyCode::Char('q'), KeyModifiers::NONE)),
+            Some(key(KeyCode::Char('q'), KeyModifiers::NONE)),
+            Some(key(KeyCode::Char('y'), KeyModifiers::NONE)),
+        ],
+        target.clone(),
+    );
+    let outcome = run(
+        backend,
+        Box::new(input),
+        settings(root.path()),
+        Box::new(VirtualClock::new()),
+    )
+    .expect("stale plan should be rebuilt after the focused rescan");
+    assert!(
+        matches!(outcome, OperationOutcome::Exact(_)),
+        "unexpected outcome: {outcome:?}"
+    );
+    assert!(!target.exists(), "freshly planned target should be deleted");
+}
+
+#[cfg(unix)]
+#[test]
+fn replaced_directory_target_rescans_parent_before_reprompting() {
+    let root = tempfile::tempdir().expect("deletion root should exist");
+    let target = root.path().join("target");
+    let displaced = root.path().join("displaced-target");
+    std::fs::create_dir(&target).expect("deletion target should be created");
+    std::fs::write(target.join("old-child"), b"old")
+        .expect("initial directory child should be written");
+    let (_, _, backend) = test_backend_factory(80, 24);
+    let input = ReplanInput::planning_directory_replacement(
+        vec![
+            None,
+            Some(key(KeyCode::Down, KeyModifiers::NONE)),
+            Some(key(KeyCode::Backspace, KeyModifiers::NONE)),
+            None,
+            Some(key(KeyCode::Char('y'), KeyModifiers::NONE)),
+            None,
+            Some(key(KeyCode::Char('q'), KeyModifiers::NONE)),
+            Some(key(KeyCode::Char('q'), KeyModifiers::NONE)),
+            Some(key(KeyCode::Char('y'), KeyModifiers::NONE)),
+        ],
+        target.clone(),
+    );
+    let mut settings = settings(root.path());
+    settings.disable_delete_confirmation = true;
+    let outcome = run(
+        backend,
+        Box::new(input),
+        settings,
+        Box::new(VirtualClock::new()),
+    )
+    .expect("directory replacement should trigger a parent rescan");
+    assert!(
+        matches!(outcome, OperationOutcome::Exact(_)),
+        "unexpected outcome: {outcome:?}"
+    );
+    assert!(
+        !target.exists(),
+        "fresh replacement target should be deleted"
+    );
+    assert!(
+        displaced.join("old-child").exists(),
+        "old occupant should remain untouched"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn final_directory_replacement_rescans_parent_before_reprompting() {
+    let root = tempfile::tempdir().expect("deletion root should exist");
+    let target = root.path().join("target");
+    let displaced = root.path().join("displaced-target");
+    std::fs::create_dir(&target).expect("deletion target should be created");
+    std::fs::write(target.join("old-child"), b"old")
+        .expect("initial directory child should be written");
+    let (_, _, backend) = test_backend_factory(80, 24);
+    let input = ReplanInput::directory_replacement(
+        vec![
+            None,
+            Some(key(KeyCode::Down, KeyModifiers::NONE)),
+            Some(key(KeyCode::Backspace, KeyModifiers::NONE)),
+            None,
+            Some(key(KeyCode::Char('y'), KeyModifiers::NONE)),
+            None,
+            Some(key(KeyCode::Char('y'), KeyModifiers::NONE)),
+            None,
+            Some(key(KeyCode::Char('q'), KeyModifiers::NONE)),
+            Some(key(KeyCode::Char('q'), KeyModifiers::NONE)),
+            Some(key(KeyCode::Char('y'), KeyModifiers::NONE)),
+        ],
+        target.clone(),
+    );
+    let mut settings = settings(root.path());
+    settings.disable_delete_confirmation = true;
+    let outcome = run(
+        backend,
+        Box::new(input),
+        settings,
+        Box::new(VirtualClock::new()),
+    )
+    .expect("final directory replacement should trigger a parent rescan");
+    assert!(
+        matches!(outcome, OperationOutcome::Exact(_)),
+        "unexpected outcome: {outcome:?}"
+    );
+    assert!(
+        !target.exists(),
+        "fresh replacement target should be deleted"
+    );
+    assert!(
+        displaced.join("old-child").exists(),
+        "old occupant should remain untouched"
+    );
+}
+
+#[cfg(any(unix, windows))]
+#[test]
+fn changed_plan_during_planning_rescans_before_reprompting() {
+    let root = tempfile::tempdir().expect("runtime root should exist");
+    let target = root.path().join("target");
+    std::fs::write(&target, b"payload").expect("deletion target should be written");
+    let (_, _, backend) = test_backend_factory(80, 24);
+    let input = ReplanInput::planning_change(
+        vec![
+            None,
+            Some(key(KeyCode::Down, KeyModifiers::NONE)),
+            Some(key(KeyCode::Backspace, KeyModifiers::NONE)),
+            None,
+            Some(key(KeyCode::Char('y'), KeyModifiers::NONE)),
+            None,
+            Some(key(KeyCode::Char('q'), KeyModifiers::NONE)),
+            Some(key(KeyCode::Char('q'), KeyModifiers::NONE)),
+            Some(key(KeyCode::Char('y'), KeyModifiers::NONE)),
+        ],
+        target.clone(),
+    );
+    let outcome = run(
+        backend,
+        Box::new(input),
+        settings(root.path()),
+        Box::new(VirtualClock::new()),
+    )
+    .expect("planning drift should trigger a focused rescan");
+    assert!(
+        matches!(outcome, OperationOutcome::Exact(_)),
+        "unexpected outcome: {outcome:?}"
+    );
+    assert!(!target.exists(), "freshly planned target should be deleted");
+}
+
+#[cfg(any(unix, windows))]
+#[test]
+fn missing_plan_target_reports_partial_summary() {
+    let root = tempfile::tempdir().expect("runtime root should exist");
+    let target = root.path().join("target");
+    std::fs::write(&target, b"payload").expect("deletion target should be written");
+    let (_, _, backend) = test_backend_factory(80, 24);
+    let input = ReplanInput::planning_missing(
+        vec![
+            None,
+            Some(key(KeyCode::Down, KeyModifiers::NONE)),
+            Some(key(KeyCode::Backspace, KeyModifiers::NONE)),
+            None,
+            Some(key(KeyCode::Char('q'), KeyModifiers::NONE)),
+            Some(key(KeyCode::Char('y'), KeyModifiers::NONE)),
+        ],
+        target.clone(),
+    );
+    let outcome = run(
+        backend,
+        Box::new(input),
+        settings(root.path()),
+        Box::new(VirtualClock::new()),
+    )
+    .expect("missing planning target should produce a partial summary");
+    let OperationOutcome::Partial {
+        completed_entries,
+        failed_entries,
+        value: summary,
+    } = outcome
+    else {
+        panic!("missing planning target must not return exact: {outcome:?}");
+    };
+    assert_eq!(completed_entries, 0);
+    assert_eq!(failed_entries, 1);
+    assert_eq!(summary.deletion_missing_entries, 1);
+    assert!(!target.exists(), "missing target should remain absent");
+}
+
+#[cfg(any(unix, windows))]
+#[test]
+fn missing_final_validation_reports_partial_summary() {
+    let root = tempfile::tempdir().expect("runtime root should exist");
+    let target = root.path().join("target");
+    std::fs::write(&target, b"payload").expect("deletion target should be written");
+    let (_, _, backend) = test_backend_factory(80, 24);
+    let input = ReplanInput::missing(
+        vec![
+            None,
+            Some(key(KeyCode::Down, KeyModifiers::NONE)),
+            Some(key(KeyCode::Backspace, KeyModifiers::NONE)),
+            None,
+            Some(key(KeyCode::Char('y'), KeyModifiers::NONE)),
+            None,
+            Some(key(KeyCode::Char('q'), KeyModifiers::NONE)),
+            Some(key(KeyCode::Char('q'), KeyModifiers::NONE)),
+            Some(key(KeyCode::Char('q'), KeyModifiers::NONE)),
+            Some(key(KeyCode::Char('y'), KeyModifiers::NONE)),
+        ],
+        target.clone(),
+    );
+    let outcome = run(
+        backend,
+        Box::new(input),
+        settings(root.path()),
+        Box::new(VirtualClock::new()),
+    )
+    .expect("missing final validation should produce a partial summary");
+    let OperationOutcome::Partial {
+        completed_entries,
+        failed_entries,
+        value: summary,
+    } = outcome
+    else {
+        panic!("missing final validation must not return exact: {outcome:?}");
+    };
+    assert_eq!(completed_entries, 0);
+    assert_eq!(failed_entries, 1);
+    assert_eq!(summary.deletion_missing_entries, 1);
+    assert!(!target.exists(), "missing target should remain absent");
+}
+
+#[cfg(unix)]
+#[test]
+fn persistent_directory_change_is_rescanned_before_reprompting() {
+    let root = tempfile::tempdir().expect("runtime root should exist");
+    let target = root.path().join("target");
+    let mutation = target.join("new-child");
+    std::fs::create_dir(&target).expect("deletion directory should be created");
+    std::fs::write(target.join("old-child"), b"old")
+        .expect("initial directory child should be written");
+    let (_, _, backend) = test_backend_factory(80, 24);
+    let input = ReplanInput::new(
+        vec![
+            None,
+            Some(key(KeyCode::Down, KeyModifiers::NONE)),
+            Some(key(KeyCode::Backspace, KeyModifiers::NONE)),
+            None,
+            Some(key(KeyCode::Char('y'), KeyModifiers::NONE)),
+            None,
+            Some(key(KeyCode::Char('y'), KeyModifiers::NONE)),
+            None,
+            Some(key(KeyCode::Char('q'), KeyModifiers::NONE)),
+            Some(key(KeyCode::Char('q'), KeyModifiers::NONE)),
+            Some(key(KeyCode::Char('y'), KeyModifiers::NONE)),
+        ],
+        mutation,
+    );
+    let mut settings = settings(root.path());
+    settings.disable_delete_confirmation = true;
+    let outcome = run(
+        backend,
+        Box::new(input),
+        settings,
+        Box::new(VirtualClock::new()),
+    )
+    .expect("persistent directory change should trigger a focused rescan");
+    assert!(
+        matches!(outcome, OperationOutcome::Exact(_)),
+        "unexpected outcome: {outcome:?}"
+    );
+    assert!(
+        !target.exists(),
+        "freshly planned directory should be deleted; outcome: {outcome:?}"
     );
 }
 

--- a/src/ui/display.rs
+++ b/src/ui/display.rs
@@ -935,7 +935,7 @@ mod tests {
         tree.add_entry(&metadata, &path, identity)
             .expect("fixture should be added")
             .expect("fixture should remain materialized");
-        tree.complete_directory(root.path())
+        tree.complete_directory(root.path(), None)
             .expect("fixture root should complete");
         tree.finalize().expect("fixture tree should finalize");
 


### PR DESCRIPTION
## Changes
- retain and validate resolved scan-root identity before scans, planning, confirmation, and execution
- revalidate plans at confirmation and automatically replan stale confirmations
- require generated challenges for hostile file names
- rebuild identity ownership and Shared/Other/reclaimable metrics after partial deletion
- count allocated bytes only when the last known hard link is deleted

## Verification
- `cargo check --lib --bin excise`
- `cargo clippy --lib --bin excise --all-targets -- -D warnings`
- focused deletion, arena, FileTree, worker, app, runtime, and UI deletion tests

Signed-off-by: Tom Larcher <tom.larcher@gmail.com>