### PR TITLE
docs: define `v1.0.0` support matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ Excise preserves the historical Diskonaut changelog below. Diskonaut versions an
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Changed
+
+* Defined the planned `1.0.0` support matrix: x86_64 Linux, AArch64 macOS, and x86_64 Windows are fully supported by native evidence; the other three published archives remain build-only/best-effort with documented filesystem-provider caveats.
 
 ## [0.3.0] - 2026-08-27
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The provenance check requires the GitHub CLI (`gh`) and a GitHub API-authenticat
 )
 ```
 
-The release provides archives for AArch64 and x86_64 macOS, AArch64 and x86_64 Linux, and x86_64 and AArch64 Windows. The example verifies the selected archive before extraction or execution; verify the remaining release assets before placing a binary on your `PATH`.
+The release provides archives for AArch64 and x86_64 macOS, AArch64 and x86_64 Linux, and x86_64 and AArch64 Windows. For the planned `1.0.0` support policy, x86_64 Linux, AArch64 macOS, and x86_64 Windows are fully supported by native evidence; the other three archives are build-only/best-effort until native behavioral evidence exists.
 
 </details>
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,6 +4,23 @@
 
 The `0.3.0` release makes the CLI, configuration, and versioned JSON reports the supported product contracts. Its Rust implementation modules are private by default, while repository-only fuzzing and benchmark access uses explicit feature gates. Support remains best effort, and no early-testing release should be trusted with irreplaceable data. Start with [Getting started](docs/getting-started.md) and a disposable fixture.
 
+## `1.0.0` support matrix
+
+The planned stable runtime support set is:
+
+| Target | `1.0.0` status | Evidence |
+| --- | --- | --- |
+| x86_64 Linux (`x86_64-unknown-linux-gnu`) | Supported | Native CI, native PTY checks, and release archive |
+| AArch64 macOS (`aarch64-apple-darwin`) | Supported | Native CI, native PTY checks, and release archive |
+| x86_64 Windows (`x86_64-pc-windows-msvc`) | Supported | Native CI, native PTY checks, and release archive |
+| x86_64 macOS (`x86_64-apple-darwin`) | Build-only/best-effort | Release compilation and archive only |
+| AArch64 Linux (`aarch64-unknown-linux-gnu`) | Build-only/best-effort | Release compilation and archive only |
+| AArch64 Windows (`aarch64-pc-windows-msvc`) | Build-only/best-effort | Release compilation and archive only |
+
+The three build-only archives remain available for experimentation, but a successful download or compilation is not evidence of native runtime compatibility.
+
+Filesystem-provider-specific ACL, sharing, allocation, network or remote filesystem, reflink, clone, compression, and shared-extent behavior is best-effort unless separately evidenced. Unknown allocation remains explicit. Interactive use requires the documented TTY, ANSI, alternate-screen, and minimum-size capabilities; use table or JSON mode for non-TTY environments.
+
 ## Usage questions
 
 Search the [documentation](docs/README.md) and existing discussions first. Use [GitHub Discussions](https://github.com/findyourexit/excise/discussions) for installation, configuration, and usage questions.

--- a/docs/development.md
+++ b/docs/development.md
@@ -15,20 +15,28 @@ rustup target add \
   x86_64-pc-windows-msvc
 ```
 
-A host may not be able to install every target. The published target set has separate native-behavior and release-artifact evidence.
+The published target set has separate native-behavior and release-artifact evidence. The `1.0.0` support policy is runtime evidence first: only native behavioral targets are fully supported.
 
 ## Target evidence
 
 | Target | Support classification | Published evidence |
 | --- | --- | --- |
-| `x86_64-unknown-linux-gnu` (x86_64 Linux) | Native behavioral target | Native verification plus hosted release build/archive |
-| `aarch64-apple-darwin` (AArch64 macOS) | Native behavioral target | Native verification plus hosted release build/archive |
-| `x86_64-pc-windows-msvc` (x86_64 Windows) | Native behavioral target | Native verification plus hosted release build/archive |
-| `x86_64-apple-darwin` (x86_64 macOS) | Release target; compile/archive only | Hosted release build/archive job |
-| `aarch64-unknown-linux-gnu` (AArch64 Linux) | Release target; compile/archive only | Hosted release build/archive job |
-| `aarch64-pc-windows-msvc` (AArch64 Windows) | Release target; compile/archive only | Hosted release build/archive job |
+| `x86_64-unknown-linux-gnu` (x86_64 Linux) | Supported in `1.0.0`; native behavioral target | Native verification plus hosted release build/archive |
+| `aarch64-apple-darwin` (AArch64 macOS) | Supported in `1.0.0`; native behavioral target | Native verification plus hosted release build/archive |
+| `x86_64-pc-windows-msvc` (x86_64 Windows) | Supported in `1.0.0`; native behavioral target | Native verification plus hosted release build/archive |
+| `x86_64-apple-darwin` (x86_64 macOS) | Build-only/best-effort; compile/archive only | Hosted release build/archive job |
+| `aarch64-unknown-linux-gnu` (AArch64 Linux) | Build-only/best-effort; compile/archive only | Hosted release build/archive job |
+| `aarch64-pc-windows-msvc` (AArch64 Windows) | Build-only/best-effort; compile/archive only | Hosted release build/archive job |
 
