### PR TITLE
chore: update dependencies and toolchain to Rust `1.98`

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,8 +38,8 @@ jobs:
           printf 'Release SHA: %s\n' "$RELEASE_SHA"
       - name: Install pinned MSRV
         run: |
-          rustup toolchain install 1.88.0 --profile minimal
-          rustup override set 1.88.0
+          rustup toolchain install 1.98.0 --profile minimal
+          rustup override set 1.98.0
       - name: Run statistical render benchmark
         run: cargo bench --bench tachyonfx --features internal --locked -- --noplot
       - name: Run statistical core benchmark

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Install pinned MSRV
         shell: bash
         run: |
-          rustup toolchain install 1.88.0 --profile minimal --component clippy,rustfmt
-          rustup override set 1.88.0
+          rustup toolchain install 1.98.0 --profile minimal --component clippy,rustfmt
+          rustup override set 1.98.0
           rustc --version --verbose
       - name: Install dependency policy tool
         shell: bash

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -30,8 +30,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          rustup toolchain install 1.88.0 --profile minimal
-          rustup override set 1.88.0
+          rustup toolchain install 1.98.0 --profile minimal
+          rustup override set 1.98.0
 
       - name: Build release binary
         run: cargo build --package excise --release --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,9 +301,9 @@ jobs:
           TARGET: ${{ matrix.target }}
         run: |
           set -euo pipefail
-          rustup toolchain install 1.88.0 --profile minimal --no-self-update
-          rustup target add "$TARGET" --toolchain 1.88.0
-          rustup override set 1.88.0
+          rustup toolchain install 1.98.0 --profile minimal --no-self-update
+          rustup target add "$TARGET" --toolchain 1.98.0
+          rustup override set 1.98.0
       - name: Build locked release binary
         shell: bash
         env:
@@ -836,8 +836,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          rustup toolchain install 1.88.0 --profile minimal --no-self-update
-          rustup override set 1.88.0
+          rustup toolchain install 1.98.0 --profile minimal --no-self-update
+          rustup override set 1.98.0
       - name: Verify checked-out tag and manifest version
         shell: bash
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -105,7 +105,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -173,27 +173,25 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.9.3"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
+checksum = "9e3fac94a66da67200398458a25412bcc3f9b6443b5119a6cad9cf3ccfcd8cc6"
 dependencies = [
  "bon-macros",
- "rustversion",
 ]
 
 [[package]]
 name = "bon-macros"
-version = "3.9.3"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
+checksum = "d4654961ad0494e4774c5c60b4cb4cd0ae9b9d92d039d901638b1dba97ebebf5"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "ident_case",
  "prettyplease",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -241,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "cap-primitives"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+checksum = "8b5f74729fd2f44701d1a8eb47e906cdb3ccd9ec0f02baad85a744b791940b18"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
@@ -253,7 +251,7 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
  "winx",
 ]
 
