### PR TITLE
test: enforce v1 contract evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Excise preserves the historical Diskonaut changelog below. Diskonaut versions an
 ### Changed
 
 * Defined the planned `1.0.0` support matrix: x86_64 Linux, AArch64 macOS, and x86_64 Windows are fully supported by native evidence; the other three published archives remain build-only/best-effort with documented filesystem-provider caveats.
+* Tightened release verification so Cargo package checks reject dirty tracked or untracked release input, and added binary-level CLI contract smoke coverage for configuration errors, exit classes, JSON schema output, and hostile table paths.
+
+* Recorded the normative `1.0.0` contract decision record and explicit current lead-maintainer release authority.
 
 ## [0.3.0] - 2026-08-27
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -3,6 +3,7 @@
 ## Maintainer model
 
 Excise currently uses a lead-maintainer model. The lead maintainer has final responsibility for product direction, safety, releases, and project administration. Delegated authority is recorded in [MAINTAINERS.md](MAINTAINERS.md).
+Until a second maintainer is appointed, the lead maintainer may approve stable releases and material safety or release-trust changes after the required public review, evidence, protected-main ruleset checks, and publication-environment approval. This is the current release authority; it does not imply that a second maintainer exists.
 
 When a second maintainer is appointed:
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -267,7 +267,7 @@ If a destructive-safety or release-integrity defect is found, stop promotion and
 
 `1.0.0` is authorized only after the public behavior, supported-platform policy, safety evidence, and release procedure below are explicit and reviewed. The `0.3.x` line remains early testing until this gate is complete.
 
-### Contract decisions to freeze
+### Contract decision record
 
 | Area | Required v1 decision | Current position |
 | --- | --- | --- |
@@ -280,14 +280,18 @@ If a destructive-safety or release-integrity defect is found, stop promotion and
 | Accounting | Preserve identity-unique allocated bytes, separate apparent bytes, conservative reclaimable bounds, and explicit unknowns. Do not claim physical shared-extent exactness. | The accounting contract and fixtures are the baseline. |
 | Library API | Treat the CLI, configuration, and versioned reports as the supported product surface. Rust implementation modules are private; the crate-root bridges used by the binary and tooling are hidden and carry no semver guarantee. | The private implementation boundary is implemented; the crate exposes no supported Rust API. |
 | Platforms | Make only native behavioral targets fully supported in `1.0.0`; classify compile/archive-only targets as build-only until native behavior evidence promotes them. | Decision recorded: three native targets are supported; three compile-only archives remain published and explicitly best-effort. |
-| Distribution and governance | Require exact protected-commit artifacts, checksums, SBOM, provenance, rollback, and an explicit release-approval authority. | Artifact identity and rollback are operational; the second-maintainer approval path is not yet established. |
+| Distribution and governance | Require exact protected-commit artifacts, checksums, SBOM, provenance, rollback, and an explicit release-approval authority. | Artifact identity and rollback are operational; the lead-maintainer approval authority is explicit in `GOVERNANCE.md`, with a second-maintainer review to apply when one is appointed. |
+
+The table above is the normative `1.0.0` public-contract decision record. Maintain it through reviewed pull requests; any implementation change that affects a row requires that row to be re-reviewed before release authorization. The current authority is explicit: the lead maintainer listed in `MAINTAINERS.md` owns final product, safety, and release decisions and may authorize publication only after this gate, the protected-main ruleset checks, and the publication-environment approval pass. No second maintainer is currently appointed; when one is appointed, the additional approval requirements in `GOVERNANCE.md` apply.
+
+The release candidate must also record the exact source commit, candidate run, artifact checksums, SBOM, attestations, package-channel results, and reviewer decision against this table. A passing automated check is evidence for its scope; it is not approval for a different scope.
 
 ### Required exit evidence
 
 Before the `v1.0.0` release PR can be approved, attach:
 
 1. a reviewed public-contract decision record covering every row above;
-2. upgrade and compatibility tests for CLI/configuration (including rejection of unsupported versions), table safety and escaping, JSON schemas, native paths, and exit classes;
+2. upgrade and compatibility tests for CLI/configuration (including rejection of unsupported versions), table safety and escaping, JSON schemas, native paths, and exit classes; `tests/cli_contract_smoke.rs` must exercise the binary-level portion of this contract;
 3. native behavioral evidence for every target classified as supported, plus an explicit disposition for build-only targets;
 4. focused security reviews of deletion, identity, spill, terminal restoration, and release supply chain;
 5. dependency, unsafe-boundary, fuzz, benchmark, packaging, SBOM, checksum, and provenance evidence from the exact release commit;