-Only the native behavioral rows carry published runtime-behavior evidence. For `1.0.0`, only those rows should be classified as fully supported; compile-only targets must remain build-only or best-effort until native behavior is demonstrated. A successful hosted build or archive demonstrates release compilation and packaging, not native runtime compatibility.
+The native behavioral rows are the complete `1.0.0` runtime support set. The release pipeline continues to publish all six archives, but the three compile-only targets carry no native runtime guarantee and remain best-effort until promoted by native evidence. A successful hosted build or archive demonstrates release compilation and packaging, not native runtime compatibility.
+
+The target rows and workflow matrices are checked by `cargo run --locked --package xtask -- check-support-matrix` and are included in `cargo verify`.
+
+## Filesystem and terminal scope
+
+The supported runtime target policy applies to local filesystem paths accessed through the documented operating-system APIs. Filesystem-provider-specific ACL, sharing, allocation, network or remote filesystem, reflink, clone, compression, and shared-extent behavior is best-effort unless separately evidenced; unknown allocation remains explicit rather than guessed.
+
+Interactive support requires stdin and stdout TTYs, ANSI rendering, alternate-screen support, and a window at least `32 x 8`. Table and JSON modes are the supported non-TTY path for redirection, pipelines, CI, and terminals without those capabilities.
 
 ## Fast feedback
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,6 +16,8 @@ The project is independent from Diskonaut. Tags `0.1.0` through `0.11.0` are pre
 
 The repository pins Rust 1.88 in `rust-toolchain.toml`.
 
