### PR TITLE
release: prepare `v1.0.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@ All notable Excise changes are documented here. The format follows [Keep a Chang
 
 Excise preserves the historical Diskonaut changelog below. Diskonaut versions and tags are not Excise releases.
 
-## [Unreleased]
+## [1.0.1] - 2026-08-28
 
 ### Changed
 
 * Clarified the first-run path in the README and supporting documentation. The simplest `excise` command now leads the usage guidance, while detailed scan examples remain in the getting-started guide.
 
 * Reworded the safety, support, configuration, architecture, and release documentation in plain English without changing product behavior.
+
+* Removed the Developer Certificate of Origin sign-off requirement for contributors. No contributor license agreement or copyright assignment has ever been required; historical authorship records are unchanged.
 
 ## [1.0.0] - 2026-08-27
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Surgical terminal storage navigator"
 keywords = ["disk-usage", "filesystem", "terminal", "tui"]
 categories = ["command-line-utilities", "filesystem"]
 
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Aram Drevekenin <aram@poor.dev>", "Tom Larcher <tom.larcher@gmail.com>"]
 readme = "README.md"
 homepage = "https://github.com/findyourexit/excise"

--- a/docs/development.md
+++ b/docs/development.md
@@ -21,12 +21,12 @@ The published target set has separate native-behavior and release-artifact evide
 
 | Target | Support classification | Published evidence |
 | --- | --- | --- |
-| `x86_64-unknown-linux-gnu` (x86_64 Linux) | Supported in `1.0.0`; native behavioral target | Native verification plus hosted release build/archive |
-| `aarch64-apple-darwin` (AArch64 macOS) | Supported in `1.0.0`; native behavioral target | Native verification plus hosted release build/archive |
-| `x86_64-pc-windows-msvc` (x86_64 Windows) | Supported in `1.0.0`; native behavioral target | Native verification plus hosted release build/archive |
-| `x86_64-apple-darwin` (x86_64 macOS) | Build-only/best-effort; compile/archive only | Hosted release build/archive job |
-| `aarch64-unknown-linux-gnu` (AArch64 Linux) | Build-only/best-effort; compile/archive only | Hosted release build/archive job |
-| `aarch64-pc-windows-msvc` (AArch64 Windows) | Build-only/best-effort; compile/archive only | Hosted release build/archive job |
+| `x86_64-unknown-linux-gnu` (x86_64 Linux) | Supported in `1.0.0` and tested on the target system | Native checks and hosted release archive |
+| `aarch64-apple-darwin` (AArch64 macOS) | Supported in `1.0.0` and tested on the target system | Native checks and hosted release archive |
+| `x86_64-pc-windows-msvc` (x86_64 Windows) | Supported in `1.0.0` and tested on the target system | Native checks and hosted release archive |
+| `x86_64-apple-darwin` (x86_64 macOS) | Build-only and best effort | Hosted release archive |
+| `aarch64-unknown-linux-gnu` (AArch64 Linux) | Build-only and best effort | Hosted release archive |
+| `aarch64-pc-windows-msvc` (AArch64 Windows) | Build-only and best effort | Hosted release archive |
 
 The native behavioral rows are the complete `1.0.0` runtime support set. The release pipeline continues to publish all six archives, but the three compile-only targets carry no native runtime guarantee and remain best-effort until promoted by native evidence. A successful hosted build or archive demonstrates release compilation and packaging, not native runtime compatibility.
 
@@ -34,7 +34,7 @@ The target rows and workflow matrices are checked by `cargo run --locked --packa
 
 ## Filesystem and terminal scope
 
-The supported runtime target policy applies to local filesystem paths accessed through the documented operating-system APIs. Filesystem-provider-specific ACL, sharing, allocation, network or remote filesystem, reflink, clone, compression, and shared-extent behavior is best-effort unless separately evidenced; unknown allocation remains explicit rather than guessed.
+The supported runtime target policy applies to local filesystem paths accessed through the documented operating-system APIs. Behavior can vary with file system types, access rules, network file systems, copy-on-write files, clones, compression, and shared physical storage. These cases remain best effort unless they have separate evidence. Unknown allocated space remains explicit rather than guessed.
 
 Interactive support requires stdin and stdout TTYs, ANSI rendering, alternate-screen support, and a window at least `32 x 8`. Table and JSON modes are the supported non-TTY path for redirection, pipelines, CI, and terminals without those capabilities.
 

--- a/generated/man/excise.1
+++ b/generated/man/excise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH excise 1  "excise 1.0.0"
+.TH excise 1  "excise 1.0.1"
 .SH NAME
 excise
 .SH SYNOPSIS
@@ -122,4 +122,4 @@ Print version
 [\fIfolder\fR]
 Folder to scan
 .SH VERSION
-v1.0.0
+v1.0.1


### PR DESCRIPTION
Patch release preparation for 1.0.1.

## Changes

- Bumps `version` to `1.0.1` in `Cargo.toml` and updates the single `excise` entry in `Cargo.lock`.
- Moves the `[Unreleased]` changelog entries to `[1.0.1] - 2026-08-28`; adds the DCO removal entry.
- Regenerates the man page and shell completions for the updated version string.

## Verification

`cargo verify` running locally.