### PR TITLE
fix: skip disk capacity refresh when checking for mount roots

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/src/deletion.rs
+++ b/src/deletion.rs
@@ -12,7 +12,8 @@ use cap_primitives::ambient_authority;
 use cap_primitives::fs::{self as cap_fs, FollowSymlinks};
 use file_id::FileId;
 use serde::{Deserialize, Serialize};
-use sysinfo::Disks;
+#[cfg(not(unix))]
+use sysinfo::{DiskRefreshKind, Disks};
 
 use crate::model::NodeId;
 use crate::model::NodeKind;
@@ -1267,10 +1268,21 @@ fn is_mount_root(path: &Path) -> io::Result<bool> {
     if canonical.parent().is_none_or(|parent| parent == canonical) {
         return Ok(true);
     }
-    let disks = Disks::new_with_refreshed_list();
-    Ok(disks.list().iter().any(|disk| {
-        std::fs::canonicalize(disk.mount_point()).is_ok_and(|mount| mount == canonical)
-    }))
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt as _;
+        let path_dev = std::fs::symlink_metadata(&canonical)?.dev();
+        let parent = canonical.parent().expect("non-root path has a parent");
+        let parent_dev = std::fs::symlink_metadata(parent)?.dev();
+        Ok(path_dev != parent_dev)
+    }
+    #[cfg(not(unix))]
+    {
+        let disks = Disks::new_with_refreshed_list_specifics(DiskRefreshKind::nothing());
+        Ok(disks.list().iter().any(|disk| {
+            std::fs::canonicalize(disk.mount_point()).is_ok_and(|mount| mount == canonical)
+        }))
+    }
 }
 
 fn relative_target(target: &FileToDelete) -> Result<PathBuf, DeletionPlanError> {


### PR DESCRIPTION
This is a cherry-pick of the same fix as PR #47, carried here so that PR #46 (inline arena node storage) has a clean stack to sit on.

The arena `complete_directory` optimization originally intended for this PR uncovered a regression in the deletion-rescan cycle and has been deferred to a separate investigation. This PR now contains only the disk capacity fix.

See PR #47 for the full explanation of the fix.