+For the planned `1.0.0` support policy, x86_64 Linux, AArch64 macOS, and x86_64 Windows have native runtime evidence. x86_64 macOS, AArch64 Linux, and AArch64 Windows have release artifacts but remain build-only/best-effort until native behavior is demonstrated. Filesystem-provider caveats are documented in [Support](../SUPPORT.md).
+
 ## Build and run from source
 
 ```console

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -265,7 +265,7 @@ If a destructive-safety or release-integrity defect is found, stop promotion and
 
 ## v1.0.0 readiness gate
 
-`1.0.0` is authorized only after the public behavior, supported-platform policy, safety evidence, and release procedure below are explicit and reviewed. The `0.2.x` line remains early testing until this gate is complete.
+`1.0.0` is authorized only after the public behavior, supported-platform policy, safety evidence, and release procedure below are explicit and reviewed. The `0.3.x` line remains early testing until this gate is complete.
 
 ### Contract decisions to freeze
 
@@ -279,7 +279,7 @@ If a destructive-safety or release-integrity defect is found, stop promotion and
 | Deletion | Preserve no-follow identity binding, independent enumeration, revalidation, root and synthetic-node rejection, explicit partial results, and the permanent/no-undo contract. | The deletion contract and focused safety suite are the baseline. |
 | Accounting | Preserve identity-unique allocated bytes, separate apparent bytes, conservative reclaimable bounds, and explicit unknowns. Do not claim physical shared-extent exactness. | The accounting contract and fixtures are the baseline. |
 | Library API | Treat the CLI, configuration, and versioned reports as the supported product surface. Rust implementation modules are private; the crate-root bridges used by the binary and tooling are hidden and carry no semver guarantee. | The private implementation boundary is implemented; the crate exposes no supported Rust API. |
-| Platforms | Make only native behavioral targets fully supported in `1.0.0`; classify compile/archive-only targets as build-only until native behavior evidence promotes them. | Linux x86_64, macOS AArch64, and Windows x86_64 have native evidence; the remaining three published targets are build/archive-only. |
+| Platforms | Make only native behavioral targets fully supported in `1.0.0`; classify compile/archive-only targets as build-only until native behavior evidence promotes them. | Decision recorded: three native targets are supported; three compile-only archives remain published and explicitly best-effort. |
 | Distribution and governance | Require exact protected-commit artifacts, checksums, SBOM, provenance, rollback, and an explicit release-approval authority. | Artifact identity and rollback are operational; the second-maintainer approval path is not yet established. |
 
 ### Required exit evidence

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -73,6 +73,17 @@ const WINDOWS_RELEASE_ASSETS: [WindowsReleaseAsset; 2] = [
     },
 ];
 
+const NATIVE_SUPPORT_TARGETS: [&str; 3] = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+];
+const BUILD_ONLY_TARGETS: [&str; 3] = [
+    "x86_64-apple-darwin",
+    "aarch64-unknown-linux-gnu",
+    "aarch64-pc-windows-msvc",
+];
+
 fn main() {
     if let Err(error) = dispatch() {
         eprintln!("verification failed: {error}");
@@ -86,11 +97,12 @@ fn dispatch() -> Result<(), Box<dyn Error>> {
         Some("generate") => write_generated(),
         Some("check-generated") => check_generated(),
         Some("check-distribution") => check_distribution_contract(&release_version()?),
+        Some("check-support-matrix") => check_support_matrix(),
         Some("render-homebrew") => render_homebrew_formula(),
         Some("dist-local") => build_local_dist(),
         Some("demo") => render_demo(),
         _ => Err(io::Error::other(
-            "usage: cargo xtask <verify|generate|check-generated|check-distribution|render-homebrew|dist-local|demo>",
+            "usage: cargo xtask <verify|generate|check-generated|check-distribution|check-support-matrix|render-homebrew|dist-local|demo>",
         )
         .into()),
     }
@@ -102,6 +114,90 @@ fn release_version() -> Result<String, Box<dyn Error>> {
         .get_version()
         .ok_or_else(|| io::Error::other("CLI version was absent"))?;
     Ok(version.to_owned())
+}
+
+fn check_support_matrix() -> Result<(), Box<dyn Error>> {
+    let ci = fs::read_to_string(".github/workflows/ci.yml")?;
+    let release = fs::read_to_string(".github/workflows/release.yml")?;
+    let development = fs::read_to_string("docs/development.md")?;
+    let support = fs::read_to_string("SUPPORT.md")?;
+
+    for target in NATIVE_SUPPORT_TARGETS {
+        require_text(&ci, target, "native CI target")?;
+        require_row(
+            &development,
+            target,
+            "Supported in `1.0.0`",
+            "docs/development.md",
+        )?;
+        require_row(&support, target, "| Supported |", "SUPPORT.md")?;
+    }
+    for target in BUILD_ONLY_TARGETS {
+        if ci.contains(target) {
+            return Err(io::Error::other(format!(
+                "build-only target {target} must not appear in the native CI matrix"
+            ))
+            .into());
+        }
+        require_text(&release, target, "release archive target")?;
+        require_row(
+            &development,
+            target,
+            "Build-only/best-effort",
+            "docs/development.md",
+        )?;
+        require_row(&support, target, "Build-only/best-effort", "SUPPORT.md")?;
+    }
+    require_text(
+        &development,
+        "Filesystem-provider-specific",
+        "filesystem caveat in docs/development.md",
+    )?;
+    require_text(
+        &support,
+        "Filesystem-provider-specific",
+        "filesystem caveat in SUPPORT.md",
+    )?;
+
+    for asset in UNIX_RELEASE_ASSETS {
+        require_text(&release, asset.target, "Unix release target")?;
+    }
+    for asset in WINDOWS_RELEASE_ASSETS {
+        require_text(&release, asset.target, "Windows release target")?;
+    }
+    println!(
+        "Support matrix validated: {} native targets, {} build-only targets.",
+        NATIVE_SUPPORT_TARGETS.len(),
+        BUILD_ONLY_TARGETS.len()
+    );
+    Ok(())
+}
+
+fn require_text(contents: &str, needle: &str, description: &str) -> Result<(), Box<dyn Error>> {
+    if contents.contains(needle) {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!("missing {description}: {needle}")).into())
+    }
+}
+
+fn require_row(
+    contents: &str,
+    target: &str,
+    marker: &str,
+    source: &str,
+) -> Result<(), Box<dyn Error>> {
+    if contents
+        .lines()
+        .any(|line| line.contains(target) && line.contains(marker))
+    {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "{source} has no support row for {target} marked {marker}"
+        ))
+        .into())
+    }
 }
 
 /// Frames per second the published recording keeps.
@@ -400,6 +496,7 @@ fn verify() -> Result<(), Box<dyn Error>> {
     run_behavior_checks(&cargo)?;
     check_generated()?;
     check_distribution_contract(&release_version()?)?;
+    check_support_matrix()?;
     run_dynamic_checks(&cargo)?;
 
     println!("\nLocal verification passed.");


### PR DESCRIPTION
## Summary

Record the evidence-based `1.0.0` platform and filesystem support policy after publishing `v0.3.0`.

## Decision

- Fully support x86_64 Linux, AArch64 macOS, and x86_64 Windows.
- Keep x86_64 macOS, AArch64 Linux, and AArch64 Windows archives available as build-only/best-effort artifacts.
- Describe filesystem-provider-specific ACL, sharing, allocation, network/remote filesystem, reflink, clone, compression, and shared-extent behavior as best-effort unless separately evidenced.

## Changes

- Publish the target matrix in `SUPPORT.md`, `docs/development.md`, `docs/getting-started.md`, and the README.
- Update the v1 release gate with the finalized support disposition.
- Add `xtask check-support-matrix` and include it in `cargo verify` so CI and documentation cannot silently drift.
- Record the decision in the Unreleased changelog.

## Verification

- `cargo run --locked --package xtask -- check-support-matrix`
- `cargo verify` (passed)
- Native CI for the three supported targets passed on `d5a6c155ecc2c0cbed8e35099c65a40efd6b13ec`.
- `v0.3.0` published all six archives; the three non-native targets remain explicitly non-supported for `1.0.0`.
