### PR TITLE
docs: refresh post-release guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
     id: version
     attributes:
       label: Excise version or commit
-      placeholder: "v1.0.0 or 0123456789abcdef"
+      placeholder: "v0.1.2 or 0123456789abcdef"
     validations:
       required: true
   - type: dropdown

--- a/docs/development.md
+++ b/docs/development.md
@@ -9,7 +9,9 @@ rustup show
 rustup target add \
   aarch64-apple-darwin \
   x86_64-apple-darwin \
+  aarch64-unknown-linux-gnu \
   x86_64-unknown-linux-gnu \
+  aarch64-pc-windows-msvc \
   x86_64-pc-windows-msvc
 ```
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -19,7 +19,7 @@ The release does not enable Scoop, WinGet, Homebrew Core, or any other package c
 
 ## The 0.1.2 corrective release
 
-The corrective `0.1.2` release contains the post-`0.1.1` accounting hardening and fuzz-oracle fix. It remains an early-testing release: its public library API and destructive behavior are provisional. Use `0.1.2` and `v0.1.2` in the active candidate, verification, and promotion procedure below; the `0.1.1` publication record remains historical and immutable.
+The corrective `0.1.2` release contains the post-`0.1.1` accounting hardening and fuzz-oracle fix. It is published but remains an early-testing release: its public library API and destructive behavior are provisional. Use `0.1.2` and `v0.1.2` in the active candidate, verification, and promotion procedure below; the `0.1.1` publication record remains historical and immutable.
 
 ## Preconditions and clean tree
 
@@ -157,6 +157,14 @@ The approved `0.1.1` publication used:
 - publication recovery run: [32742153533](https://github.com/findyourexit/excise/actions/runs/32742153533).
 
 The tag was never moved. The recovery workflow verified and promoted the exact candidate bytes without rebuilding them.
+
+The approved `0.1.2` publication used:
+
+- source commit: `94987c5f48b7814b6c035cb61931cf7aeb11eab0`;
+- candidate workflow run: [32798065116](https://github.com/findyourexit/excise/actions/runs/32798065116);
+- annotated tag: `v0.1.2`, carrying `candidate-run-id: 32798065116`;
+- publication workflow run: [32798482623](https://github.com/findyourexit/excise/actions/runs/32798482623);
+- post-publication native verification: [32800896471](https://github.com/findyourexit/excise/actions/runs/32800896471).
 
 The publication semantics are:
 


### PR DESCRIPTION
## Audit scope

Reviewed all tracked Markdown, the generated man page, published JSON schemas, issue templates, packaging templates, and release-related workflow guidance. Separately reviewed the two local `docs/handoff/` documents; those files remain untracked in the canonical checkout and are intentionally not part of this PR.

## Changes

- record the published `0.1.2` candidate and publication evidence in `docs/releasing.md`;
- make the development target-install example include all six published targets;
- refresh the bug-report version placeholder to the current release.

The audit found the remaining tracked documentation consistent with the current `0.1.2` early-testing status, safety contracts, support matrix, distribution channels, configuration surface, report schemas, and maintainer policies.

## Verification

- `cargo verify`
- `git diff --check`
- online `lychee --no-progress docs/handoff` passed for both local handoff documents

No `docs/handoff/` file is committed or pushed.