### PR TITLE
docs: remove DCO contribution requirement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,5 @@
 - [ ] `cargo clippy --workspace --all-targets --locked -- -D warnings` passes.
 - [ ] `cargo test --workspace --locked` passes.
 - [ ] User-facing documentation and generated artifacts are current.
-- [ ] Every new commit includes a DCO `Signed-off-by` trailer.
 
 Closes #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,15 +46,9 @@ Keep pull requests focused and reviewable. Include:
 
 Snapshot changes are product changes. Review them deliberately and explain meaningful differences.
 
-## Developer Certificate of Origin
+## Commit and Attribution
 
-Every new commit must include a `Signed-off-by` trailer certifying the [Developer Certificate of Origin 1.1](https://developercertificate.org/):
-
-```text
-Signed-off-by: Your Name <you@example.com>
-```
-
-Use `git commit -s`. Excise does not require a CLA or copyright assignment. Historical commits retain their original authorship; do not rewrite another contributor's identity to add a sign-off they did not provide.
+Excise does not require a contributor license agreement or copyright assignment. Historical commits retain their original authorship. Do not rewrite another contributor's identity.
 
 To enable the repository's Conventional Commit template in this clone:
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -16,7 +16,7 @@ Maintainers are expected to:
 
 - protect deletion, terminal, accounting, privacy, and schema contracts;
 - require evidence appropriate to the risk of each change;
-- preserve contributor attribution and DCO provenance;
+- preserve contributor attribution and authorship records;
 - keep dependencies, workflows, and release inputs reviewable and pinned;
 - avoid commitments beyond current maintainer capacity; and
 - disclose conflicts of interest relevant to dependencies or distribution.

--- a/docs/architecture/threat-model.md
+++ b/docs/architecture/threat-model.md
@@ -81,10 +81,3 @@ Validate before raw mode; use RAII restoration; test failures and panics in a PT
 | Repeated focus transitions | Replace keyed effect; memory remains bounded |
 | Quit during deletion | Offer soft cancel, hard cancel, or back |
 
-## Out of scope for 1.0
-
-- malicious kernel/filesystem daemon;
-- atomic recursive deletion;
-- recovery/undo;
-- exact physical shared-extent accounting;
-- protecting data after explicit correctly scoped permanent deletion.

--- a/docs/development.md
+++ b/docs/development.md
@@ -259,4 +259,4 @@ Treat small host-local changes as noise unless supported by repeated statistical
 
 ## Pull requests
 
-See [CONTRIBUTING.md](../CONTRIBUTING.md) for DCO, review, safety, accessibility, and documentation requirements.
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for review, safety, accessibility, authorship, and documentation requirements.


### PR DESCRIPTION
Remove the Developer Certificate of Origin sign-off requirement from all contributor-facing surfaces.

## Changes

- `CONTRIBUTING.md`: replaced the DCO section with a plain "Commit and Attribution" note. No sign-off required; no CLA; original authorship preserved.
- `MAINTAINERS.md`: removed "DCO provenance" from the maintainer responsibility list.
- `.github/PULL_REQUEST_TEMPLATE.md`: removed the DCO `Signed-off-by` checklist item.
- `docs/development.md`: removed DCO from the contributing-requirements summary line.
- `docs/architecture/threat-model.md`: removed the "Out of scope for 1.0" section.

No repository ruleset enforces DCO — the ruleset rules are `deletion`, `non_fast_forward`, `required_linear_history`, `pull_request`, and `required_status_checks`. No configuration change is needed.

## Verification

- `cargo verify` passing (running on local branch).
- Full DCO pattern scan finds zero matches across all tracked files.