### PR TITLE
release: prepare `v1.1.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable Excise changes are documented here. The format follows [Keep a Chang
 
 Excise preserves the historical Diskonaut changelog below. Diskonaut versions and tags are not Excise releases.
 
+## [1.1.1] - 2026-09-01
+
+### Fixed
+
+* Directory deletion now works correctly regardless of whether the initial scan is still running or whether directory contents were evicted from the bounded in-memory model due to memory pressure. The previous release required a complete in-memory snapshot of every file in the subtree before allowing a deletion plan to proceed; this blocked deletion of any directory whose descendants were still scanning or had been aggregated, even when the directory's own node was fully scanned. The planning worker now builds the deletion plan from its own fresh live filesystem walk, matching the approach used by Diskonaut. File and link deletion retains per-entry identity snapshots for targeted single-entry safety.
+
+### Changed
+
+* Added `cargo create-release-tag <version> <sha> <candidate-run-id>` as a `cargo xtask` subcommand. It creates an annotated release tag in the format required by the release workflow, embedding `candidate-run-id: <id>` in the tag message. The `docs/releasing.md` runbook now documents the annotated-tag creation step between bundle verification and the push that triggers the release workflow.
+
 ## [1.1.0] - 2026-09-01
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Surgical terminal storage navigator"
 keywords = ["disk-usage", "filesystem", "terminal", "tui"]
 categories = ["command-line-utilities", "filesystem"]
 
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Aram Drevekenin <aram@poor.dev>", "Tom Larcher <tom.larcher@gmail.com>"]
 readme = "README.md"
 homepage = "https://github.com/findyourexit/excise"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/generated/man/excise.1
+++ b/generated/man/excise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH excise 1  "excise 1.1.0"
+.TH excise 1  "excise 1.1.1"
 .SH NAME
 excise
 .SH SYNOPSIS
@@ -122,4 +122,4 @@ Print version
 [\fIfolder\fR]
 Folder to scan
 .SH VERSION
-v1.1.0
+v1.1.1


### PR DESCRIPTION
Patch release following the 1.1.0 post-release fixes.

## Changes since 1.1.0

### Fixed
- **Directory deletion** now works correctly regardless of whether the initial scan is still running or whether directory contents were evicted from the bounded in-memory model due to memory pressure. The prior release required a complete in-memory snapshot of every file in the subtree before allowing a deletion plan to proceed; this blocked deletion of any directory whose descendants were still scanning or had been aggregated. The planning worker now builds the deletion plan from its own fresh live filesystem walk, matching Diskonaut's approach. File and link deletion retains per-entry identity snapshots.

### Changed
- Added `cargo create-release-tag <version> <sha> <candidate-run-id>` xtask subcommand. Creates an annotated release tag in the format required by the release workflow. The `docs/releasing.md` runbook now documents this step.

## Files changed
- `CHANGELOG.md`: new `[1.1.1]` section
- `Cargo.toml`, `Cargo.lock`, `fuzz/Cargo.lock`: 1.1.0 → 1.1.1
- `generated/man/excise.1`: regenerated for 1.1.1