@@ -298,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -391,7 +389,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -461,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -586,70 +584,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
-dependencies = [
- "darling_core 0.24.0",
- "darling_macro 0.24.0",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
 dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
-dependencies = [
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
-dependencies = [
- "darling_core 0.24.0",
- "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -714,7 +678,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -725,7 +689,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -745,9 +709,9 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "email_address"
@@ -777,7 +741,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -882,12 +846,13 @@ checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1096,9 +1061,9 @@ checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1154,9 +1119,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -1189,11 +1154,11 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf84e73fa6f27f299dec58e13223cf70db80da872eb921d4f6138342a0eabc8"
 dependencies = [
- "darling 0.24.0",
+ "darling",
  "indoc",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1356,9 +1321,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
 dependencies = [
  "libc",
 ]
@@ -1401,15 +1366,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
+checksum = "0d317b4b9eb398e6acce275758ec6125535505e7a146fb1a9b8bda2451b0ff4c"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -1440,9 +1405,9 @@ checksum = "c3c8dda44ff03a2f238717214da50f65d5a53b45cd213a7370424ffdb6fae815"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -1751,12 +1716,12 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.37"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
 dependencies = [
  "proc-macro2",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1902,7 +1867,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1976,7 +1941,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2053,7 +2018,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2223,9 +2188,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2292,7 +2257,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2332,7 +2297,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2582,7 +2547,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3003,9 +2968,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3014,14 +2979,20 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,7 +2,7 @@
 
 ## Toolchain
 
-The workspace uses Rust 1.88 and edition 2024. Install the pinned toolchain and supported compilation targets:
+The workspace uses Rust 1.98 and edition 2024. Install the pinned toolchain and supported compilation targets:
 
 ```console
 rustup show
@@ -228,7 +228,7 @@ The `cargo demo` alias is current `main` development behavior rather than a rele
 ```console
 (
   set -euo pipefail
-  cargo +1.88.0 build --release --locked --package excise
+  cargo +1.98.0 build --release --locked --package excise
   cargo demo
 )
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,11 +10,11 @@ The project is independent from Diskonaut. Tags `0.1.0` through `0.11.0` are pre
 
 ## Requirements
 
-- Rust 1.88 or newer
+- Rust 1.98 or newer
 - A terminal with color and separate-screen support for the interactive interface
 - Linux, macOS, or Windows
 
-The repository pins Rust 1.88 in `rust-toolchain.toml`.
+The repository pins Rust 1.98 in `rust-toolchain.toml`.
 
 For the `1.0.0` support policy, x86_64 Linux, AArch64 macOS, and x86_64 Windows have been tested on the target systems and are fully supported. x86_64 macOS, AArch64 Linux, and AArch64 Windows have release artifacts but remain build-only and best effort until they have been tested on the target systems. File system limitations are documented in [Support](../SUPPORT.md).
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.98.0"
 components = ["clippy", "rustfmt"]
 profile = "minimal"

--- a/src/deletion.rs
+++ b/src/deletion.rs
@@ -758,12 +758,11 @@ where
     };
     match removal {
         Ok(()) => {
-            if let Some(link_hold) = link_hold.as_ref() {
-                if !link_hold_matches_count(&parent, link_hold, actual.identity.link_count)
+            if let Some(link_hold) = link_hold.as_ref()
+                && !link_hold_matches_count(&parent, link_hold, actual.identity.link_count)
                     .unwrap_or(false)
-                {
-                    entry.snapshot.identity.link_count = None;
-                }
+            {
+                entry.snapshot.identity.link_count = None;
             }
             let finalization =
                 finalize_placeholder(&parent, &original_name, &detached_name, &placeholder);

--- a/src/model/arena.rs
+++ b/src/model/arena.rs
@@ -2284,10 +2284,7 @@ impl Arena {
     }
 
     fn propagate_add(&mut self, mut id: NodeId, metrics: NodeMetrics) {
-        loop {
-            let Some(node) = self.node_mut(id) else {
-                break;
-            };
+        while let Some(node) = self.node_mut(id) {
             if node
                 .unscanned_reason
                 .as_ref()
@@ -2304,10 +2301,7 @@ impl Arena {
     }
 
     fn propagate_descendant(&mut self, mut id: NodeId, count: u64) {
-        loop {
-            let Some(node) = self.node_mut(id) else {
-                break;
-            };
+        while let Some(node) = self.node_mut(id) {
             node.metrics.descendants = node.metrics.descendants.saturating_add(count);
             let Some(parent) = node.parent else {
                 break;

--- a/src/native_path.rs
+++ b/src/native_path.rs
@@ -391,8 +391,10 @@ fn decode_path(encoded: &EncodedNativePath) -> Result<PathBuf, PathCodecError> {
                 return Err(PathCodecError::OddUtf16Length);
             }
             let units = bytes
-                .chunks_exact(2)
-                .map(|bytes| u16::from_le_bytes([bytes[0], bytes[1]]))
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .map(|bytes| u16::from_le_bytes(*bytes))
                 .collect::<Vec<_>>();
             Ok(PathBuf::from(OsString::from_wide(&units)))
         }

--- a/src/runtime/scanner.rs
+++ b/src/runtime/scanner.rs
@@ -1402,9 +1402,8 @@ mod tests {
             state.pending = 1;
         }
 
-        let error = match queue.take(&cancelled, &failed, &root_invalid) {
-            Ok(_) => panic!("out-of-root spill path should be rejected"),
-            Err(error) => error,
+        let Err(error) = queue.take(&cancelled, &failed, &root_invalid) else {
+            panic!("out-of-root spill path should be rejected")
         };
         assert_eq!(error.kind(), io::ErrorKind::InvalidData);
     }

--- a/src/tests/cases/test_utils.rs
+++ b/src/tests/cases/test_utils.rs
@@ -72,8 +72,9 @@ pub fn assert_terminal_lifecycle(events: &[TerminalEvent]) {
     assert_eq!(frames.len() % 3, 0, "incomplete draw frame: {frames:?}");
     assert!(
         frames
-            .chunks_exact(3)
-            .all(|frame| frame == [Draw, HideCursor, Flush]),
-        "unexpected terminal frame sequence: {frames:?}"
+            .as_chunks::<3>()
+            .0
+            .iter()
+            .all(|frame| frame == &[Draw, HideCursor, Flush]),
     );
 }

--- a/src/ui/format/truncate.rs
+++ b/src/ui/format/truncate.rs
@@ -18,7 +18,11 @@ pub fn truncate_middle(row: &str, max_length: u16) -> String {
     if max_length < 6 {
         truncate_iter_to_unicode_width(row.chars(), max_length as usize)
     } else if row.width() as u16 > max_length {
-        let marker = if max_length % 2 == 0 { "[...]" } else { "[..]" };
+        let marker = if max_length.is_multiple_of(2) {
+            "[...]"
+        } else {
+            "[..]"
+        };
         let remaining = usize::from(max_length).saturating_sub(marker.width());
         let first_width = remaining / 2;
         let second_width = remaining.saturating_sub(first_width);

--- a/src/ui/palette.rs
+++ b/src/ui/palette.rs
@@ -177,7 +177,7 @@ impl Oklch {
             hue: self.hue,
         };
         let lead = tinted_ink(fill, [dark.to_rgb(), light.to_rgb()], LEAD_CONTRAST_FLOOR)
-            .map_or_else(|| strongest_neutral(fill), |ink| ink);
+            .unwrap_or_else(|| strongest_neutral(fill));
         let detail = tinted_ink(
             fill,
             [
@@ -186,7 +186,7 @@ impl Oklch {
             ],
             DETAIL_CONTRAST_FLOOR,
         )
-        .map_or_else(|| strongest_neutral(fill), |ink| ink);
+        .unwrap_or_else(|| strongest_neutral(fill));
         (color_from_rgb(lead), color_from_rgb(detail))
     }
 }
@@ -765,10 +765,10 @@ pub(crate) fn derived_for_with_monochrome(
     let slot = usize::from(monochrome);
     DERIVED_PALETTE.with(|memo| {
         let mut memo = memo.borrow_mut();
-        if let Some(derived) = memo[slot] {
-            if derived.key == key {
-                return (derived.cycle, derived.map);
-            }
+        if let Some(derived) = memo[slot]
+            && derived.key == key
+        {
+            return (derived.cycle, derived.map);
         }
         let derived = DerivedPalette {
             key,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -353,10 +353,10 @@ fn remove_demo_files(paths: &[&Path]) -> io::Result<()> {
     let mut first_error: Option<io::Error> = None;
 
     for &path in paths {
-        if let Err(error) = remove_file_if_exists(path) {
-            if first_error.is_none() {
-                first_error = Some(error);
-            }
+        if let Err(error) = remove_file_if_exists(path)
+            && first_error.is_none()
+        {
+            first_error = Some(error);
         }
     }
 
@@ -1735,7 +1735,7 @@ fn validate_winget_manifest(rendered: &str, version: &str) -> Result<(), Box<dyn
             format!("{context} must publish the excise command alias"),
         )?;
         require(
-            windows_archive_executable(asset, version) == PathBuf::from(relative_path),
+            windows_archive_executable(asset, version) == *relative_path,
             format!("{context} would not install the wrapped executable"),
         )?;
     }


### PR DESCRIPTION
Bumps the pinned Rust toolchain from 1.88.0 to 1.98.0 and updates all compatible dependencies.

## Changes

**Toolchain**
- `rust-toolchain.toml`: 1.88.0 → 1.98.0
- All workflow files (`ci.yml`, `release.yml`, `benchmark.yml`, `demo.yml`): matching `rustup` install and override calls updated
- `docs/development.md`, `docs/getting-started.md`: version references updated

**Dependencies** (`cargo update` — 21 packages)
- `bon` / `bon-macros` 3.9.3 → 3.10.0
- `cap-primitives` 4.0.2 → 4.0.3
- `darling` / `darling_core` / `darling_macro` 0.24.0 → 0.24.1
- `flate2` 1.1.9 → 1.1.10, `miniz_oxide` 0.8.9 → 0.9.1, adds `zlib-rs` 0.6.7
- `prettyplease` 0.2.37 → 0.3.0 (transitive proc-macro formatter; no product API exposure)
- `syn` 3.0.3 → 3.0.4, `icu_provider` 2.3.0 → 2.3.1, and 14 further patch bumps

**Clippy fixes** (new 1.98 lints, all mechanical)
- `collapsible_if`: 3 sites (`src/deletion.rs`, `src/ui/palette.rs`, `xtask/src/main.rs`)
- `while_let_loop`: 2 sites (`src/model/arena.rs`)
- `manual_is_multiple_of`: 1 site (`src/ui/format/truncate.rs`)
- `unnecessary_option_map_or_else`: 2 sites (`src/ui/palette.rs`)
- `manual_let_else`: 1 site (`src/runtime/scanner.rs`)
- `chunks_exact_to_as_chunks`: 1 site (`src/tests/cases/test_utils.rs`)
- `cmp_owned`: 1 site (`xtask/src/main.rs`)

## Verification

Full `cargo verify` passed on the clean committed tree: format, workflow syntax, Renovate config, documentation links, compile, cross-check `aarch64-apple-darwin`, strict Clippy, 445 unit and snapshot tests, release binary build, PTY smoke, CLI contract smoke, native path smoke, and package verification.