### PR TITLE
release: prepare `v1.1.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable Excise changes are documented here. The format follows [Keep a Chang
 
 Excise preserves the historical Diskonaut changelog below. Diskonaut versions and tags are not Excise releases.
 
-## [Unreleased]
+## [1.1.0] - 2026-09-01
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Surgical terminal storage navigator"
 keywords = ["disk-usage", "filesystem", "terminal", "tui"]
 categories = ["command-line-utilities", "filesystem"]
 
-version = "1.0.2"
+version = "1.1.0"
 authors = ["Aram Drevekenin <aram@poor.dev>", "Tom Larcher <tom.larcher@gmail.com>"]
 readme = "README.md"
 homepage = "https://github.com/findyourexit/excise"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -438,7 +438,7 @@ checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "equivalent"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/generated/man/excise.1
+++ b/generated/man/excise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH excise 1  "excise 1.0.2"
+.TH excise 1  "excise 1.1.0"
 .SH NAME
 excise
 .SH SYNOPSIS
@@ -122,4 +122,4 @@ Print version
 [\fIfolder\fR]
 Folder to scan
 .SH VERSION
-v1.0.2
+v1.1.0


### PR DESCRIPTION
Bumps version to 1.1.0. Moves the deletion-friction UX improvement entries into the dated changelog section and regenerates the man page.

## Changes
- `Cargo.toml`: 1.0.2 → 1.1.0
- `CHANGELOG.md`: `[Unreleased]` → `[1.1.0] - 2026-09-01`
- `generated/man/excise.1`: regenerated for 1.1.0
- `Cargo.lock`, `fuzz/Cargo.lock`: version references updated