### PR TITLE
test: pin Windows sharing violation fixture

### DIFF
--- a/docs/safety/deletion.md
+++ b/docs/safety/deletion.md
@@ -67,6 +67,7 @@ Normal completion and soft cancellation report every planned identity as deleted
 - new-child races;
 - symlink and Windows junction behavior;
 - permission and sharing failures;
+- deterministic Windows sharing-violation behavior;
 - partial best-effort continuation;
 - elevated and reduced-guard modes;
 - hostile name confirmation;

--- a/src/deletion.rs
+++ b/src/deletion.rs
@@ -2245,9 +2245,12 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn sharing_failure_is_reported_without_deleting_target() {
+    fn sharing_violation_is_reported_without_deleting_target() {
         use std::os::windows::fs::OpenOptionsExt as _;
 
+        use windows_sys::Win32::Foundation::ERROR_SHARING_VIOLATION;
+
+        const DELETE: u32 = 0x0001_0000;
         const FILE_SHARE_READ: u32 = 0x0000_0001;
         const FILE_SHARE_WRITE: u32 = 0x0000_0002;
 
@@ -2265,6 +2268,15 @@ mod tests {
             .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
             .open(&path)
             .expect("sharing blocker should open");
+        let denied_delete = std::fs::OpenOptions::new()
+            .access_mode(DELETE)
+            .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+            .open(&path)
+            .expect_err("delete access should be denied by the sharing blocker");
+        assert_eq!(
+            denied_delete.raw_os_error(),
+            i32::try_from(ERROR_SHARING_VIOLATION).ok()
+        );
 
         let report = execute_plan(
             root.path(),


### PR DESCRIPTION
## Summary

- rename the Windows sharing regression to identify the concrete violation being exercised;
- hold a synthetic file open without `FILE_SHARE_DELETE`;
- assert that a second delete-access open fails with `ERROR_SHARING_VIOLATION` before exercising Excise's deletion plan;
- retain the assertion that the planned target remains present after the fail-closed result;
- record deterministic Windows sharing-violation behavior in the permanent-deletion evidence list.

This closes the documented Windows sharing-fixture evidence gap without changing production deletion behavior.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --workspace --locked` (255 passed)
- Windows-native execution is covered by the required hosted Windows CI job.

The local macOS cross-target check could not run because the host lacks a Windows C toolchain/SDK (`alloca.c` requires `malloc.h`); no source failure was observed.