### PR TITLE
fix: restore equivalent 1.0.2 in fuzz/Cargo.lock

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -438,7 +438,7 @@ checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "equivalent"
-version = "1.1.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 


### PR DESCRIPTION
An over-broad release-prep sed replaced every `version = "1.0.2"` entry in `fuzz/Cargo.lock`, incorrectly changing the registry-only `equivalent` crate to unavailable version 1.1.0. This restores `equivalent` to 1.0.2; only that package was changed and the local `excise` package remains at 1.1.0.