### PR TITLE
ci: avoid SIGPIPE in release archive checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -435,19 +435,19 @@ jobs:
             aarch64-apple-darwin; do
             archive="excise-${target}-v${EXPECTED_VERSION}.tar.gz"
             root="excise-${target}-v${EXPECTED_VERSION}"
-            tar -tzf "$archive" | grep -Fqx "$root/excise"
-            tar -tzf "$archive" | grep -Fqx "$root/LICENSE"
-            tar -tzf "$archive" | grep -Fqx "$root/generated/man/excise.1"
-            tar -tzf "$archive" | grep -Fqx "$root/schemas/scan-report.schema.json"
+            tar -tzf "$archive" | grep -Fx "$root/excise" >/dev/null
+            tar -tzf "$archive" | grep -Fx "$root/LICENSE" >/dev/null
+            tar -tzf "$archive" | grep -Fx "$root/generated/man/excise.1" >/dev/null
+            tar -tzf "$archive" | grep -Fx "$root/schemas/scan-report.schema.json" >/dev/null
           done
           for target in x86_64-pc-windows-msvc aarch64-pc-windows-msvc; do
             archive="excise-${target}-v${EXPECTED_VERSION}.zip"
             root="excise-${target}-v${EXPECTED_VERSION}"
             unzip -t "$archive" >/dev/null
-            unzip -Z1 "$archive" | grep -Fqx "$root/excise.exe"
-            unzip -Z1 "$archive" | grep -Fqx "$root/LICENSE"
-            unzip -Z1 "$archive" | grep -Fqx "$root/generated/man/excise.1"
-            unzip -Z1 "$archive" | grep -Fqx "$root/schemas/scan-report.schema.json"
+            unzip -Z1 "$archive" | grep -Fx "$root/excise.exe" >/dev/null
+            unzip -Z1 "$archive" | grep -Fx "$root/LICENSE" >/dev/null
+            unzip -Z1 "$archive" | grep -Fx "$root/generated/man/excise.1" >/dev/null
+            unzip -Z1 "$archive" | grep -Fx "$root/schemas/scan-report.schema.json" >/dev/null
           done
           for subject in "${archives[@]}" checksums.sha256 excise.spdx.json; do
             gh attestation verify "$subject" \


### PR DESCRIPTION
## Problem

The approved `v0.1.1` tag workflow failed in `Promote reviewed candidate bundle` before publication. With `set -o pipefail`, `tar -tzf ... | grep -Fqx ...` let `grep -q` close the pipe early; `tar` then reported `stdout: write error`.

No GitHub Release, crates.io publication, or Homebrew Tap update occurred.

## Change

Use non-early-closing exact membership checks (`grep -Fx ... >/dev/null`) for tar and zip archive entries. The full archive stream is consumed, so the verifier remains strict without treating SIGPIPE as a validation failure.

## Verification

- `actionlint .github/workflows/*.yml`
- `git diff --check`
- The failed run logs identify the replaced commands as the sole failure point.