### PR TITLE
release: prepare `v0.1.2` corrective release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Excise preserves the historical Diskonaut changelog below. Diskonaut versions an
 
 _No unreleased changes._
 
+## [0.1.2] - 2026-08-25
+
+### Fixed
+
+* Treat conflicting hard-link observations as unknown and propagate conservative reclaimable bounds.
+* Accept invalidated deletion plans in fuzz validation without classifying safe rejections as crashes.
+
 ## [0.1.1] - 2026-08-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Surgical terminal storage navigator"
 keywords = ["disk-usage", "filesystem", "terminal", "tui"]
 categories = ["command-line-utilities", "filesystem"]
 
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Aram Drevekenin <aram@poor.dev>", "Tom Larcher <tom.larcher@gmail.com>"]
 readme = "README.md"
 homepage = "https://github.com/findyourexit/excise"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Excise is an independent successor to [Diskonaut](https://github.com/imsnif/disk
 > Excise permanently deletes selected filesystem entries. There is no trash or undo. Use it only on data you can safely remove.
 
 > [!IMPORTANT]
-The published Excise **0.1.1** release is for early testing. Start with a disposable directory, keep the default confirmation enabled, and read the [deletion contract](docs/safety/deletion.md) before selecting anything you might need.
+The published Excise **0.1.2** release is a corrective early-testing release. Start with a disposable directory, keep the default confirmation enabled, and read the [deletion contract](docs/safety/deletion.md) before selecting anything you might need.
 
 ## Why Excise
 
@@ -31,7 +31,7 @@ The published Excise **0.1.1** release is for early testing. Start with a dispos
 
 ## Quick Start
 
-All release-channel commands below target the published **0.1.1** early-testing release. Before using them, read the [release process](docs/releasing.md) and follow the disposable-fixture guidance.
+All release-channel commands below target the published **0.1.2** corrective early-testing release. Before using them, read the [release process](docs/releasing.md) and follow the disposable-fixture guidance.
 
 ### Install it
 
@@ -43,7 +43,7 @@ The first-party Homebrew tap carries the formula:
 ```console
 brew tap findyourexit/tap
 brew install findyourexit/tap/excise
-excise --version  # excise 0.1.1
+excise --version  # excise 0.1.2
 ```
 
 </details>
@@ -51,11 +51,11 @@ excise --version  # excise 0.1.1
 <details>
 <summary><strong>crates.io</strong></summary>
 
-The `0.1.1` package is published on crates.io; install it with the locked dependency graph:
+The `0.1.2` package is published on crates.io; install it with the locked dependency graph:
 
 ```console
-cargo install excise --version 0.1.1 --locked
-excise --version  # excise 0.1.1
+cargo install excise --version 0.1.2 --locked
+excise --version  # excise 0.1.2
 ```
 
 </details>
@@ -63,7 +63,7 @@ excise --version  # excise 0.1.1
 <details>
 <summary><strong>GitHub Release</strong></summary>
 
-Download the archive for your platform from the [published 0.1.1 GitHub Release](https://github.com/findyourexit/excise/releases/tag/v0.1.1). For example, Apple silicon macOS:
+Download the archive for your platform from the [published 0.1.2 GitHub Release](https://github.com/findyourexit/excise/releases/tag/v0.1.2). For example, Apple silicon macOS:
 The provenance check requires the GitHub CLI (`gh`) and a GitHub API-authenticated session.
 
 ```console
@@ -73,21 +73,21 @@ The provenance check requires the GitHub CLI (`gh`) and a GitHub API-authenticat
   readonly download_dir
   trap 'rm -rf -- "$download_dir"' EXIT
   cd "$download_dir"
-  curl --fail --location --remote-name https://github.com/findyourexit/excise/releases/download/v0.1.1/excise-aarch64-apple-darwin-v0.1.1.tar.gz
-  curl --fail --location --remote-name https://github.com/findyourexit/excise/releases/download/v0.1.1/checksums.sha256
+  curl --fail --location --remote-name https://github.com/findyourexit/excise/releases/download/v0.1.2/excise-aarch64-apple-darwin-v0.1.2.tar.gz
+  curl --fail --location --remote-name https://github.com/findyourexit/excise/releases/download/v0.1.2/checksums.sha256
   shasum -a 256 --ignore-missing --check checksums.sha256
-  source_sha="$(git ls-remote --exit-code https://github.com/findyourexit/excise.git 'refs/tags/v0.1.1^{}' | cut -f1)"
+  source_sha="$(git ls-remote --exit-code https://github.com/findyourexit/excise.git 'refs/tags/v0.1.2^{}' | cut -f1)"
   if [[ ! "$source_sha" =~ ^[0-9a-f]{40}$ ]]; then
-    echo "could not resolve the v0.1.1 tag commit" >&2
+    echo "could not resolve the v0.1.2 tag commit" >&2
     exit 1
   fi
-  gh attestation verify excise-aarch64-apple-darwin-v0.1.1.tar.gz \
+  gh attestation verify excise-aarch64-apple-darwin-v0.1.2.tar.gz \
     --repo findyourexit/excise \
     --signer-workflow findyourexit/excise/.github/workflows/release.yml \
     --source-digest "$source_sha" \
     --source-ref refs/heads/main
-  tar --extract --gzip --file excise-aarch64-apple-darwin-v0.1.1.tar.gz
-  ./excise-aarch64-apple-darwin-v0.1.1/excise --version  # excise 0.1.1
+  tar --extract --gzip --file excise-aarch64-apple-darwin-v0.1.2.tar.gz
+  ./excise-aarch64-apple-darwin-v0.1.2/excise --version  # excise 0.1.2
 )
 ```
 
@@ -107,19 +107,19 @@ cargo install --path . --locked
 excise --version
 ```
 
-To reproduce the exact published release commit, replace `main` with `v0.1.1` in the clone command.
+To reproduce the exact published release commit, replace `main` with `v0.1.2` in the clone command.
 
 </details>
 
 <details>
 <summary><strong>Nix</strong></summary>
 
-Run or install the published `v0.1.1` flake without updating its lock file:
+Run or install the published `v0.1.2` flake without updating its lock file:
 
 ```console
-nix run github:findyourexit/excise/v0.1.1 -- --format table /path/to/inspect
-nix profile install github:findyourexit/excise/v0.1.1
-excise --version  # excise 0.1.1
+nix run github:findyourexit/excise/v0.1.2 -- --format table /path/to/inspect
+nix profile install github:findyourexit/excise/v0.1.2
+excise --version  # excise 0.1.2
 ```
 
 </details>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,12 @@ Excise performs permanent filesystem deletion, so data-loss defects are treated 
 
 ## Supported versions
 
-Excise supports the latest stable release, currently `0.1.0`. The published `0.1.1` release is for early testing and is not a stable support promise; do not trust either line with irreplaceable data.
+Excise supports the latest stable release, currently `0.1.0`. The published `0.1.2` release is a corrective early-testing release; `0.1.1` is superseded. Do not trust either early-testing line with irreplaceable data.
 
 | Version | Status |
 |---|---|
-| `0.1.1` | Early testing; best-effort support |
+| `0.1.2` | Corrective early testing; best-effort support |
+| `0.1.1` | Superseded early testing; upgrade to `0.1.2` |
 | `0.1.0` | Supported stable line |
 | `main` | Development only |
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,8 +1,8 @@
 # Support
 
-## 0.1.1 early testing
+## 0.1.2 corrective early testing
 
-The published `0.1.1` release is for early testing. Support is best effort, the public library API may change before 1.0, and no release build should be trusted with irreplaceable data. Start with [Getting started](docs/getting-started.md) and a disposable fixture.
+The published `0.1.2` release includes corrective accounting and fuzz-validation fixes but remains early testing. Support is best effort, the public library API may change before 1.0, and no release build should be trusted with irreplaceable data. Start with [Getting started](docs/getting-started.md) and a disposable fixture.
 
 ## Usage questions
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -43,9 +43,9 @@ Run the actual terminal lifecycle tests with:
 cargo test --test pty_smoke --locked
 ```
 
-## 0.1.1 candidate checks
+## 0.1.2 candidate checks
 
-The `0.1.1` release is early testing, not a stable API or a promise that destructive behavior is safe for irreplaceable data. From a clean checkout at the release commit, run the focused checks before requesting the hosted candidate:
+The `0.1.2` corrective release remains early testing, not a stable API or a promise that destructive behavior is safe for irreplaceable data. From a clean checkout at the release commit, run the focused checks before requesting the hosted candidate:
 
 ```console
 (
@@ -74,7 +74,7 @@ if command -v sha256sum >/dev/null 2>&1; then
 else
   dispatch_id="$(printf '%s' "$dispatch_seed" | shasum -a 256 | cut -c1-32)"
 fi
-run_url="$(gh workflow run release.yml --repo findyourexit/excise --ref main --field version=0.1.1 --field source_sha="$source_sha" --field dispatch_id="$dispatch_id")"
+run_url="$(gh workflow run release.yml --repo findyourexit/excise --ref main --field version=0.1.2 --field source_sha="$source_sha" --field dispatch_id="$dispatch_id")"
 run_id="${run_url##*/}"
 if [[ ! "$run_id" =~ ^[0-9]+$ ]]; then
   run_id="$(
@@ -135,29 +135,29 @@ The workflow rejects a moving or unprotected source ref, checks the exact SHA an
   fi
   jq -e '.packages | length > 1' excise.spdx.json
   jq -e '.packages[] | select(.name == "serde")' excise.spdx.json
-  jq -e --arg version 0.1.1 '([.packages[] | select(.name == "excise" and .versionInfo == $version)] | length == 1)' excise.spdx.json
+  jq -e --arg version 0.1.2 '([.packages[] | select(.name == "excise" and .versionInfo == $version)] | length == 1)' excise.spdx.json
   archives=(
-    excise-x86_64-unknown-linux-gnu-v0.1.1.tar.gz
-    excise-aarch64-unknown-linux-gnu-v0.1.1.tar.gz
-    excise-x86_64-apple-darwin-v0.1.1.tar.gz
-    excise-aarch64-apple-darwin-v0.1.1.tar.gz
-    excise-x86_64-pc-windows-msvc-v0.1.1.zip
-    excise-aarch64-pc-windows-msvc-v0.1.1.zip
+    excise-x86_64-unknown-linux-gnu-v0.1.2.tar.gz
+    excise-aarch64-unknown-linux-gnu-v0.1.2.tar.gz
+    excise-x86_64-apple-darwin-v0.1.2.tar.gz
+    excise-aarch64-apple-darwin-v0.1.2.tar.gz
+    excise-x86_64-pc-windows-msvc-v0.1.2.zip
+    excise-aarch64-pc-windows-msvc-v0.1.2.zip
   )
   for archive in "${archives[@]}"; do
     test -s "$archive"
   done
   for target in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu x86_64-apple-darwin aarch64-apple-darwin; do
-    archive="excise-${target}-v0.1.1.tar.gz"
-    root="excise-${target}-v0.1.1"
+    archive="excise-${target}-v0.1.2.tar.gz"
+    root="excise-${target}-v0.1.2"
     tar -tzf "$archive" | grep -Fqx "$root/excise"
     tar -tzf "$archive" | grep -Fqx "$root/LICENSE"
     tar -tzf "$archive" | grep -Fqx "$root/generated/man/excise.1"
     tar -tzf "$archive" | grep -Fqx "$root/schemas/scan-report.schema.json"
   done
   for target in x86_64-pc-windows-msvc aarch64-pc-windows-msvc; do
-    archive="excise-${target}-v0.1.1.zip"
-    root="excise-${target}-v0.1.1"
+    archive="excise-${target}-v0.1.2.zip"
+    root="excise-${target}-v0.1.2"
     unzip -t "$archive" >/dev/null
     unzip -Z1 "$archive" | grep -Fqx "$root/excise.exe"
     unzip -Z1 "$archive" | grep -Fqx "$root/LICENSE"
@@ -177,8 +177,8 @@ The workflow rejects a moving or unprotected source ref, checks the exact SHA an
 After reviewing the candidate, create the annotated release tag with the reviewed candidate run ID in its message, then push it:
 
 ```console
-git tag -a v0.1.1 "$source_sha" -m "candidate-run-id: $run_id"
-git push origin v0.1.1
+git tag -a v0.1.2 "$source_sha" -m "candidate-run-id: $run_id"
+git push origin v0.1.2
 ```
 
 The push-triggered workflow requires that exact annotated-tag candidate ID; never substitute a different candidate run or a lightweight tag.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,9 +2,9 @@
 
 Excise permanently deletes selected filesystem entries. There is no trash or undo. Begin with a disposable directory.
 
-## The 0.1.1 early-testing release
+## The 0.1.2 corrective early-testing release
 
-The published `0.1.1` release is for early testing. Its public library API and destructive behavior are provisional; do not use it on irreplaceable data, and do not infer stable support from a successful install. Verify the version and read the [permanent-deletion contract](safety/deletion.md) before making a scan or deletion plan.
+The published `0.1.2` release includes corrective accounting and fuzz-validation fixes but remains early testing. Its public library API and destructive behavior are provisional; do not use it on irreplaceable data, and do not infer stable support from a successful install. Verify the version and read the [permanent-deletion contract](safety/deletion.md) before making a scan or deletion plan.
 
 The project is independent from Diskonaut. Tags `0.1.0` through `0.11.0` are preserved Diskonaut releases, not Excise releases; do not move, reuse, or treat those tags as an Excise installation.
 
@@ -40,12 +40,12 @@ nix build
 ./result/bin/excise /path/to/inspect
 ```
 
-## Install 0.1.1 from a release channel
+## Install 0.1.2 from a release channel
 
-The `0.1.1` crates.io package is published and compiles locally; it is not one of the prebuilt GitHub archives:
+The `0.1.2` crates.io package is published and compiles locally; it is not one of the prebuilt GitHub archives:
 
 ```console
-cargo install excise --version 0.1.1 --locked
+cargo install excise --version 0.1.2 --locked
 excise --version
 ```
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,8 +1,8 @@
 # Release process
 
-This runbook records the published `0.1.1` early-testing release contract and the evidence required for publication and future corrective releases. It is a procedure, not authorization.
+This runbook records the published `0.1.1` early-testing release contract, the corrective `0.1.2` release contract, and the evidence required for future corrective releases. It is a procedure, not authorization.
 
-## The 0.1.1 contract
+## The 0.1.1 contract (historical)
 
 The published `0.1.1` release is for early testing. Its public library API and destructive behavior remain provisional until the project declares a stable line. Test only with disposable data; do not treat this release as suitable for irreplaceable files.
 
@@ -16,6 +16,10 @@ The release commit and candidate must agree on all of the following:
 - the tagged Nix flake and cargo-binstall metadata resolve the same immutable `0.1.1` release.
 
 The release does not enable Scoop, WinGet, Homebrew Core, or any other package channel beyond the first-party Homebrew tap, tagged Nix flake, crates.io, and cargo-binstall metadata. Templates under `packaging/` are validation inputs unless a separately approved channel promotion says otherwise. The source formula at `packaging/homebrew-core/excise.rb.in` is for a possible future Homebrew Core submission; it is not the first-party tap formula.
+
+## The 0.1.2 corrective release
+
+The corrective `0.1.2` release contains the post-`0.1.1` accounting hardening and fuzz-oracle fix. It remains an early-testing release: its public library API and destructive behavior are provisional. Use `0.1.2` and `v0.1.2` in the active candidate, verification, and promotion procedure below; the `0.1.1` publication record remains historical and immutable.
 
 ## Preconditions and clean tree
 
@@ -68,7 +72,7 @@ if command -v sha256sum >/dev/null 2>&1; then
 else
   dispatch_id="$(printf '%s' "$dispatch_seed" | shasum -a 256 | cut -c1-32)"
 fi
-run_url="$(gh workflow run release.yml --repo findyourexit/excise --ref main --field version=0.1.1 --field source_sha="$source_sha" --field dispatch_id="$dispatch_id")"
+run_url="$(gh workflow run release.yml --repo findyourexit/excise --ref main --field version=0.1.2 --field source_sha="$source_sha" --field dispatch_id="$dispatch_id")"
 run_id="${run_url##*/}"
 if [[ ! "$run_id" =~ ^[0-9]+$ ]]; then
   run_id="$(
@@ -129,7 +133,7 @@ The candidate contains six immutable target archives, `checksums.sha256`, and `e
   fi
   jq -e '.packages | length > 1' excise.spdx.json
   jq -e '.packages[] | select(.name == "serde")' excise.spdx.json
-  jq -e --arg version 0.1.1 '([.packages[] | select(.name == "excise" and .versionInfo == $version)] | length == 1)' excise.spdx.json
+  jq -e --arg version 0.1.2 '([.packages[] | select(.name == "excise" and .versionInfo == $version)] | length == 1)' excise.spdx.json
   for archive in excise-*.tar.gz; do tar -tzf "$archive" >/dev/null; done
   for archive in excise-*.zip; do unzip -t "$archive" >/dev/null; done
   for subject in excise-*.tar.gz excise-*.zip checksums.sha256 excise.spdx.json; do
@@ -160,23 +164,23 @@ The publication semantics are:
 2. The `publish-crate` job publishes the crate once after the release job succeeds. Do not run `cargo publish` manually; the job accepts an existing version only after matching its registry checksum and non-yanked state, and otherwise fails before retrying.
 3. After the `homebrew-tap` environment approval, the `publish-homebrew` job renders and pushes only `Formula/excise.rb` from the verified source SHA. Review the resulting tap commit and formula after the job; do not edit that external repository from this checkout.
 
-The crates.io package follows the release commit's Cargo exclusions (`.cargo`, `.github`, `.gitmessage`, `assets`, `tapes`, `handoff`, and `packaging`); `cargo package --locked --list` is the source of truth. It does not turn the GitHub archive or tap into crate contents. The `0.1.1` API is provisional; publishing it is not a stability promise.
+The crates.io package follows the release commit's Cargo exclusions (`.cargo`, `.github`, `.gitmessage`, `assets`, `tapes`, `handoff`, and `packaging`); `cargo package --locked --list` is the source of truth. It does not turn the GitHub archive or tap into crate contents. The `0.1.2` API is provisional; publishing it is not a stability promise.
 
 ## Nix and cargo-binstall verification
 
 The tagged Nix flake is a source-build channel, while cargo-binstall downloads target-specific release archives. Verify the channels independently:
 
 ```console
-nix flake check github:findyourexit/excise/v0.1.1
-nix eval --raw "github:findyourexit/excise/v0.1.1#packages.$(nix eval --raw --impure --expr builtins.currentSystem).default.version"
-nix run github:findyourexit/excise/v0.1.1 -- --version
-nix run github:findyourexit/excise/v0.1.1 -- --format table /path/to/inspect
+nix flake check github:findyourexit/excise/v0.1.2
+nix eval --raw "github:findyourexit/excise/v0.1.2#packages.$(nix eval --raw --impure --expr builtins.currentSystem).default.version"
+nix run github:findyourexit/excise/v0.1.2 -- --version
+nix run github:findyourexit/excise/v0.1.2 -- --format table /path/to/inspect
 (
   set -euo pipefail
   binstall_dir="$(mktemp -d "${TMPDIR:-/tmp}/excise-binstall.XXXXXX")"
   readonly binstall_dir
   trap 'rm -rf -- "$binstall_dir"' EXIT
-  cargo binstall --no-confirm --force --install-path "$binstall_dir" --version 0.1.1 excise
+  cargo binstall --no-confirm --force --install-path "$binstall_dir" --version 0.1.2 excise
   "$binstall_dir/excise" --version
 )
 ```
@@ -198,7 +202,7 @@ brew info findyourexit/tap/excise
 excise --version
 ```
 
-`brew fetch` checks the formula URL and SHA-256 for the host archive. `brew audit` checks formula policy, `brew test` runs the formula's version and JSON-scan smoke checks, and `brew info` confirms the selected version and tap. Also inspect the rendered formula with `brew cat findyourexit/tap/excise`; every URL must be a `releases/download/v0.1.1/` asset and every checksum must match `checksums.sha256`. The source formula in `packaging/homebrew-core/excise.rb.in` has different build semantics and must not be used as evidence that Homebrew Core has accepted the package.
+`brew fetch` checks the formula's archive URL and SHA-256, `brew audit` checks formula policy, `brew test` runs the formula's version and JSON-scan smoke checks, and `brew info` confirms the selected version and tap. Also inspect the rendered formula with `brew cat findyourexit/tap/excise`; every URL must be a `releases/download/v0.1.2/` asset and every checksum must match `checksums.sha256`. The source formula in `packaging/homebrew-core/excise.rb.in` has different build semantics and must not be used as evidence that Homebrew Core has accepted the package.
 
 ## Credentials and approvals
 
@@ -226,13 +230,13 @@ gh workflow run release.yml \
   --field version="$version" \
   --field source_sha="$source_sha" \
   --field dispatch_id="$recovery_id" \
-  --field tag=v0.1.1 \
+  --field tag=v0.1.2 \
   --field candidate_run_id="$run_id"
 ```
 
 The recovery gate verifies that protected `main` has not moved during dispatch, that the immutable tag still targets `source_sha`, and that `run_id` is the successful candidate for that exact source before reusing its artifacts.
 
-If a destructive-safety or release-integrity defect is found, stop promotion and mark the affected channel unavailable while preserving the candidate evidence. Do not move, delete, or overwrite an existing tag or GitHub asset. A rollback cannot undo filesystem deletion and must not ask users to rerun a destructive command; after the fix is reviewed, publish a new corrective version (for example `0.1.2`), then update each channel to that immutable version. A crates.io yank only prevents new dependency resolution; it does not erase an already downloaded crate.
+If a destructive-safety or release-integrity defect is found, stop promotion and mark the affected channel unavailable while preserving the candidate evidence. Do not move, delete, or overwrite an existing tag or GitHub asset. A rollback cannot undo filesystem deletion and must not ask users to rerun a destructive command; after the fix is reviewed, publish a new corrective version (for example `0.1.3`), then update each channel to that immutable version. A crates.io yank only prevents new dependency resolution; it does not erase an already downloaded crate.
 
 ## Historical tags
 

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
         let pkgs = nixpkgs.legacyPackages.${system};
         in pkgs.rustPlatform.buildRustPackage {
           pname = "excise";
-          version = "0.1.1";
+          version = "0.1.2";
           src = pkgs.lib.cleanSource self;
           cargoLock.lockFile = ./Cargo.lock;
           preCheck = ''

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "base64",

--- a/generated/man/excise.1
+++ b/generated/man/excise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH excise 1  "excise 0.1.1"
+.TH excise 1  "excise 0.1.2"
 .SH NAME
 excise
 .SH SYNOPSIS
@@ -122,4 +122,4 @@ Print version
 [\fIfolder\fR]
 Folder to scan
 .SH VERSION
-v0.1.1
+v0.1.2


### PR DESCRIPTION
## Summary

- bump the package, lockfiles, flake, and generated man page to `0.1.2`;
- document the conflicting-link-count accounting fix and safe fuzz-plan oracle fix;
- update current installation, support, security, development, and release instructions for `0.1.2` while preserving the immutable `0.1.1` publication record.

This is a corrective early-testing release. The published `0.1.1` artifact predates the fixes.

## Verification

- `cargo generate`
- `cargo check-generated`
- `cargo run --locked --package xtask -- check-distribution`
- `cargo verify`
- `cargo package --locked --list`
- `cargo publish --locked --dry-run`
- `cargo dist-local`
- release binary smoke: `excise 0.1.2` and disposable table scan

## Release intent

After this PR merges, dispatch the release candidate workflow from the exact protected `main` SHA, verify all six archives/checksums/SBOM/attestations, then create annotated tag `v0.1.2` with the candidate run ID for gated promotion to GitHub Releases, crates.io, and the first-party Homebrew Tap.