### PR TITLE
test: make scanner replacement race deterministic

### DIFF
--- a/src/runtime/scanner.rs
+++ b/src/runtime/scanner.rs
@@ -805,6 +805,9 @@ fn validate_directory_task(
 #[cfg(all(test, unix))]
 static VALIDATION_REPLACEMENT: std::sync::OnceLock<Mutex<Option<(PathBuf, PathBuf, PathBuf)>>> =
     std::sync::OnceLock::new();
+#[cfg(all(test, unix))]
+static BATCH_REPLACEMENT: std::sync::OnceLock<Mutex<Option<(PathBuf, PathBuf, PathBuf)>>> =
+    std::sync::OnceLock::new();
 
 #[cfg(test)]
 fn maybe_replace_after_validation(path: &Path) {
@@ -833,9 +836,41 @@ fn maybe_replace_after_validation(path: &Path) {
     let _ = path;
 }
 
+#[cfg(test)]
+fn maybe_replace_after_batch(path: &Path) {
+    #[cfg(unix)]
+    {
+        let replacement = BATCH_REPLACEMENT.get_or_init(|| Mutex::new(None));
+        let mut pending = replacement
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let Some((expected_path, displaced_path, target_path)) = pending.take() else {
+            return;
+        };
+        if expected_path != path {
+            *pending = Some((expected_path, displaced_path, target_path));
+            return;
+        }
+        drop(pending);
+        fs::rename(path, displaced_path).expect("original directory should be displaced");
+        std::os::unix::fs::symlink(target_path, path)
+            .expect("replacement symlink should be created");
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+}
+
 #[cfg(all(test, unix))]
 fn replace_after_next_validation(path: PathBuf, displaced: PathBuf, target: PathBuf) {
     *VALIDATION_REPLACEMENT
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some((path, displaced, target));
+}
+
+#[cfg(all(test, unix))]
+pub(super) fn replace_after_next_batch(path: PathBuf, displaced: PathBuf, target: PathBuf) {
+    *BATCH_REPLACEMENT
         .get_or_init(|| Mutex::new(None))
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner) = Some((path, displaced, target));
@@ -1249,6 +1284,9 @@ fn flush_frame(
         frame.directories.clear();
         return false;
     }
+    // Let replacement-race fixtures mutate only after the batch is observable.
+    #[cfg(test)]
+    maybe_replace_after_batch(&frame.task.path);
     for task in std::mem::take(&mut frame.directories) {
         if let Err(error) = queue.schedule(task) {
             failed.store(true, Ordering::Release);

--- a/src/runtime/worker.rs
+++ b/src/runtime/worker.rs
@@ -895,7 +895,6 @@ mod tests {
     #[test]
     fn scanner_stops_before_following_a_replaced_root() {
         use crate::native_path::identity_for;
-        use std::os::unix::fs::symlink;
 
         let parent = tempfile::tempdir().expect("scan parent should exist");
         let scan_root = parent.path().join("scan-root");
@@ -913,11 +912,12 @@ mod tests {
         let identity = identity_for(&scan_root, &metadata)
             .expect("root identity should be readable")
             .expect("root should not be a symbolic link");
+        scanner::replace_after_next_batch(scan_root.clone(), original, outside.clone());
 
         let mut scanner_options = options(&scan_root, 1);
         scanner_options.root_identity = Some(identity);
         let workers = WorkerPool::start(scanner_options, 1).expect("workers should start");
-        let mut replaced = false;
+        let mut saw_batch = false;
         let mut saw_root_change = false;
         let mut saw_replacement = false;
         loop {
@@ -927,16 +927,10 @@ mod tests {
                 .expect("scanner should produce completion")
             {
                 WorkerEvent::ScanBatch { entries } => {
+                    saw_batch = true;
                     saw_replacement |= entries
                         .iter()
                         .any(|entry| entry.path == outside.join("replacement"));
-                    if !replaced {
-                        std::fs::rename(&scan_root, &original)
-                            .expect("original root should be displaced");
-                        symlink(&outside, &scan_root)
-                            .expect("replacement symlink should be created");
-                        replaced = true;
-                    }
                 }
                 WorkerEvent::ScanFailed { message, .. } => {
                     saw_root_change |= message.contains("during traversal");
@@ -952,7 +946,10 @@ mod tests {
                 | WorkerEvent::DeletionFinished { .. } => {}
             }
         }
-        assert!(replaced, "test must replace root after the first batch");
+        assert!(
+            saw_batch,
+            "test must emit a batch before replacing the root"
+        );
         assert!(
             saw_root_change,
             "root replacement should emit an explicit failure"


### PR DESCRIPTION
## Problem

The merged main native verification run failed on macOS ARM in `runtime::worker::tests::scanner_stops_before_following_a_replaced_root`. The test replaced the root after receiving a batch, but the scanner could finish before the test thread ran the replacement.

## Change

Use a test-only scanner hook that performs the replacement immediately after the batch is delivered. The regression test now verifies that a batch was emitted, root replacement produced an explicit traversal failure, and the replacement target was never scanned. Production behavior is unchanged outside `cfg(test)`.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` (253 passed)