### PR TITLE
test: accept safe changed fuzz plans

### DIFF
--- a/fuzz/fuzz_targets/deletion_plan.rs
+++ b/fuzz/fuzz_targets/deletion_plan.rs
@@ -111,6 +111,9 @@ fn exercise(data: &[u8]) -> Result<(), Box<dyn Error>> {
             assert_eq!(classified as usize, report.entries.len());
             assert_eq!(report.precise, !hard.load(std::sync::atomic::Ordering::Acquire));
         }
+        (0, Err(DeletionPlanError::Changed)) => {
+            // Rejecting an inconsistent snapshot is a valid safety outcome.
+        }
         (1 | 2, Err(DeletionPlanError::Changed)) => {}
         (3, Err(DeletionPlanError::MemoryLimit { limit: 1 })) => {}
         (mode, result) => panic!("unexpected deletion plan result for mode {mode}: {result:?}"),


### PR DESCRIPTION
## Problem

The tagged fuzz smoke run found a panic in `fuzz_targets/deletion_plan.rs` for mode 0 when `build_plan_cancellable` returned `Err(Changed)`. That is a safe deletion-plan rejection, not a product panic; the fuzz oracle treated it as impossible.

## Change

Accept `DeletionPlanError::Changed` in the no-mutation fuzz mode while retaining the panic for unclassified results. This keeps the fuzz target focused on unexpected behavior and preserves its execution/report invariants for successful plans.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --manifest-path fuzz/Cargo.toml --locked`
- Reproduced the archived failing input with `cargo +nightly-2026-08-18 fuzz run deletion_plan /tmp/excise-fuzz-repro -- -runs=1 -max_len=256`; it now completes without a panic.