--- a/tests/cli_contract_smoke.rs
+++ b/tests/cli_contract_smoke.rs
@@ -1,0 +1,137 @@
+use std::fs;
+use std::process::Command;
+
+use anyhow::{Context as _, Result, ensure};
+use serde_json::Value;
+
+const NATIVE_PATH_SCHEMA_ID: &str =
+    "https://github.com/findyourexit/excise/schemas/native-path-v1.json";
+
+fn scan_report_validator() -> jsonschema::Validator {
+    let native_path_schema: Value =
+        serde_json::from_str(include_str!("../docs/schemas/native-path.schema.json"))
+            .expect("native-path schema should be valid JSON");
+    let scan_report_schema: Value =
+        serde_json::from_str(include_str!("../docs/schemas/scan-report.schema.json"))
+            .expect("scan-report schema should be valid JSON");
+    let registry = jsonschema::Registry::new()
+        .add(NATIVE_PATH_SCHEMA_ID, native_path_schema)
+        .expect("native-path schema should have a valid identity")
+        .prepare()
+        .expect("native-path registry should prepare");
+    jsonschema::draft202012::options()
+        .with_registry(&registry)
+        .build(&scan_report_schema)
+        .expect("scan-report schema should compile")
+}
+
+#[test]
+fn version_output_matches_the_package_contract() -> Result<()> {
+    let output = Command::new(env!("CARGO_BIN_EXE_excise"))
+        .arg("--version")
+        .output()?;
+    ensure!(output.status.success(), "--version should succeed");
+    let stdout = String::from_utf8(output.stdout)?;
+    assert_eq!(stdout.trim(), concat!("excise ", env!("CARGO_PKG_VERSION")));
+    Ok(())
+}
+
+#[test]
+fn invalid_configuration_and_cli_inputs_keep_documented_exit_classes() -> Result<()> {
+    let root = tempfile::tempdir()?;
+    let cases = [
+        (
+            "unsupported.toml",
+            "version = 2\n",
+            78,
+            "unsupported config version 2; expected 1",
+        ),
+        (
+            "unknown.toml",
+            "version = 1\nunknown = true\n",
+            78,
+            "unknown field",
+        ),
+    ];
+    for (filename, contents, expected_exit, expected_message) in cases {
+        let config = root.path().join(filename);
+        fs::write(&config, contents)?;
+        let output = Command::new(env!("CARGO_BIN_EXE_excise"))
+            .args([
+                "--config",
+                config.to_str().context("config path should be UTF-8")?,
+            ])
+            .arg("--format")
+            .arg("json")
+            .arg(root.path())
+            .output()?;
+        ensure!(
+            output.status.code() == Some(expected_exit),
+            "{filename} should exit {expected_exit}, got {}",
+            output.status
+        );
+        let stderr = String::from_utf8(output.stderr)?;
+        assert!(
+            stderr.contains(expected_message),
+            "{filename} error should contain {expected_message:?}: {stderr:?}"
+        );
+        assert!(
+            output.stdout.is_empty(),
+            "invalid configuration must not emit JSON"
+        );
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_excise"))
+        .arg("--not-a-real-option")
+        .output()?;
+    assert_eq!(output.status.code(), Some(64));
+    Ok(())
+}
+
+#[test]
+fn headless_json_output_satisfies_the_published_schema() -> Result<()> {
+    let root = tempfile::tempdir()?;
+    fs::write(root.path().join("entry"), b"payload")?;
+    let output = Command::new(env!("CARGO_BIN_EXE_excise"))
+        .args(["--format", "json"])
+        .arg(root.path())
+        .output()?;
+    ensure!(
+        output.status.success(),
+        "JSON scan failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let document: Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(document["document_kind"], "scan-report");
+    assert_eq!(document["schema_version"], 1);
+    scan_report_validator()
+        .validate(&document)
+        .map_err(|error| anyhow::anyhow!("CLI JSON report violated its schema: {error}"))?;
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn table_output_escapes_hostile_names_without_emitting_controls() -> Result<()> {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt as _;
+
+    let root = tempfile::tempdir()?;
+    let hostile_name = OsString::from_vec(b"hostile-\n-\x1b[31m".to_vec());
+    fs::write(root.path().join(hostile_name), b"payload")?;
+    let output = Command::new(env!("CARGO_BIN_EXE_excise"))
+        .args(["--format", "table"])
+        .arg(root.path())
+        .output()?;
+    ensure!(
+        output.status.success(),
+        "table scan failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let table = String::from_utf8(output.stdout)?;
+    assert!(table.contains("[deceptive]"));
+    assert!(table.contains("\\n"));
+    assert!(table.contains("\\x1b"));
+    assert!(!table.contains('\u{1b}'));
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -579,14 +579,18 @@ fn run_behavior_checks(cargo: &OsStr) -> Result<(), Box<dyn Error>> {
     )?;
     run(
         cargo,
+        "CLI contract smoke",
+        &["test", "--test", "cli_contract_smoke", "--locked"],
+    )?;
+    run(
+        cargo,
+        "native path smoke",
+        &["test", "--test", "native_path_smoke", "--locked"],
+    )?;
+    run(
+        cargo,
         "package verification",
-        &[
-            "package",
-            "--package",
-            "excise",
-            "--locked",
-            "--allow-dirty",
-        ],
+        &["package", "--package", "excise", "--locked"],
     )?;
     run(cargo, "dependency policy", &["deny", "check"])
 }


### PR DESCRIPTION
## Summary

Close the concrete v1 readiness gaps identified after the `0.3.0` early-testing release.

## Changes

- Remove the `--allow-dirty` packaging bypass from `cargo verify`.
- Run binary-level CLI contract and native-path smoke suites as part of full verification.
- Validate version output, configuration-version and unknown-field rejection, documented exit classes, JSON schema output, and hostile table-path escaping.
- Make the v1 contract table normative and record the current lead-maintainer release authority under the existing governance model.

## Verification

- `cargo test --test cli_contract_smoke --locked`
- `cargo verify` (clean committed worktree)
