### PR TITLE
release: prepare early-testing `v0.3.0`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
     id: version
     attributes:
       label: Excise version or commit
-      placeholder: "v0.2.0 or 0123456789abcdef"
+      placeholder: "v0.3.0 or 0123456789abcdef"
     validations:
       required: true
   - type: dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ Excise preserves the historical Diskonaut changelog below. Diskonaut versions an
 
 ## [Unreleased]
 
+_No unreleased changes._
+
+## [0.3.0] - 2026-08-27
+
 ### Changed
 
+* **Breaking library API:** removed the provisional public Rust module exports from the supported surface. The CLI and documented configuration/report contracts are now the compatibility boundary; repository fuzzing and benchmark access uses explicit feature gates.
 * Added the v1.0.0 release-readiness gate covering public contracts, compatibility, support classification, safety evidence, and exact-commit publication.
 * Established the conservative v1 baseline: configuration versions other than `1` are rejected, table output is human-facing rather than machine-stable, and only native behavioral targets qualify for full support.
-* Removed the provisional public Rust module exports from the supported surface; the CLI and documented configuration/report contracts remain the compatibility boundary.
 
 ## [0.2.0] - 2026-08-27
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Surgical terminal storage navigator"
 keywords = ["disk-usage", "filesystem", "terminal", "tui"]
 categories = ["command-line-utilities", "filesystem"]
 
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Aram Drevekenin <aram@poor.dev>", "Tom Larcher <tom.larcher@gmail.com>"]
 readme = "README.md"
 homepage = "https://github.com/findyourexit/excise"

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Excise is an independent successor to [Diskonaut](https://github.com/imsnif/disk
 > Excise permanently deletes selected filesystem entries. There is no trash or undo. Use it only on data you can safely remove.
 
 > [!IMPORTANT]
-The published Excise **0.2.0** release is an early-testing release with the dense storage map, accessible terminal presentation, and accounting improvements described below. Start with a disposable directory, keep the default confirmation enabled, and read the [deletion contract](docs/safety/deletion.md) before selecting anything you might need.
+The `0.3.0` release is an early-testing release with the private Rust API boundary and the dense storage map, accessible terminal presentation, and accounting improvements described below. Start with a disposable directory, keep the default confirmation enabled, and read the [deletion contract](docs/safety/deletion.md) before selecting anything you might need.
 
-The hero above, dense half-block map, per-folder heat ramp, overflow summary, and directed map-layout transitions are part of the published `0.2.0` experience. Build the current source above or install the release packages to use them. `assets/demo-main.gif` is the current-main recording, while `assets/demo.gif` remains the historical `0.1.2` recording for the versioned README.
+The hero above, dense half-block map, per-folder heat ramp, overflow summary, and directed map-layout transitions are part of the current `0.3.0` experience. Build the current source above or install the release packages to use them. `assets/demo-main.gif` is the current-main recording, while `assets/demo.gif` remains the historical `0.1.2` recording for the versioned README.
 
 ## Why Excise
 
@@ -35,7 +35,7 @@ The hero above, dense half-block map, per-folder heat ramp, overflow summary, an
 
 ## Quick Start
 
-All release-channel commands below target the published **0.2.0** early-testing release. Before using them, read the [release process](docs/releasing.md) and follow the disposable-fixture guidance.
+All release-channel commands below target the `0.3.0` early-testing release. Before using them, read the [release process](docs/releasing.md) and follow the disposable-fixture guidance.
 
 ### Install it
 
@@ -47,7 +47,7 @@ The first-party Homebrew tap carries the formula:
 ```console
 brew tap findyourexit/tap
 brew install findyourexit/tap/excise
-excise --version  # excise 0.2.0
+excise --version  # excise 0.3.0
 ```
 
 </details>
@@ -55,11 +55,11 @@ excise --version  # excise 0.2.0
 <details>
 <summary><strong>crates.io</strong></summary>
 
-The `0.2.0` package is published on crates.io; install it with the locked dependency graph:
+The `0.3.0` package is published on crates.io; install it with the locked dependency graph:
 
 ```console
-cargo install excise --version 0.2.0 --locked
-excise --version  # excise 0.2.0
+cargo install excise --version 0.3.0 --locked
+excise --version  # excise 0.3.0
 ```
 
 </details>
@@ -67,7 +67,7 @@ excise --version  # excise 0.2.0
 <details>
 <summary><strong>GitHub Release</strong></summary>
 
-Download the archive for your platform from the [published 0.2.0 GitHub Release](https://github.com/findyourexit/excise/releases/tag/v0.2.0). For example, Apple silicon macOS:
+Download the archive for your platform from the `0.3.0` GitHub Release. For example, Apple silicon macOS:
 The provenance check requires the GitHub CLI (`gh`) and a GitHub API-authenticated session.
 
 ```console
@@ -77,21 +77,21 @@ The provenance check requires the GitHub CLI (`gh`) and a GitHub API-authenticat
   readonly download_dir
   trap 'rm -rf -- "$download_dir"' EXIT
   cd "$download_dir"
-  curl --fail --location --remote-name https://github.com/findyourexit/excise/releases/download/v0.2.0/excise-aarch64-apple-darwin-v0.2.0.tar.gz
-  curl --fail --location --remote-name https://github.com/findyourexit/excise/releases/download/v0.2.0/checksums.sha256
+  curl --fail --location --remote-name https://github.com/findyourexit/excise/releases/download/v0.3.0/excise-aarch64-apple-darwin-v0.3.0.tar.gz
+  curl --fail --location --remote-name https://github.com/findyourexit/excise/releases/download/v0.3.0/checksums.sha256
   shasum -a 256 --ignore-missing --check checksums.sha256
-  source_sha="$(git ls-remote --exit-code https://github.com/findyourexit/excise.git 'refs/tags/v0.2.0^{}' | cut -f1)"
+  source_sha="$(git ls-remote --exit-code https://github.com/findyourexit/excise.git 'refs/tags/v0.3.0^{}' | cut -f1)"
   if [[ ! "$source_sha" =~ ^[0-9a-f]{40}$ ]]; then
-    echo "could not resolve the v0.2.0 tag commit" >&2
+    echo "could not resolve the v0.3.0 tag commit" >&2
     exit 1
   fi
-  gh attestation verify excise-aarch64-apple-darwin-v0.2.0.tar.gz \
+  gh attestation verify excise-aarch64-apple-darwin-v0.3.0.tar.gz \
     --repo findyourexit/excise \
     --signer-workflow findyourexit/excise/.github/workflows/release.yml \
     --source-digest "$source_sha" \
     --source-ref refs/heads/main
-  tar --extract --gzip --file excise-aarch64-apple-darwin-v0.2.0.tar.gz
-  ./excise-aarch64-apple-darwin-v0.2.0/excise --version  # excise 0.2.0
+  tar --extract --gzip --file excise-aarch64-apple-darwin-v0.3.0.tar.gz
+  ./excise-aarch64-apple-darwin-v0.3.0/excise --version  # excise 0.3.0
 )
 ```
 
@@ -111,19 +111,19 @@ cargo install --path . --locked
 excise --version
 ```
 
-To reproduce the exact published release commit, replace `main` with `v0.2.0` in the clone command.
+To reproduce the exact published release commit, replace `main` with `v0.3.0` in the clone command.
 
 </details>
 
 <details>
 <summary><strong>Nix</strong></summary>
 
-Run or install the published `v0.2.0` flake without updating its lock file:
+Run or install the published `v0.3.0` flake without updating its lock file:
 
 ```console
-nix run github:findyourexit/excise/v0.2.0 -- --format table /path/to/inspect
-nix profile install github:findyourexit/excise/v0.2.0
-excise --version  # excise 0.2.0
+nix run github:findyourexit/excise/v0.3.0 -- --format table /path/to/inspect
+nix profile install github:findyourexit/excise/v0.3.0
+excise --version  # excise 0.3.0
 ```
 
 </details>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,13 +4,14 @@ Excise performs permanent filesystem deletion, so data-loss defects are treated 
 
 ## Supported versions
 
-Excise supports the latest stable release, currently `0.1.0`. The published `0.2.0` release is an early-testing release; `0.1.2` and `0.1.1` are superseded. Do not trust any early-testing line with irreplaceable data.
+Excise supports the latest stable release, currently `0.1.0`. The `0.3.0` release is early testing; `0.2.0`, `0.1.2`, and `0.1.1` are superseded early-testing releases. Do not trust any early-testing line with irreplaceable data.
 
 | Version | Status |
 |---|---|
-| `0.2.0` | Early testing; best-effort support |
-| `0.1.2` | Superseded early testing; upgrade to `0.2.0` |
-| `0.1.1` | Superseded early testing; upgrade to `0.2.0` |
+| `0.3.0` | Early testing; best-effort support |
+| `0.2.0` | Superseded early testing; upgrade to `0.3.0` |
+| `0.1.2` | Superseded early testing; upgrade to `0.3.0` |
+| `0.1.1` | Superseded early testing; upgrade to `0.3.0` |
 | `0.1.0` | Supported stable line |
 | `main` | Development only |
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,8 +1,8 @@
 # Support
 
-## 0.2.0 early testing
+## 0.3.0 early testing
 
-The published `0.2.0` release includes the dense storage map, accessible terminal presentation, animation, overflow reporting, and retained-accounting improvements but remains early testing. Support is best effort, the public library API may change before 1.0, and no release build should be trusted with irreplaceable data. Start with [Getting started](docs/getting-started.md) and a disposable fixture.
+The `0.3.0` release makes the CLI, configuration, and versioned JSON reports the supported product contracts. Its Rust implementation modules are private by default, while repository-only fuzzing and benchmark access uses explicit feature gates. Support remains best effort, and no early-testing release should be trusted with irreplaceable data. Start with [Getting started](docs/getting-started.md) and a disposable fixture.
 
 ## Usage questions
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -45,9 +45,9 @@ Run the actual terminal lifecycle tests with:
 cargo test --test pty_smoke --locked
 ```
 
-## 0.2.0 candidate checks
+## 0.3.0 candidate checks
 
-The `0.2.0` release is an early-testing minor release, not a stable API or a promise that destructive behavior is safe for irreplaceable data. From a clean checkout at the release commit, run the focused checks before requesting the hosted candidate:
+The `0.3.0` release is an early-testing breaking minor release for the Rust API boundary, not a stable API or a promise that destructive behavior is safe for irreplaceable data. From a clean checkout at the release commit, run the focused checks before requesting the hosted candidate:
 
 ```console
 (
@@ -76,7 +76,7 @@ if command -v sha256sum >/dev/null 2>&1; then
 else
   dispatch_id="$(printf '%s' "$dispatch_seed" | shasum -a 256 | cut -c1-32)"
 fi
-run_url="$(gh workflow run release.yml --repo findyourexit/excise --ref main --field version=0.2.0 --field source_sha="$source_sha" --field dispatch_id="$dispatch_id")"
+run_url="$(gh workflow run release.yml --repo findyourexit/excise --ref main --field version=0.3.0 --field source_sha="$source_sha" --field dispatch_id="$dispatch_id")"
 run_id="${run_url##*/}"
 if [[ ! "$run_id" =~ ^[0-9]+$ ]]; then
   run_id="$(
@@ -137,29 +137,29 @@ The workflow rejects a moving or unprotected source ref, checks the exact SHA an
   fi
   jq -e '.packages | length > 1' excise.spdx.json
   jq -e '.packages[] | select(.name == "serde")' excise.spdx.json
-  jq -e --arg version 0.2.0 '([.packages[] | select(.name == "excise" and .versionInfo == $version)] | length == 1)' excise.spdx.json
+  jq -e --arg version 0.3.0 '([.packages[] | select(.name == "excise" and .versionInfo == $version)] | length == 1)' excise.spdx.json
   archives=(
-    excise-x86_64-unknown-linux-gnu-v0.2.0.tar.gz
-    excise-aarch64-unknown-linux-gnu-v0.2.0.tar.gz
-    excise-x86_64-apple-darwin-v0.2.0.tar.gz
-    excise-aarch64-apple-darwin-v0.2.0.tar.gz
-    excise-x86_64-pc-windows-msvc-v0.2.0.zip
-    excise-aarch64-pc-windows-msvc-v0.2.0.zip
+    excise-x86_64-unknown-linux-gnu-v0.3.0.tar.gz
+    excise-aarch64-unknown-linux-gnu-v0.3.0.tar.gz
+    excise-x86_64-apple-darwin-v0.3.0.tar.gz
+    excise-aarch64-apple-darwin-v0.3.0.tar.gz
+    excise-x86_64-pc-windows-msvc-v0.3.0.zip
+    excise-aarch64-pc-windows-msvc-v0.3.0.zip
   )
   for archive in "${archives[@]}"; do
     test -s "$archive"
   done
   for target in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu x86_64-apple-darwin aarch64-apple-darwin; do
-    archive="excise-${target}-v0.2.0.tar.gz"
-    root="excise-${target}-v0.2.0"
+    archive="excise-${target}-v0.3.0.tar.gz"
+    root="excise-${target}-v0.3.0"
     tar -tzf "$archive" | grep -Fqx "$root/excise"
     tar -tzf "$archive" | grep -Fqx "$root/LICENSE"
     tar -tzf "$archive" | grep -Fqx "$root/generated/man/excise.1"
     tar -tzf "$archive" | grep -Fqx "$root/schemas/scan-report.schema.json"
   done
   for target in x86_64-pc-windows-msvc aarch64-pc-windows-msvc; do
-    archive="excise-${target}-v0.2.0.zip"
-    root="excise-${target}-v0.2.0"
+    archive="excise-${target}-v0.3.0.zip"
+    root="excise-${target}-v0.3.0"
     unzip -t "$archive" >/dev/null
     unzip -Z1 "$archive" | grep -Fqx "$root/excise.exe"
     unzip -Z1 "$archive" | grep -Fqx "$root/LICENSE"
@@ -179,8 +179,8 @@ The workflow rejects a moving or unprotected source ref, checks the exact SHA an
 After reviewing the candidate, create the annotated release tag with the reviewed candidate run ID in its message, then push it:
 
 ```console
-git tag -a v0.2.0 "$source_sha" -m "candidate-run-id: $run_id"
-git push origin v0.2.0
+git tag -a v0.3.0 "$source_sha" -m "candidate-run-id: $run_id"
+git push origin v0.3.0
 ```
 
 The push-triggered workflow requires that exact annotated-tag candidate ID; never substitute a different candidate run or a lightweight tag.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,9 +2,9 @@
 
 Excise permanently deletes selected filesystem entries. There is no trash or undo. Begin with a disposable directory.
 
-## The 0.2.0 early-testing release
+## The 0.3.0 early-testing release
 
-The published `0.2.0` release adds the dense storage map, accessible terminal presentation, animation, overflow reporting, and retained-accounting improvements while remaining early testing. Its public library API and destructive behavior are provisional; do not use it on irreplaceable data, and do not infer stable support from a successful install. Verify the version and read the [permanent-deletion contract](safety/deletion.md) before making a scan or deletion plan.
+The `0.3.0` release makes the CLI, configuration, and versioned JSON reports the supported product contracts while keeping the Rust implementation modules private by default. It remains early testing; do not use it on irreplaceable data, and do not infer stable support from a successful install. Verify the version and read the [permanent-deletion contract](safety/deletion.md) before making a scan or deletion plan.
 
 The project is independent from Diskonaut. Tags `0.1.0` through `0.11.0` are preserved Diskonaut releases, not Excise releases; do not move, reuse, or treat those tags as an Excise installation.
 
@@ -40,12 +40,12 @@ nix build
 ./result/bin/excise /path/to/inspect
 ```
 
-## Install 0.2.0 from a release channel
+## Install 0.3.0 from a release channel
 
-The `0.2.0` crates.io package is published and compiles locally; it is not one of the prebuilt GitHub archives:
+The `0.3.0` package is published on crates.io and compiles locally; it is not one of the prebuilt GitHub archives:
 
 ```console
-cargo install excise --version 0.2.0 --locked
+cargo install excise --version 0.3.0 --locked
 excise --version
 ```
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,6 +1,6 @@
 # Release process
 
-This runbook records the published `0.1.1` early-testing release contract, the corrective `0.1.2` release contract, and the evidence required for the `0.2.0` release and future releases. It is a procedure, not authorization.
+This runbook records the published `0.1.1` early-testing release contract, the corrective `0.1.2` release contract, the published `0.2.0` release evidence, and the evidence required for the `0.3.0` release and future releases. It is a procedure, not authorization.
 
 ## The 0.1.1 contract (historical)
 
@@ -23,7 +23,7 @@ The corrective `0.1.2` release contains the post-`0.1.1` accounting hardening an
 
 ## The 0.2.0 early-testing release
 
-The `0.2.0` release packages the dense storage map, accessible terminal presentation, animation, overflow reporting, and retained-accounting work described in the changelog. It is a minor release because the public library API changed; it remains early testing, and its public library API and destructive behavior are provisional. Use `0.2.0` and `v0.2.0` in the active candidate, verification, and promotion procedure below.
+The `0.2.0` release packages the dense storage map, accessible terminal presentation, animation, overflow reporting, and retained-accounting work described in the changelog. It was a minor early-testing release because the public library API changed; its publication record is historical and immutable.
 
 The approved `0.2.0` publication used:
 
@@ -33,6 +33,10 @@ The approved `0.2.0` publication used:
 - annotated tag: `v0.2.0`, pointing to the exact source commit;
 - successful native verification: https://github.com/findyourexit/excise/actions/runs/33044958150;
 - published GitHub Release assets, crates.io package, first-party Homebrew Tap, cargo-binstall metadata, and tagged Nix flake.
+
+## The 0.3.0 early-testing release
+
+The `0.3.0` release packages the private Rust API boundary and compatibility-policy work described in the changelog. It is a breaking minor release because provisional Rust module paths are removed from the default public surface; it remains early testing, and its destructive behavior is provisional. Use `0.3.0` and `v0.3.0` in the active candidate, verification, and promotion procedure below.
 
 ## Preconditions and clean tree
 
@@ -85,7 +89,7 @@ if command -v sha256sum >/dev/null 2>&1; then
 else
   dispatch_id="$(printf '%s' "$dispatch_seed" | shasum -a 256 | cut -c1-32)"
 fi
-run_url="$(gh workflow run release.yml --repo findyourexit/excise --ref main --field version=0.2.0 --field source_sha="$source_sha" --field dispatch_id="$dispatch_id")"
+run_url="$(gh workflow run release.yml --repo findyourexit/excise --ref main --field version=0.3.0 --field source_sha="$source_sha" --field dispatch_id="$dispatch_id")"
 run_id="${run_url##*/}"
 if [[ ! "$run_id" =~ ^[0-9]+$ ]]; then
   run_id="$(
@@ -146,7 +150,7 @@ The candidate contains six immutable target archives, `checksums.sha256`, and `e
   fi
   jq -e '.packages | length > 1' excise.spdx.json
   jq -e '.packages[] | select(.name == "serde")' excise.spdx.json
-  jq -e --arg version 0.2.0 '([.packages[] | select(.name == "excise" and .versionInfo == $version)] | length == 1)' excise.spdx.json
+  jq -e --arg version 0.3.0 '([.packages[] | select(.name == "excise" and .versionInfo == $version)] | length == 1)' excise.spdx.json
   for archive in excise-*.tar.gz; do tar -tzf "$archive" >/dev/null; done
   for archive in excise-*.zip; do unzip -t "$archive" >/dev/null; done
   for subject in excise-*.tar.gz excise-*.zip checksums.sha256 excise.spdx.json; do
@@ -185,23 +189,23 @@ The publication semantics are:
 2. The `publish-crate` job publishes the crate once after the release job succeeds. Do not run `cargo publish` manually; the job accepts an existing version only after matching its registry checksum and non-yanked state, and otherwise fails before retrying.
 3. After the `homebrew-tap` environment approval, the `publish-homebrew` job renders and pushes only `Formula/excise.rb` from the verified source SHA. Review the resulting tap commit and formula after the job; do not edit that external repository from this checkout.
 
-The crates.io package follows the release commit's Cargo exclusions (`.cargo`, `.github`, `.gitmessage`, `assets`, `tapes`, `handoff`, and `packaging`); `cargo package --locked --list` is the source of truth. It does not turn the GitHub archive or tap into crate contents. The `0.2.0` API is provisional; publishing it is not a stability promise.
+The crates.io package follows the release commit's Cargo exclusions (`.cargo`, `.github`, `.gitmessage`, `assets`, `tapes`, `handoff`, and `packaging`); `cargo package --locked --list` is the source of truth. It does not turn the GitHub archive or tap into crate contents. The `0.3.0` API boundary is CLI-only; publishing it is not a promise of a supported Rust library.
 
 ## Nix and cargo-binstall verification
 
 The tagged Nix flake is a source-build channel, while cargo-binstall downloads target-specific release archives. Verify the channels independently:
 
 ```console
-nix flake check github:findyourexit/excise/v0.2.0
-nix eval --raw "github:findyourexit/excise/v0.2.0#packages.$(nix eval --raw --impure --expr builtins.currentSystem).default.version"
-nix run github:findyourexit/excise/v0.2.0 -- --version
-nix run github:findyourexit/excise/v0.2.0 -- --format table /path/to/inspect
+nix flake check github:findyourexit/excise/v0.3.0
+nix eval --raw "github:findyourexit/excise/v0.3.0#packages.$(nix eval --raw --impure --expr builtins.currentSystem).default.version"
+nix run github:findyourexit/excise/v0.3.0 -- --version
+nix run github:findyourexit/excise/v0.3.0 -- --format table /path/to/inspect
 (
   set -euo pipefail
   binstall_dir="$(mktemp -d "${TMPDIR:-/tmp}/excise-binstall.XXXXXX")"
   readonly binstall_dir
   trap 'rm -rf -- "$binstall_dir"' EXIT
-  cargo binstall --no-confirm --force --install-path "$binstall_dir" --version 0.2.0 excise
+  cargo binstall --no-confirm --force --install-path "$binstall_dir" --version 0.3.0 excise
   "$binstall_dir/excise" --version
 )
 ```
@@ -223,7 +227,7 @@ brew info findyourexit/tap/excise
 excise --version
 ```
 
-`brew fetch` checks the formula's archive URL and SHA-256, `brew audit` checks formula policy, `brew test` runs the formula's version and JSON-scan smoke checks, and `brew info` confirms the selected version and tap. Also inspect the rendered formula with `brew cat findyourexit/tap/excise`; every URL must be a `releases/download/v0.2.0/` asset and every checksum must match `checksums.sha256`. The source formula in `packaging/homebrew-core/excise.rb.in` has different build semantics and must not be used as evidence that Homebrew Core has accepted the package.
+`brew fetch` checks the formula's archive URL and SHA-256, `brew audit` checks formula policy, `brew test` runs the formula's version and JSON-scan smoke checks, and `brew info` confirms the selected version and tap. Also inspect the rendered formula with `brew cat findyourexit/tap/excise`; every URL must be a `releases/download/v0.3.0/` asset and every checksum must match `checksums.sha256`. The source formula in `packaging/homebrew-core/excise.rb.in` has different build semantics and must not be used as evidence that Homebrew Core has accepted the package.
 
 ## Credentials and approvals
 
@@ -251,7 +255,7 @@ gh workflow run release.yml \
   --field version="$version" \
   --field source_sha="$source_sha" \
   --field dispatch_id="$recovery_id" \
-  --field tag=v0.2.0 \
+  --field tag=v0.3.0 \
   --field candidate_run_id="$run_id"
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
         let pkgs = nixpkgs.legacyPackages.${system};
         in pkgs.rustPlatform.buildRustPackage {
           pname = "excise";
-          version = "0.2.0";
+          version = "0.3.0";
           src = pkgs.lib.cleanSource self;
           cargoLock.lockFile = ./Cargo.lock;
           preCheck = ''

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/generated/man/excise.1
+++ b/generated/man/excise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH excise 1  "excise 0.2.0"
+.TH excise 1  "excise 0.3.0"
 .SH NAME
 excise
 .SH SYNOPSIS
@@ -122,4 +122,4 @@ Print version
 [\fIfolder\fR]
 Folder to scan
 .SH VERSION
-v0.2.0
+v0.3.0


### PR DESCRIPTION
## Summary

Prepare the next early-testing release after the CLI-only Rust API boundary landed in PR #31.

## Changes

- Bump the package, lockfiles, Nix flake, and generated man page to `0.3.0`.
- Move the API-boundary and v1 readiness notes into the `0.3.0` changelog section.
- Update README, support, security, issue-template, development, getting-started, and release-runbook references to `0.3.0`.
- Preserve the published `0.2.0` evidence as historical release documentation.
- Keep `0.3.0` explicitly early testing; this is not a 1.0 stability declaration.

## Compatibility and safety

This release carries the intentional pre-1.0 Rust API clean break from PR #31. No deletion, accounting, scanner, terminal-restoration, or report semantics are changed.

## Verification

- `cargo verify`
- generated man/completion checks
- distribution-contract checks
- exact version consistency across Cargo, Nix, lockfiles, and release instructions
