### PR TITLE
fix: drop per-file review requirement for directory deletion

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -591,37 +591,24 @@ where
             self.show_error("Deletion requires a complete, materialized entry");
             return None;
         }
-        // Pre-check the full subtree before building the reviewed list, so the
-        // user sees an actionable message rather than an internal invariant error.
-        if let Err(reason) = self
-            .file_tree
-            .subtree_deletion_eligibility(file_to_delete.node_id)
-        {
-            let message = match reason {
-                "still scanning" => {
-                    "This directory has entries that are still being scanned. \
-                     Deletion is available for fully scanned entries; \
-                     wait for the scan to complete and try again."
-                }
-                _ => {
-                    "Some entries in this directory are held as a memory-efficient \
-                     aggregate and cannot be individually verified for deletion. \
-                     Navigate into the directory to select specific items to delete."
+        // For file and link targets, build a per-entry reviewed list used by
+        // the planning worker to detect model-vs-filesystem drift. For directory
+        // targets, skip this: the worker performs its own live filesystem walk
+        // and uses that as the authoritative plan, matching diskonaut's simpler
+        // deletion model. The directory identity check in the worker (via
+        // validate_model_snapshot) still ensures we target the right directory.
+        if file_to_delete.file_type != FileType::Folder {
+            file_to_delete.reviewed_entries = match self
+                .file_tree
+                .reviewed_subtree(file_to_delete.node_id, self.maximum_deletion_plan_bytes())
+            {
+                Ok(entries) => entries,
+                Err(error) => {
+                    self.show_error(error.to_string());
+                    return None;
                 }
             };
-            self.show_error(message);
-            return None;
         }
-        file_to_delete.reviewed_entries = match self
-            .file_tree
-            .reviewed_subtree(file_to_delete.node_id, self.maximum_deletion_plan_bytes())
-        {
-            Ok(entries) => entries,
-            Err(error) => {
-                self.show_error(error.to_string());
-                return None;
-            }
-        };
         self.deletion_replan = None;
         self.ui_mode = UiMode::PlanningDeletion(Box::new(file_to_delete.display_copy()));
         self.mark_dirty();

--- a/src/deletion.rs
+++ b/src/deletion.rs
@@ -458,15 +458,19 @@ pub(crate) fn build_plan_cancellable_with_root_identity(
     target
         .reviewed_entries
         .sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    if entries.len() != target.reviewed_entries.len()
-        || entries.iter().any(|entry| {
-            target
-                .reviewed_entries
-                .binary_search_by(|reviewed| reviewed.relative_path.cmp(&entry.relative_path))
-                .ok()
-                .and_then(|index| target.reviewed_entries.get(index))
-                .is_none_or(|reviewed| reviewed.snapshot != entry.snapshot)
-        })
+    // reviewed_entries is empty for directory targets (the live walk above is
+    // the authoritative plan). For file and link targets it is always populated
+    // and the comparison detects model-vs-filesystem drift before committing.
+    if !target.reviewed_entries.is_empty()
+        && (entries.len() != target.reviewed_entries.len()
+            || entries.iter().any(|entry| {
+                target
+                    .reviewed_entries
+                    .binary_search_by(|reviewed| reviewed.relative_path.cmp(&entry.relative_path))
+                    .ok()
+                    .and_then(|index| target.reviewed_entries.get(index))
+                    .is_none_or(|reviewed| reviewed.snapshot != entry.snapshot)
+            }))
     {
         return Err(DeletionPlanError::Changed);
     }

--- a/src/state/files/file_tree.rs
+++ b/src/state/files/file_tree.rs
@@ -193,36 +193,6 @@ impl FileTree {
         })
     }
 
-    /// Returns a human-readable ineligibility reason if any node in the
-    /// subtree rooted at `root` cannot currently be reviewed for deletion,
-    /// or `Ok(())` if the subtree is fully eligible.
-    ///
-    /// Call this before [`Self::reviewed_subtree`] to surface actionable
-    /// messages rather than internal invariant errors.
-    pub fn subtree_deletion_eligibility(&self, root: NodeId) -> Result<(), &'static str> {
-        let mut stack = vec![root];
-        while let Some(id) = stack.pop() {
-            let Some(node) = self.arena.node(id) else {
-                continue;
-            };
-            // Shared entries are excluded by the deletion review and worker; skip them.
-            if node.kind == NodeKind::Synthetic(SyntheticKind::Shared) {
-                continue;
-            }
-            match node.state {
-                NodeState::Scanning => return Err("still scanning"),
-                NodeState::Aggregated => return Err("aggregated"),
-                NodeState::Uncertain => return Err("uncertain"),
-                NodeState::Complete => {}
-            }
-            if node.kind.is_synthetic() {
-                return Err("aggregated");
-            }
-            stack.extend(node.children.iter().copied());
-        }
-        Ok(())
-    }
-
     pub fn reviewed_subtree(
         &self,
         root: NodeId,


### PR DESCRIPTION
Supersedes the previous diagnostic approach from #55.

## What was wrong

The prior commit added `subtree_deletion_eligibility` and blocked directory deletion whenever any child node was in `Scanning` or `Aggregated` state. This was the wrong fix — it produced a better error message but still refused deletions that work fine in diskonaut.

The underlying issue was the `reviewed_entries` consistency check in the deletion planner (`build_plan_cancellable_with_root_identity`). The check compares the live filesystem walk against a snapshot derived from the in-memory model. For directory targets the model snapshot is unreliable: children may still be scanning (initial scan in progress) or may have been evicted into memory-efficient aggregate nodes (bounded model under pressure). Either situation causes a count mismatch and the planner returns `Changed`.

## Why this check exists and why it is wrong for directories

For **file** deletion the check matters: the user is targeting a specific inode and the identity comparison detects a replaced or modified file between the moment they pressed Backspace and when the worker runs.

For **directory** deletion the planner already does a fresh, comprehensive live filesystem walk and revalidates every entry against the filesystem immediately before execution (`revalidate_plan_cancellable`). The `reviewed_entries` snapshot is a redundant second picture that only adds failure modes. Diskonaut has never had this check; it simply deletes the directory tree as it finds it.

## The fix

- Remove `subtree_deletion_eligibility` (no longer needed).
- In `prompt_file_deletion`, call `reviewed_subtree` only for file and link targets; directory targets proceed with `reviewed_entries` left empty.
- In `build_plan_cancellable_with_root_identity`, skip the model-vs-filesystem comparison when `reviewed_entries` is empty. The live walk is the authoritative plan. The directory identity check (`validate_model_snapshot`) still verifies we are targeting the right directory.