### PR TITLE
release: prepare pre-release version `v0.2.0`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
     id: version
     attributes:
       label: Excise version or commit
-      placeholder: "v0.1.2 or 0123456789abcdef"
+      placeholder: "v0.2.0 or 0123456789abcdef"
     validations:
       required: true
   - type: dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ Excise preserves the historical Diskonaut changelog below. Diskonaut versions an
 
 ## [Unreleased]
 
+_No unreleased changes._
+
+## [0.2.0] - 2026-08-27
+
 ### Added
 
-* Added the current `main` (unreleased) `cargo demo` alias and its `xtask demo` command. `xtask demo` validates `tapes/demo.tape`, stages its rendering under `assets/demo-main.*.gif`, resamples the tape's 24 fps GIF to 20 fps while rebuilding a non-dithered 64-colour palette and applying lossy GIF quantisation, and atomically promotes `assets/demo-main.gif` only after the size gate passes. `assets/demo.gif` remains the published `0.1.2` recording for the historical README. The hosted demo workflow now uses it; the tape and current-main README hero asset were refreshed.
+* Added the `cargo demo` alias and its `xtask demo` command. `xtask demo` validates `tapes/demo.tape`, stages its rendering under `assets/demo-main.*.gif`, resamples the tape's 24 fps GIF to 20 fps while rebuilding a non-dithered 64-colour palette and applying lossy GIF quantisation, and atomically promotes `assets/demo-main.gif` only after the size gate passes. `assets/demo.gif` remains the historical `0.1.2` recording for the README. The hosted demo workflow now uses it; the tape and current-main README hero asset were refreshed.
 
 * Added the public `geometry::MapOverflow` and `TreeMap::overflow() -> Option<geometry::MapOverflow>` APIs. They summarize entries omitted from the final map viewport, retaining their count, byte total, and lower-bound uncertainty even when the layout cannot draw an overflow region.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Surgical terminal storage navigator"
 keywords = ["disk-usage", "filesystem", "terminal", "tui"]
 categories = ["command-line-utilities", "filesystem"]
 
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Aram Drevekenin <aram@poor.dev>", "Tom Larcher <tom.larcher@gmail.com>"]
 readme = "README.md"
 homepage = "https://github.com/findyourexit/excise"

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Excise is an independent successor to [Diskonaut](https://github.com/imsnif/disk
 > Excise permanently deletes selected filesystem entries. There is no trash or undo. Use it only on data you can safely remove.
 
 > [!IMPORTANT]
-The published Excise **0.1.2** release is a corrective early-testing release. Start with a disposable directory, keep the default confirmation enabled, and read the [deletion contract](docs/safety/deletion.md) before selecting anything you might need.
+The published Excise **0.2.0** release is an early-testing release with the dense storage map, accessible terminal presentation, and accounting improvements described below. Start with a disposable directory, keep the default confirmation enabled, and read the [deletion contract](docs/safety/deletion.md) before selecting anything you might need.
 
-The hero above, dense half-block map, per-folder heat ramp, overflow summary, and directed map-layout transitions described below are unreleased behavior on the current `main` branch. They are not in the published `0.1.2` packages; build current `main` from source to use them. `assets/demo-main.gif` is the current-main recording, while `assets/demo.gif` remains the `0.1.2` recording so the published `v0.1.2` README cannot display unreleased behavior.
+The hero above, dense half-block map, per-folder heat ramp, overflow summary, and directed map-layout transitions are part of the published `0.2.0` experience. Build the current source above or install the release packages to use them. `assets/demo-main.gif` is the current-main recording, while `assets/demo.gif` remains the historical `0.1.2` recording for the versioned README.
 
 ## Why Excise
 
@@ -35,7 +35,7 @@ The hero above, dense half-block map, per-folder heat ramp, overflow summary, an
 
 ## Quick Start
 
-All release-channel commands below target the published **0.1.2** corrective early-testing release. Before using them, read the [release process](docs/releasing.md) and follow the disposable-fixture guidance.
+All release-channel commands below target the published **0.2.0** early-testing release. Before using them, read the [release process](docs/releasing.md) and follow the disposable-fixture guidance.
 
 ### Install it
 
@@ -47,7 +47,7 @@ The first-party Homebrew tap carries the formula:
 ```console
 brew tap findyourexit/tap
 brew install findyourexit/tap/excise
-excise --version  # excise 0.1.2
+excise --version  # excise 0.2.0
 ```
 
 </details>
@@ -55,11 +55,11 @@ excise --version  # excise 0.1.2
 <details>
 <summary><strong>crates.io</strong></summary>
 
-The `0.1.2` package is published on crates.io; install it with the locked dependency graph:
+The `0.2.0` package is published on crates.io; install it with the locked dependency graph:
 
 ```console
-cargo install excise --version 0.1.2 --locked
-excise --version  # excise 0.1.2
+cargo install excise --version 0.2.0 --locked
+excise --version  # excise 0.2.0
 ```
 
 </details>
@@ -67,7 +67,7 @@ excise --version  # excise 0.1.2
 <details>
 <summary><strong>GitHub Release</strong></summary>
 
-Download the archive for your platform from the [published 0.1.2 GitHub Release](https://github.com/findyourexit/excise/releases/tag/v0.1.2). For example, Apple silicon macOS:
+Download the archive for your platform from the [published 0.2.0 GitHub Release](https://github.com/findyourexit/excise/releases/tag/v0.2.0). For example, Apple silicon macOS:
 The provenance check requires the GitHub CLI (`gh`) and a GitHub API-authenticated session.
 
 ```console
@@ -77,21 +77,21 @@ The provenance check requires the GitHub CLI (`gh`) and a GitHub API-authenticat
   readonly download_dir
   trap 'rm -rf -- "$download_dir"' EXIT
   cd "$download_dir"
-  curl --fail --location --remote-name https://github.com/findyourexit/excise/releases/download/v0.1.2/excise-aarch64-apple-darwin-v0.1.2.tar.gz
-  curl --fail --location --remote-name https://github.com/findyourexit/excise/releases/download/v0.1.2/checksums.sha256
+  curl --fail --location --remote-name https://github.com/findyourexit/excise/releases/download/v0.2.0/excise-aarch64-apple-darwin-v0.2.0.tar.gz
+  curl --fail --location --remote-name https://github.com/findyourexit/excise/releases/download/v0.2.0/checksums.sha256
   shasum -a 256 --ignore-missing --check checksums.sha256
-  source_sha="$(git ls-remote --exit-code https://github.com/findyourexit/excise.git 'refs/tags/v0.1.2^{}' | cut -f1)"
+  source_sha="$(git ls-remote --exit-code https://github.com/findyourexit/excise.git 'refs/tags/v0.2.0^{}' | cut -f1)"
   if [[ ! "$source_sha" =~ ^[0-9a-f]{40}$ ]]; then
-    echo "could not resolve the v0.1.2 tag commit" >&2
+    echo "could not resolve the v0.2.0 tag commit" >&2
     exit 1
   fi
-  gh attestation verify excise-aarch64-apple-darwin-v0.1.2.tar.gz \
+  gh attestation verify excise-aarch64-apple-darwin-v0.2.0.tar.gz \
     --repo findyourexit/excise \
     --signer-workflow findyourexit/excise/.github/workflows/release.yml \
     --source-digest "$source_sha" \
     --source-ref refs/heads/main
-  tar --extract --gzip --file excise-aarch64-apple-darwin-v0.1.2.tar.gz
-  ./excise-aarch64-apple-darwin-v0.1.2/excise --version  # excise 0.1.2
+  tar --extract --gzip --file excise-aarch64-apple-darwin-v0.2.0.tar.gz
+  ./excise-aarch64-apple-darwin-v0.2.0/excise --version  # excise 0.2.0
 )
 ```
 
@@ -111,19 +111,19 @@ cargo install --path . --locked
 excise --version
 ```
 
-To reproduce the exact published release commit, replace `main` with `v0.1.2` in the clone command.
+To reproduce the exact published release commit, replace `main` with `v0.2.0` in the clone command.
 
 </details>
 
 <details>
 <summary><strong>Nix</strong></summary>
 
-Run or install the published `v0.1.2` flake without updating its lock file:
+Run or install the published `v0.2.0` flake without updating its lock file:
 
 ```console
-nix run github:findyourexit/excise/v0.1.2 -- --format table /path/to/inspect
-nix profile install github:findyourexit/excise/v0.1.2
-excise --version  # excise 0.1.2
+nix run github:findyourexit/excise/v0.2.0 -- --format table /path/to/inspect
+nix profile install github:findyourexit/excise/v0.2.0
+excise --version  # excise 0.2.0
 ```
 
 </details>
@@ -200,9 +200,9 @@ Read the [deletion contract](docs/safety/deletion.md), [storage accounting contr
 - [Release process](docs/releasing.md)
 - [Project lineage](docs/lineage.md)
 
-## Demo recording (current main, unreleased)
+## Demo recording (current main)
 
-On current `main`, the unreleased `cargo demo` alias delegates to `xtask demo`; it is not part of published `0.1.2`. The hero recording is generated by [VHS](https://github.com/charmbracelet/vhs) from [`tapes/demo.tape`](tapes/demo.tape). The tape creates a fresh temporary fixture, scans only that fixture, and exits without entering deletion mode or sending a deletion confirmation. `xtask demo` requires VHS, `ttyd`, `ffmpeg`, `ffprobe`, and `gifsicle` on `PATH`, plus a Unix-like `bash` and core utilities: the tape explicitly selects `bash`, creates its fixture under `/tmp`, and invokes utilities including `head`, `mkdir`, and `rm`.
+The current-main `cargo demo` alias delegates to `xtask demo`; it is a development helper rather than a release-package command. The hero recording is generated by [VHS](https://github.com/charmbracelet/vhs) from [`tapes/demo.tape`](tapes/demo.tape). The tape creates a fresh temporary fixture, scans only that fixture, and exits without entering deletion mode or sending a deletion confirmation. `xtask demo` requires VHS, `ttyd`, `ffmpeg`, `ffprobe`, and `gifsicle` on `PATH`, plus a Unix-like `bash` and core utilities: the tape explicitly selects `bash`, creates its fixture under `/tmp`, and invokes utilities including `head`, `mkdir`, and `rm`.
 
 ```console
 (
@@ -212,7 +212,7 @@ On current `main`, the unreleased `cargo demo` alias delegates to `xtask demo`; 
 )
 ```
 
-`xtask demo` validates the tape and renders it at the tape's 24 fps, then resamples it to 20 fps while rebuilding a 64-colour palette without dithering before lossy GIF quantisation. It owns the staging paths and only atomically promotes the size-gated result to `assets/demo-main.gif`, so a failed render leaves the current-main recording untouched and never changes `assets/demo.gif`, the published `0.1.2` recording. Dithering, not palette size, dominates the weight of a recorded terminal: it converts flat cells into per-pixel noise that no frame differ can compress. Skipping it and capping the palette at 64 colours keeps the flat interface compact without visible loss. Running `vhs tapes/demo.tape` directly writes an unoptimised 24 fps sequence to `assets/demo-main.gif`; it skips the 20 fps resampling, palette rebuild, quantisation, and size gate, so it must not be used to refresh the committed hero.
+`xtask demo` validates the tape and renders it at the tape's 24 fps, then resamples it to 20 fps while rebuilding a 64-colour palette without dithering before lossy GIF quantisation. It owns the staging paths and only atomically promotes the size-gated result to `assets/demo-main.gif`, so a failed render leaves the current-main recording untouched and never changes `assets/demo.gif`, the historical `0.1.2` recording. Dithering, not palette size, dominates the weight of a recorded terminal: it converts flat cells into per-pixel noise that no frame differ can compress. Skipping it and capping the palette at 64 colours keeps the flat interface compact without visible loss. Running `vhs tapes/demo.tape` directly writes an unoptimised 24 fps sequence to `assets/demo-main.gif`; it skips the 20 fps resampling, palette rebuild, quantisation, and size gate, so it must not be used to refresh the committed hero.
 
 The [demo workflow](.github/workflows/demo.yml) runs the same pipeline and uploads the GIF as a build artifact on pull requests and pushes to `main`; it never commits generated media or pushes to `main`. `assets/` and `tapes/` are demo-only and excluded from release package metadata.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,12 +4,13 @@ Excise performs permanent filesystem deletion, so data-loss defects are treated 
 
 ## Supported versions
 
-Excise supports the latest stable release, currently `0.1.0`. The published `0.1.2` release is a corrective early-testing release; `0.1.1` is superseded. Do not trust either early-testing line with irreplaceable data.
+Excise supports the latest stable release, currently `0.1.0`. The published `0.2.0` release is an early-testing release; `0.1.2` and `0.1.1` are superseded. Do not trust any early-testing line with irreplaceable data.
 
 | Version | Status |
 |---|---|
-| `0.1.2` | Corrective early testing; best-effort support |
-| `0.1.1` | Superseded early testing; upgrade to `0.1.2` |
+| `0.2.0` | Early testing; best-effort support |
+| `0.1.2` | Superseded early testing; upgrade to `0.2.0` |
+| `0.1.1` | Superseded early testing; upgrade to `0.2.0` |
 | `0.1.0` | Supported stable line |
 | `main` | Development only |
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,8 +1,8 @@
 # Support
 
-## 0.1.2 corrective early testing
+## 0.2.0 early testing
 
-The published `0.1.2` release includes corrective accounting and fuzz-validation fixes but remains early testing. Support is best effort, the public library API may change before 1.0, and no release build should be trusted with irreplaceable data. Start with [Getting started](docs/getting-started.md) and a disposable fixture.
+The published `0.2.0` release includes the dense storage map, accessible terminal presentation, animation, overflow reporting, and retained-accounting improvements but remains early testing. Support is best effort, the public library API may change before 1.0, and no release build should be trusted with irreplaceable data. Start with [Getting started](docs/getting-started.md) and a disposable fixture.
 
 ## Usage questions
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -43,7 +43,7 @@ The default worker count is `min(available_parallelism, 8)`, with a validated `1
 
 A flat arena keyed by stable node IDs stores names once, parent/child relationships, native identity, metrics, scan state, and aggregate state. Traversal, compaction, and destruction are iterative.
 
-On current `main`, the public `geometry::MapOverflow` summary returned by `TreeMap::overflow()` records entries omitted from the final map viewport, not merely individually small entries. It retains their count, bytes, and lower-bound uncertainty even when no overflow region can be drawn; its anchor may be a non-drawable sentinel when no free field exists, so consumers must check drawable bounds before painting; count and weight labels appear only when that region has enough usable space.
+The public `geometry::MapOverflow` summary returned by `TreeMap::overflow()` records entries omitted from the final map viewport, not merely individually small entries. It retains their count, bytes, and lower-bound uncertainty even when no overflow region can be drawn; its anchor may be a non-drawable sentinel when no free field exists, so consumers must check drawable bounds before painting; count and weight labels appear only when that region has enough usable space.
 
 The default process envelope is 512 MiB. A hard 75% model/index budget leaves 25% process headroom. Cold compaction preserves exact aggregates while active ancestors, visible nodes, and operation targets remain pinned.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -45,9 +45,9 @@ Run the actual terminal lifecycle tests with:
 cargo test --test pty_smoke --locked
 ```
 
-## 0.1.2 candidate checks
+## 0.2.0 candidate checks
 
-The `0.1.2` corrective release remains early testing, not a stable API or a promise that destructive behavior is safe for irreplaceable data. From a clean checkout at the release commit, run the focused checks before requesting the hosted candidate:
+The `0.2.0` release is an early-testing minor release, not a stable API or a promise that destructive behavior is safe for irreplaceable data. From a clean checkout at the release commit, run the focused checks before requesting the hosted candidate:
 
 ```console
 (
@@ -76,7 +76,7 @@ if command -v sha256sum >/dev/null 2>&1; then
 else
   dispatch_id="$(printf '%s' "$dispatch_seed" | shasum -a 256 | cut -c1-32)"
 fi
-run_url="$(gh workflow run release.yml --repo findyourexit/excise --ref main --field version=0.1.2 --field source_sha="$source_sha" --field dispatch_id="$dispatch_id")"
+run_url="$(gh workflow run release.yml --repo findyourexit/excise --ref main --field version=0.2.0 --field source_sha="$source_sha" --field dispatch_id="$dispatch_id")"
 run_id="${run_url##*/}"
 if [[ ! "$run_id" =~ ^[0-9]+$ ]]; then
   run_id="$(
@@ -137,29 +137,29 @@ The workflow rejects a moving or unprotected source ref, checks the exact SHA an
   fi
   jq -e '.packages | length > 1' excise.spdx.json
   jq -e '.packages[] | select(.name == "serde")' excise.spdx.json
-  jq -e --arg version 0.1.2 '([.packages[] | select(.name == "excise" and .versionInfo == $version)] | length == 1)' excise.spdx.json
+  jq -e --arg version 0.2.0 '([.packages[] | select(.name == "excise" and .versionInfo == $version)] | length == 1)' excise.spdx.json
   archives=(
-    excise-x86_64-unknown-linux-gnu-v0.1.2.tar.gz
-    excise-aarch64-unknown-linux-gnu-v0.1.2.tar.gz
-    excise-x86_64-apple-darwin-v0.1.2.tar.gz
-    excise-aarch64-apple-darwin-v0.1.2.tar.gz
-    excise-x86_64-pc-windows-msvc-v0.1.2.zip
-    excise-aarch64-pc-windows-msvc-v0.1.2.zip
+    excise-x86_64-unknown-linux-gnu-v0.2.0.tar.gz
+    excise-aarch64-unknown-linux-gnu-v0.2.0.tar.gz
+    excise-x86_64-apple-darwin-v0.2.0.tar.gz
+    excise-aarch64-apple-darwin-v0.2.0.tar.gz
+    excise-x86_64-pc-windows-msvc-v0.2.0.zip
+    excise-aarch64-pc-windows-msvc-v0.2.0.zip
   )
   for archive in "${archives[@]}"; do
     test -s "$archive"
   done
   for target in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu x86_64-apple-darwin aarch64-apple-darwin; do
-    archive="excise-${target}-v0.1.2.tar.gz"
-    root="excise-${target}-v0.1.2"
+    archive="excise-${target}-v0.2.0.tar.gz"
+    root="excise-${target}-v0.2.0"
     tar -tzf "$archive" | grep -Fqx "$root/excise"
     tar -tzf "$archive" | grep -Fqx "$root/LICENSE"
     tar -tzf "$archive" | grep -Fqx "$root/generated/man/excise.1"
     tar -tzf "$archive" | grep -Fqx "$root/schemas/scan-report.schema.json"
   done
   for target in x86_64-pc-windows-msvc aarch64-pc-windows-msvc; do
-    archive="excise-${target}-v0.1.2.zip"
-    root="excise-${target}-v0.1.2"
+    archive="excise-${target}-v0.2.0.zip"
+    root="excise-${target}-v0.2.0"
     unzip -t "$archive" >/dev/null
     unzip -Z1 "$archive" | grep -Fqx "$root/excise.exe"
     unzip -Z1 "$archive" | grep -Fqx "$root/LICENSE"
@@ -179,8 +179,8 @@ The workflow rejects a moving or unprotected source ref, checks the exact SHA an
 After reviewing the candidate, create the annotated release tag with the reviewed candidate run ID in its message, then push it:
 
 ```console
-git tag -a v0.1.2 "$source_sha" -m "candidate-run-id: $run_id"
-git push origin v0.1.2
+git tag -a v0.2.0 "$source_sha" -m "candidate-run-id: $run_id"
+git push origin v0.2.0
 ```
 
 The push-triggered workflow requires that exact annotated-tag candidate ID; never substitute a different candidate run or a lightweight tag.
@@ -213,9 +213,9 @@ cargo check-generated
 
 Commit generated changes with the source contract that produced them.
 
-### Current-main demo pipeline (unreleased)
+### Current-main demo pipeline
 
-The `cargo demo` alias is current `main` behavior, not a `0.1.2` candidate command. It delegates to `xtask demo`; refresh the VHS demonstration after user-visible CLI or TUI changes and review the output before a release:
+The `cargo demo` alias is current `main` development behavior rather than a release-package command. It delegates to `xtask demo`; refresh the VHS demonstration after user-visible CLI or TUI changes and review the output before a release:
 
 ```console
 (
@@ -225,7 +225,7 @@ The `cargo demo` alias is current `main` behavior, not a `0.1.2` candidate comma
 )
 ```
 
-Run the tape from the repository root. `xtask demo` validates `tapes/demo.tape`, renders it at the tape's 24 fps, then resamples it to 20 fps while rebuilding a 64-colour palette without dithering and applying lossy GIF quantisation. It owns the `assets/demo-main.rendered.gif`, `assets/demo-main.palette.gif`, and `assets/demo-main.quantised.gif` staging paths and atomically promotes the last to `assets/demo-main.gif` only after it passes the published GIF's weight ceiling; a failure leaves the committed current-main asset untouched and never changes `assets/demo.gif`, the published `0.1.2` recording. It needs `vhs`, `ttyd`, `ffmpeg`, `ffprobe`, and `gifsicle` on `PATH`, plus a Unix-like `bash` and core utilities: the tape explicitly selects `bash`, creates its fixture under `/tmp`, and invokes utilities including `head`, `mkdir`, and `rm`.
+Run the tape from the repository root. `xtask demo` validates `tapes/demo.tape`, renders it at the tape's 24 fps, then resamples it to 20 fps while rebuilding a 64-colour palette without dithering and applying lossy GIF quantisation. It owns the `assets/demo-main.rendered.gif`, `assets/demo-main.palette.gif`, and `assets/demo-main.quantised.gif` staging paths and atomically promotes the last to `assets/demo-main.gif` only after it passes the published GIF's weight ceiling; a failure leaves the committed current-main asset untouched and never changes `assets/demo.gif`, the historical `0.1.2` recording. It needs `vhs`, `ttyd`, `ffmpeg`, `ffprobe`, and `gifsicle` on `PATH`, plus a Unix-like `bash` and core utilities: the tape explicitly selects `bash`, creates its fixture under `/tmp`, and invokes utilities including `head`, `mkdir`, and `rm`.
 
 Invoking `vhs tapes/demo.tape` directly writes an unoptimised 24 fps sequence to `assets/demo-main.gif` and skips the 20 fps resampling, palette rebuild, quantisation, and size gate, so it must not be used to refresh the committed current-main hero.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,9 +2,9 @@
 
 Excise permanently deletes selected filesystem entries. There is no trash or undo. Begin with a disposable directory.
 
-## The 0.1.2 corrective early-testing release
+## The 0.2.0 early-testing release
 
-The published `0.1.2` release includes corrective accounting and fuzz-validation fixes but remains early testing. Its public library API and destructive behavior are provisional; do not use it on irreplaceable data, and do not infer stable support from a successful install. Verify the version and read the [permanent-deletion contract](safety/deletion.md) before making a scan or deletion plan.
+The published `0.2.0` release adds the dense storage map, accessible terminal presentation, animation, overflow reporting, and retained-accounting improvements while remaining early testing. Its public library API and destructive behavior are provisional; do not use it on irreplaceable data, and do not infer stable support from a successful install. Verify the version and read the [permanent-deletion contract](safety/deletion.md) before making a scan or deletion plan.
 
 The project is independent from Diskonaut. Tags `0.1.0` through `0.11.0` are preserved Diskonaut releases, not Excise releases; do not move, reuse, or treat those tags as an Excise installation.
 
@@ -40,12 +40,12 @@ nix build
 ./result/bin/excise /path/to/inspect
 ```
 
-## Install 0.1.2 from a release channel
+## Install 0.2.0 from a release channel
 
-The `0.1.2` crates.io package is published and compiles locally; it is not one of the prebuilt GitHub archives:
+The `0.2.0` crates.io package is published and compiles locally; it is not one of the prebuilt GitHub archives:
 
 ```console
-cargo install excise --version 0.1.2 --locked
+cargo install excise --version 0.2.0 --locked
 excise --version
 ```
 
@@ -86,9 +86,9 @@ The default view uses identity-unique allocated bytes. Pass `--apparent-size` wh
 
 The TUI requires stdin and stdout attached to TTYs, ANSI rendering, and alternate-screen support. It needs a window at least `32 x 8`; smaller windows show a resize message. If a terminal cannot provide these capabilities, use table or JSON mode instead. `--ascii` changes symbols and borders but does not remove the TTY requirement.
 
-### Current-main map behavior (unreleased)
+### 0.2.0 map behavior
 
-The dense half-block map, animated focus chrome, heat ramp, `geometry::MapOverflow` overflow summary, and directed map-layout transitions described below are current `main` behavior. They are not included in published `0.1.2`; build the current source above to use them.
+The dense half-block map, animated focus chrome, heat ramp, `geometry::MapOverflow` overflow summary, and directed map-layout transitions are included in the published `0.2.0` release. Build the current source above or install `0.2.0` to use them.
 
 The interactive view uses a dense half-block treemap and animated focus chrome on capable terminals. `--ascii`, monochrome mode, and reduced motion preserve the same selection, scope, and deletion information when those visual effects are unavailable or undesirable.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,6 +1,6 @@
 # Release process
 
-This runbook records the published `0.1.1` early-testing release contract, the corrective `0.1.2` release contract, and the evidence required for future corrective releases. It is a procedure, not authorization.
+This runbook records the published `0.1.1` early-testing release contract, the corrective `0.1.2` release contract, and the evidence required for the `0.2.0` release and future releases. It is a procedure, not authorization.
 
 ## The 0.1.1 contract (historical)
 
@@ -17,9 +17,13 @@ The release commit and candidate must agree on all of the following:
 
 The release does not enable Scoop, WinGet, Homebrew Core, or any other package channel beyond the first-party Homebrew tap, tagged Nix flake, crates.io, and cargo-binstall metadata. Templates under `packaging/` are validation inputs unless a separately approved channel promotion says otherwise. The source formula at `packaging/homebrew-core/excise.rb.in` is for a possible future Homebrew Core submission; it is not the first-party tap formula.
 
-## The 0.1.2 corrective release
+## The 0.1.2 corrective release (historical)
 
-The corrective `0.1.2` release contains the post-`0.1.1` accounting hardening and fuzz-oracle fix. It is published but remains an early-testing release: its public library API and destructive behavior are provisional. Use `0.1.2` and `v0.1.2` in the active candidate, verification, and promotion procedure below; the `0.1.1` publication record remains historical and immutable.
+The corrective `0.1.2` release contains the post-`0.1.1` accounting hardening and fuzz-oracle fix. It is published but remains an early-testing release: its public library API and destructive behavior are provisional. The `0.1.2` publication record remains historical and immutable.
+
+## The 0.2.0 early-testing release
+
+The `0.2.0` release packages the dense storage map, accessible terminal presentation, animation, overflow reporting, and retained-accounting work described in the changelog. It is a minor release because the public library API changed; it remains early testing, and its public library API and destructive behavior are provisional. Use `0.2.0` and `v0.2.0` in the active candidate, verification, and promotion procedure below.
 
 ## Preconditions and clean tree
 
@@ -72,7 +76,7 @@ if command -v sha256sum >/dev/null 2>&1; then
 else
   dispatch_id="$(printf '%s' "$dispatch_seed" | shasum -a 256 | cut -c1-32)"
 fi
-run_url="$(gh workflow run release.yml --repo findyourexit/excise --ref main --field version=0.1.2 --field source_sha="$source_sha" --field dispatch_id="$dispatch_id")"
+run_url="$(gh workflow run release.yml --repo findyourexit/excise --ref main --field version=0.2.0 --field source_sha="$source_sha" --field dispatch_id="$dispatch_id")"
 run_id="${run_url##*/}"
 if [[ ! "$run_id" =~ ^[0-9]+$ ]]; then
   run_id="$(
@@ -133,7 +137,7 @@ The candidate contains six immutable target archives, `checksums.sha256`, and `e
   fi
   jq -e '.packages | length > 1' excise.spdx.json
   jq -e '.packages[] | select(.name == "serde")' excise.spdx.json
-  jq -e --arg version 0.1.2 '([.packages[] | select(.name == "excise" and .versionInfo == $version)] | length == 1)' excise.spdx.json
+  jq -e --arg version 0.2.0 '([.packages[] | select(.name == "excise" and .versionInfo == $version)] | length == 1)' excise.spdx.json
   for archive in excise-*.tar.gz; do tar -tzf "$archive" >/dev/null; done
   for archive in excise-*.zip; do unzip -t "$archive" >/dev/null; done
   for subject in excise-*.tar.gz excise-*.zip checksums.sha256 excise.spdx.json; do
@@ -172,23 +176,23 @@ The publication semantics are:
 2. The `publish-crate` job publishes the crate once after the release job succeeds. Do not run `cargo publish` manually; the job accepts an existing version only after matching its registry checksum and non-yanked state, and otherwise fails before retrying.
 3. After the `homebrew-tap` environment approval, the `publish-homebrew` job renders and pushes only `Formula/excise.rb` from the verified source SHA. Review the resulting tap commit and formula after the job; do not edit that external repository from this checkout.
 
-The crates.io package follows the release commit's Cargo exclusions (`.cargo`, `.github`, `.gitmessage`, `assets`, `tapes`, `handoff`, and `packaging`); `cargo package --locked --list` is the source of truth. It does not turn the GitHub archive or tap into crate contents. The `0.1.2` API is provisional; publishing it is not a stability promise.
+The crates.io package follows the release commit's Cargo exclusions (`.cargo`, `.github`, `.gitmessage`, `assets`, `tapes`, `handoff`, and `packaging`); `cargo package --locked --list` is the source of truth. It does not turn the GitHub archive or tap into crate contents. The `0.2.0` API is provisional; publishing it is not a stability promise.
 
 ## Nix and cargo-binstall verification
 
 The tagged Nix flake is a source-build channel, while cargo-binstall downloads target-specific release archives. Verify the channels independently:
 
 ```console
-nix flake check github:findyourexit/excise/v0.1.2
-nix eval --raw "github:findyourexit/excise/v0.1.2#packages.$(nix eval --raw --impure --expr builtins.currentSystem).default.version"
-nix run github:findyourexit/excise/v0.1.2 -- --version
-nix run github:findyourexit/excise/v0.1.2 -- --format table /path/to/inspect
+nix flake check github:findyourexit/excise/v0.2.0
+nix eval --raw "github:findyourexit/excise/v0.2.0#packages.$(nix eval --raw --impure --expr builtins.currentSystem).default.version"
+nix run github:findyourexit/excise/v0.2.0 -- --version
+nix run github:findyourexit/excise/v0.2.0 -- --format table /path/to/inspect
 (
   set -euo pipefail
   binstall_dir="$(mktemp -d "${TMPDIR:-/tmp}/excise-binstall.XXXXXX")"
   readonly binstall_dir
   trap 'rm -rf -- "$binstall_dir"' EXIT
-  cargo binstall --no-confirm --force --install-path "$binstall_dir" --version 0.1.2 excise
+  cargo binstall --no-confirm --force --install-path "$binstall_dir" --version 0.2.0 excise
   "$binstall_dir/excise" --version
 )
 ```
@@ -210,7 +214,7 @@ brew info findyourexit/tap/excise
 excise --version
 ```
 
-`brew fetch` checks the formula's archive URL and SHA-256, `brew audit` checks formula policy, `brew test` runs the formula's version and JSON-scan smoke checks, and `brew info` confirms the selected version and tap. Also inspect the rendered formula with `brew cat findyourexit/tap/excise`; every URL must be a `releases/download/v0.1.2/` asset and every checksum must match `checksums.sha256`. The source formula in `packaging/homebrew-core/excise.rb.in` has different build semantics and must not be used as evidence that Homebrew Core has accepted the package.
+`brew fetch` checks the formula's archive URL and SHA-256, `brew audit` checks formula policy, `brew test` runs the formula's version and JSON-scan smoke checks, and `brew info` confirms the selected version and tap. Also inspect the rendered formula with `brew cat findyourexit/tap/excise`; every URL must be a `releases/download/v0.2.0/` asset and every checksum must match `checksums.sha256`. The source formula in `packaging/homebrew-core/excise.rb.in` has different build semantics and must not be used as evidence that Homebrew Core has accepted the package.
 
 ## Credentials and approvals
 
@@ -238,13 +242,13 @@ gh workflow run release.yml \
   --field version="$version" \
   --field source_sha="$source_sha" \
   --field dispatch_id="$recovery_id" \
-  --field tag=v0.1.2 \
+  --field tag=v0.2.0 \
   --field candidate_run_id="$run_id"
 ```
 
 The recovery gate verifies that protected `main` has not moved during dispatch, that the immutable tag still targets `source_sha`, and that `run_id` is the successful candidate for that exact source before reusing its artifacts.
 
-If a destructive-safety or release-integrity defect is found, stop promotion and mark the affected channel unavailable while preserving the candidate evidence. Do not move, delete, or overwrite an existing tag or GitHub asset. A rollback cannot undo filesystem deletion and must not ask users to rerun a destructive command; after the fix is reviewed, publish a new corrective version (for example `0.1.3`), then update each channel to that immutable version. A crates.io yank only prevents new dependency resolution; it does not erase an already downloaded crate.
+If a destructive-safety or release-integrity defect is found, stop promotion and mark the affected channel unavailable while preserving the candidate evidence. Do not move, delete, or overwrite an existing tag or GitHub asset. A rollback cannot undo filesystem deletion and must not ask users to rerun a destructive command; after the fix is reviewed, publish a new corrective version (for example `0.2.1`), then update each channel to that immutable version. A crates.io yank only prevents new dependency resolution; it does not erase an already downloaded crate.
 
 ## Historical tags
 

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
         let pkgs = nixpkgs.legacyPackages.${system};
         in pkgs.rustPlatform.buildRustPackage {
           pname = "excise";
-          version = "0.1.2";
+          version = "0.2.0";
           src = pkgs.lib.cleanSource self;
           cargoLock.lockFile = ./Cargo.lock;
           preCheck = ''

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/generated/man/excise.1
+++ b/generated/man/excise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH excise 1  "excise 0.1.2"
+.TH excise 1  "excise 0.2.0"
 .SH NAME
 excise
 .SH SYNOPSIS
@@ -122,4 +122,4 @@ Print version
 [\fIfolder\fR]
 Folder to scan
 .SH VERSION
-v0.1.2
+v0.2.0


### PR DESCRIPTION
## Summary

- Bump the package, lockfiles, Nix metadata, and generated man page to `0.2.0`.
- Move the current changelog entries into the dated `0.2.0` release section.
- Update installation, support, security, architecture, development, and release-runbook documentation for the new early-testing release.

`0.2.0` reflects the breaking public animation and geometry API changes alongside the dense map, accessibility, animation, overflow, and scanner-accounting work.

## Verification

- `cargo verify`
- `cargo generate`
- `cargo package --locked --list` in a clean release verification worktree
- `cargo publish --locked --dry-run` in a clean release verification worktree
- `cargo dist-local` in a clean release verification worktree
- Local archive checksum, archive-content, `excise --version`, and disposable table-scan smoke checks
- `git diff --check`