### PR TITLE
fix: replace cryptic subtree invariant errors with actionable messages

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -591,6 +591,27 @@ where
             self.show_error("Deletion requires a complete, materialized entry");
             return None;
         }
+        // Pre-check the full subtree before building the reviewed list, so the
+        // user sees an actionable message rather than an internal invariant error.
+        if let Err(reason) = self
+            .file_tree
+            .subtree_deletion_eligibility(file_to_delete.node_id)
+        {
+            let message = match reason {
+                "still scanning" => {
+                    "This directory has entries that are still being scanned. \
+                     Deletion is available for fully scanned entries; \
+                     wait for the scan to complete and try again."
+                }
+                _ => {
+                    "Some entries in this directory are held as a memory-efficient \
+                     aggregate and cannot be individually verified for deletion. \
+                     Navigate into the directory to select specific items to delete."
+                }
+            };
+            self.show_error(message);
+            return None;
+        }
         file_to_delete.reviewed_entries = match self
             .file_tree
             .reviewed_subtree(file_to_delete.node_id, self.maximum_deletion_plan_bytes())

--- a/src/state/files/file_tree.rs
+++ b/src/state/files/file_tree.rs
@@ -193,6 +193,36 @@ impl FileTree {
         })
     }
 
+    /// Returns a human-readable ineligibility reason if any node in the
+    /// subtree rooted at `root` cannot currently be reviewed for deletion,
+    /// or `Ok(())` if the subtree is fully eligible.
+    ///
+    /// Call this before [`Self::reviewed_subtree`] to surface actionable
+    /// messages rather than internal invariant errors.
+    pub fn subtree_deletion_eligibility(&self, root: NodeId) -> Result<(), &'static str> {
+        let mut stack = vec![root];
+        while let Some(id) = stack.pop() {
+            let Some(node) = self.arena.node(id) else {
+                continue;
+            };
+            // Shared entries are excluded by the deletion review and worker; skip them.
+            if node.kind == NodeKind::Synthetic(SyntheticKind::Shared) {
+                continue;
+            }
+            match node.state {
+                NodeState::Scanning => return Err("still scanning"),
+                NodeState::Aggregated => return Err("aggregated"),
+                NodeState::Uncertain => return Err("uncertain"),
+                NodeState::Complete => {}
+            }
+            if node.kind.is_synthetic() {
+                return Err("aggregated");
+            }
+            stack.extend(node.children.iter().copied());
+        }
+        Ok(())
+    }
+
     pub fn reviewed_subtree(
         &self,
         root: NodeId,


### PR DESCRIPTION
## Problem

Two situations produce the opaque error `model invariant failed: deletion requires a fully materialized subtree` when the user presses Backspace on a directory:

**During the initial scan.** A directory's own node may be `Complete` (its immediate listing is done) while descendant directories are still in `NodeState::Scanning`. The v1.1.0 change allows Backspace during loading, so the root-node state check now passes and the call reaches `reviewed_subtree`, which correctly refuses the scanning descendants — but surfaces a raw internal string instead of something the user can act on.

**After the scan, on directories with aggregated entries.** When the bounded model memory is exhausted, subtrees are evicted and their children become `NodeState::Aggregated` under a `SyntheticKind::Aggregate` node. These entries no longer carry individual identities, so `reviewed_subtree` refuses them. For build directories with many small files, this means no top-level directory deletion is possible at all.

## Fix

Add `FileTree::subtree_deletion_eligibility` — a lightweight pre-walk that returns a short diagnostic tag (`"still scanning"`, `"aggregated"`, `"uncertain"`) for the first ineligible node it finds. Call it in `prompt_file_deletion` between the root-node state check and the `reviewed_subtree` call, translating the tag into a readable error:

- **`still scanning`** → `"This directory has entries that are still being scanned. Deletion is available for fully scanned entries; wait for the scan to complete and try again."`
- **anything else** → `"Some entries in this directory are held as a memory-efficient aggregate and cannot be individually verified for deletion. Navigate into the directory to select specific items to delete."`

The existing `reviewed_subtree` call and its handler remain as a safety net.