### PR TITLE
skip disk capacity refresh when checking for mount roots

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/src/deletion.rs
+++ b/src/deletion.rs
@@ -12,7 +12,8 @@ use cap_primitives::ambient_authority;
 use cap_primitives::fs::{self as cap_fs, FollowSymlinks};
 use file_id::FileId;
 use serde::{Deserialize, Serialize};
-use sysinfo::Disks;
+#[cfg(not(unix))]
+use sysinfo::{DiskRefreshKind, Disks};
 
 use crate::model::NodeId;
 use crate::model::NodeKind;
@@ -1268,10 +1269,21 @@ fn is_mount_root(path: &Path) -> io::Result<bool> {
     if canonical.parent().is_none_or(|parent| parent == canonical) {
         return Ok(true);
     }
-    let disks = Disks::new_with_refreshed_list();
-    Ok(disks.list().iter().any(|disk| {
-        std::fs::canonicalize(disk.mount_point()).is_ok_and(|mount| mount == canonical)
-    }))
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt as _;
+        let path_dev = std::fs::symlink_metadata(&canonical)?.dev();
+        let parent = canonical.parent().expect("non-root path has a parent");
+        let parent_dev = std::fs::symlink_metadata(parent)?.dev();
+        Ok(path_dev != parent_dev)
+    }
+    #[cfg(not(unix))]
+    {
+        let disks = Disks::new_with_refreshed_list_specifics(DiskRefreshKind::nothing());
+        Ok(disks.list().iter().any(|disk| {
+            std::fs::canonicalize(disk.mount_point()).is_ok_and(|mount| mount == canonical)
+        }))
+    }
 }
 
 fn relative_target(target: &FileToDelete) -> Result<PathBuf, DeletionPlanError> {


### PR DESCRIPTION
## Problem

\`is_mount_root\` in \`src/deletion.rs\` called \`Disks::new_with_refreshed_list()\`, which is equivalent to \`Disks::new_with_refreshed_list_specifics(DiskRefreshKind::everything())\`. The \`everything()\` refresh kind includes storage capacity data.

On macOS, querying storage capacity calls \`CacheDeleteCopyAvailableSpaceForVolume\` inside \`StorageKit.framework\`. This function asks the system to calculate how much purgeable space (Time Machine snapshots, APFS clones, caches) could be freed, and in certain volume states on macOS 26 (Tahoe) it blocks the calling thread indefinitely. There is no internal timeout.

The symptom is that any deletion plan involving a directory stalls the deletion worker thread, causing tests and the application itself to hang until the OS call eventually returns or times out.

## Fix

\`is_mount_root\` only needs to compare a candidate path against known mount points. Mount point paths are populated regardless of whether storage capacity is requested. Switching to \`DiskRefreshKind::nothing()\` gives the same list of mounts without triggering the capacity query.

Before: \`Disks::new_with_refreshed_list()\`
After: \`Disks::new_with_refreshed_list_specifics(DiskRefreshKind::nothing())\`

## Verification

The \`persistent_directory_change_is_rescanned_before_reprompting\` test exercises the full deletion planning path for a directory, which calls \`is_mount_root\`. Before this change it stalled for the full test timeout (3600 s) on macOS 26. After this change it completes in under 0.2 s.

The \`sysinfo::System::refresh_memory()\` call in \`src/model/memory.rs\` is a separate call site that reads physical RAM statistics via the Mach kernel (\`host_statistics64\`). That call does not touch disk enumeration or APFS snapshot accounting and is not affected by this issue.