### PR TITLE
docs: record the published `v0.1.1` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@ Excise preserves the historical Diskonaut changelog below. Diskonaut versions an
 
 ## [Unreleased]
 
-_The planned 0.1.1 release remains unpublished pending verification._
+_No unreleased changes._
 
-## [0.1.1] - Unreleased
+## [0.1.1] - 2026-08-24
 
 ### Added
 
-* Prepared the `excise` crate for early testing; publication is gated on release verification, and its public library surface is provisional and may change before 1.0.
+* Published the first early-testing release through GitHub archives, crates.io, the first-party Homebrew Tap, cargo-binstall metadata, and the tagged Nix flake. Its public library surface and destructive behavior remain provisional until 1.0.
 
 ## [0.1.0] - 2026-08-21
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Excise is an independent successor to [Diskonaut](https://github.com/imsnif/disk
 > Excise permanently deletes selected filesystem entries. There is no trash or undo. Use it only on data you can safely remove.
 
 > [!IMPORTANT]
-> The planned Excise **0.1.1** release is for early testing. Start with a disposable directory, keep the default confirmation enabled, and read the [deletion contract](docs/safety/deletion.md) before selecting anything you might need.
+The published Excise **0.1.1** release is for early testing. Start with a disposable directory, keep the default confirmation enabled, and read the [deletion contract](docs/safety/deletion.md) before selecting anything you might need.
 
 ## Why Excise
 
@@ -31,14 +31,14 @@ Excise is an independent successor to [Diskonaut](https://github.com/imsnif/disk
 
 ## Quick Start
 
-All release-channel commands below target the planned **0.1.1** early-testing release. Do not run them until the [release process](docs/releasing.md) announces publication; before then, use the protected `main` source build below.
+All release-channel commands below target the published **0.1.1** early-testing release. Before using them, read the [release process](docs/releasing.md) and follow the disposable-fixture guidance.
 
 ### Install it
 
 <details>
 <summary><strong>Homebrew (macOS)</strong></summary>
 
-After the `0.1.1` release is promoted, the first-party Homebrew tap will carry the formula:
+The first-party Homebrew tap carries the formula:
 
 ```console
 brew tap findyourexit/tap
@@ -51,7 +51,7 @@ excise --version  # excise 0.1.1
 <details>
 <summary><strong>crates.io</strong></summary>
 
-After the crate is published, install the `0.1.1` package with the locked dependency graph:
+The `0.1.1` package is published on crates.io; install it with the locked dependency graph:
 
 ```console
 cargo install excise --version 0.1.1 --locked
@@ -63,7 +63,7 @@ excise --version  # excise 0.1.1
 <details>
 <summary><strong>GitHub Release</strong></summary>
 
-After the GitHub release is created, download the archive for your platform from the [0.1.1 GitHub Release](https://github.com/findyourexit/excise/releases/tag/v0.1.1). For example, Apple silicon macOS:
+Download the archive for your platform from the [published 0.1.1 GitHub Release](https://github.com/findyourexit/excise/releases/tag/v0.1.1). For example, Apple silicon macOS:
 The provenance check requires the GitHub CLI (`gh`) and a GitHub API-authenticated session.
 
 ```console
@@ -98,7 +98,7 @@ The release provides archives for AArch64 and x86_64 macOS, AArch64 and x86_64 L
 <details>
 <summary><strong>Build from source</strong></summary>
 
-Before `v0.1.1` is published, build the current protected `main` source:
+To build the current protected `main` source:
 
 ```console
 git clone --branch main --depth 1 https://github.com/findyourexit/excise.git
@@ -107,14 +107,14 @@ cargo install --path . --locked
 excise --version
 ```
 
-After publication, replace `main` with `v0.1.1` to reproduce the exact release commit.
+To reproduce the exact published release commit, replace `main` with `v0.1.1` in the clone command.
 
 </details>
 
 <details>
 <summary><strong>Nix</strong></summary>
 
-After the `v0.1.1` release is announced, run or install the flake from that tag without updating its lock file:
+Run or install the published `v0.1.1` flake without updating its lock file:
 
 ```console
 nix run github:findyourexit/excise/v0.1.1 -- --format table /path/to/inspect

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@ Excise performs permanent filesystem deletion, so data-loss defects are treated 
 
 ## Supported versions
 
-Excise supports the latest stable release, currently `0.1.0`. The planned `0.1.1` release is early testing and is not a stable support promise; do not trust either line with irreplaceable data.
+Excise supports the latest stable release, currently `0.1.0`. The published `0.1.1` release is for early testing and is not a stable support promise; do not trust either line with irreplaceable data.
 
 | Version | Status |
 |---|---|

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -2,7 +2,7 @@
 
 ## 0.1.1 early testing
 
-The planned `0.1.1` release is for early testing. Support is best effort, the public library API may change before 1.0, and no release build should be trusted with irreplaceable data. Start with [Getting started](docs/getting-started.md) and a disposable fixture.
+The published `0.1.1` release is for early testing. Support is best effort, the public library API may change before 1.0, and no release build should be trusted with irreplaceable data. Start with [Getting started](docs/getting-started.md) and a disposable fixture.
 
 ## Usage questions
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ Excise permanently deletes selected filesystem entries. There is no trash or und
 
 ## The 0.1.1 early-testing release
 
-The planned `0.1.1` release is for early testing. Its public library API and destructive behavior are provisional; do not use it on irreplaceable data, and do not infer stable support from a successful install. Verify the version and read the [permanent-deletion contract](safety/deletion.md) before making a scan or deletion plan.
+The published `0.1.1` release is for early testing. Its public library API and destructive behavior are provisional; do not use it on irreplaceable data, and do not infer stable support from a successful install. Verify the version and read the [permanent-deletion contract](safety/deletion.md) before making a scan or deletion plan.
 
 The project is independent from Diskonaut. Tags `0.1.0` through `0.11.0` are preserved Diskonaut releases, not Excise releases; do not move, reuse, or treat those tags as an Excise installation.
 
@@ -42,14 +42,14 @@ nix build
 
 ## Install 0.1.1 from a release channel
 
-Use these commands only after the `0.1.1` release is announced through the [release process](releasing.md). The crates.io package compiles locally; it is not one of the prebuilt GitHub archives:
+The `0.1.1` crates.io package is published and compiles locally; it is not one of the prebuilt GitHub archives:
 
 ```console
 cargo install excise --version 0.1.1 --locked
 excise --version
 ```
 
-When the release is promoted, the first-party binary formula will be distributed through the external [findyourexit/homebrew-tap](https://github.com/findyourexit/homebrew-tap), not Homebrew Core:
+The first-party binary formula is published through the external [findyourexit/homebrew-tap](https://github.com/findyourexit/homebrew-tap), not Homebrew Core:
 
 ```console
 brew tap findyourexit/tap https://github.com/findyourexit/homebrew-tap.git

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,16 +1,16 @@
 # Release process
 
-This runbook defines the planned `0.1.1` early-testing release contract and the evidence required before publication. It is a procedure, not authorization; nothing in this document means that `0.1.1` has already been published.
+This runbook records the published `0.1.1` early-testing release contract and the evidence required for publication and future corrective releases. It is a procedure, not authorization.
 
 ## The 0.1.1 contract
 
-The planned `0.1.1` release is for early testing. It is the first release contract that permits publishing the `excise` crate, while the public library API and destructive behavior remain provisional until the project declares a stable line. Test only with disposable data; do not treat this release as suitable for irreplaceable files.
+The published `0.1.1` release is for early testing. Its public library API and destructive behavior remain provisional until the project declares a stable line. Test only with disposable data; do not treat this release as suitable for irreplaceable files.
 
 The release commit and candidate must agree on all of the following:
 
 - `Cargo.toml`, `Cargo.lock`, the CLI version, and the changelog identify `0.1.1`;
 - the crate is publishable (the release metadata must not set `publish = false`);
-- the annotated `v0.1.1` tag, when created, points to the exact protected `main` commit that passed verification;
+- the annotated `v0.1.1` tag points to the exact protected `main` commit that passed verification;
 - six target archives, their SHA-256 manifest, the SPDX JSON SBOM, and GitHub build attestations describe that same commit and version;
 - the first-party Homebrew tap formula refers only to those immutable GitHub release assets; and
 - the tagged Nix flake and cargo-binstall metadata resolve the same immutable `0.1.1` release.
@@ -145,14 +145,16 @@ The candidate contains six immutable target archives, `checksums.sha256`, and `e
 Confirm that every archive contains its target binary, `LICENSE`, `generated/man/excise.1`, and `schemas/scan-report.schema.json`; the SBOM and provenance files are candidate-bundle evidence and are not silently substituted for an archive. The workflow retains candidate artifacts for one day. Retention is a validation convenience, not publication or durable distribution.
 ## Promotion order and publication semantics
 
-After local and hosted evidence has been reviewed and approved, create the annotated `v0.1.1` tag on the verified protected commit with the reviewed candidate run ID in its message, then push it:
+The approved `0.1.1` publication used:
 
-```console
-git tag -a v0.1.1 "$source_sha" -m "candidate-run-id: $run_id"
-git push origin v0.1.1
-```
+- source commit: `59eb0d17295eaef99305521651107c28dce27613`;
+- candidate workflow run: [32733774029](https://github.com/findyourexit/excise/actions/runs/32733774029);
+- annotated tag: `v0.1.1`, carrying `candidate-run-id: 32733774029`;
+- publication recovery run: [32742153533](https://github.com/findyourexit/excise/actions/runs/32742153533).
 
-The push-triggered workflow reads that immutable tag annotation, requires the exact candidate run to be successful for the tagged source SHA, verifies its checksums, archive contents, SBOM, and attestations, and promotes those exact candidate bytes without rebuilding:
+The tag was never moved. The recovery workflow verified and promoted the exact candidate bytes without rebuilding them.
+
+The publication semantics are:
 
 1. The `release` job creates the GitHub release from the promoted candidate bundle. It reuses an existing published release only after the exact tag object, complete asset set, and every asset checksum match; published mismatches and unexpected drafts are refused, while a matching non-prerelease draft may be repaired with the reverified candidate assets.
 2. The `publish-crate` job publishes the crate once after the release job succeeds. Do not run `cargo publish` manually; the job accepts an existing version only after matching its registry checksum and non-yanked state, and otherwise fails before retrying.


### PR DESCRIPTION
## Change

Now that `v0.1.1` is published, update the public release documentation and changelog to distinguish the published early-testing release from the supported stable line.

Updated:

- `CHANGELOG.md` release status and date;
- README installation and release-channel guidance;
- getting-started publication wording;
- `SECURITY.md` and `SUPPORT.md` release status; and
- `docs/releasing.md` durable publication evidence.

No product or safety behavior changes.