### PR TITLE
release: prepare `v1.2.0`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
     id: version
     attributes:
       label: Excise version or commit
-      placeholder: "v1.0.0 or 0123456789abcdef"
+      placeholder: "v1.2.0 or 0123456789abcdef"
     validations:
       required: true
   - type: dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable Excise changes are documented here. The format follows [Keep a Chang
 
 Excise preserves the historical Diskonaut changelog below. Diskonaut versions and tags are not Excise releases.
 
+## [1.2.0] - 2026-09-02
+
+### Changed
+
+* Simplified the ordinary directory-deletion review flow to use a single-key confirmation. Directories with deceptive names still require their generated safety challenge.
+* Directory deletion plans can exceed the retained file and link history budget. The planning dialog estimates entries, and deletion displays live per-identity progress while execution runs.
+* The default scanner worker count reserves one available processor for user interaction and never exceeds eight workers.
+
+### Fixed
+
+* Treemap navigation stays responsive during active scans. Folder drills render before queued scanner work, and scanner model updates wait while treemap geometry is moving instead of skipping navigation frames.
+* Tree compaction continues at the model memory limit after deep navigation returns to the root by reusing an untracked summary slot from the subtree being removed.
+
 ## [1.1.1] - 2026-09-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Surgical terminal storage navigator"
 keywords = ["disk-usage", "filesystem", "terminal", "tui"]
 categories = ["command-line-utilities", "filesystem"]
 
-version = "1.1.1"
+version = "1.2.0"
 authors = ["Aram Drevekenin <aram@poor.dev>", "Tom Larcher <tom.larcher@gmail.com>"]
 readme = "README.md"
 homepage = "https://github.com/findyourexit/excise"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It is an independent fork and spiritual successor to [Diskonaut](https://github.
 ```console
 brew tap findyourexit/tap
 brew install findyourexit/tap/excise
-excise --version  # excise 1.0.0
+excise --version  # excise 1.2.0
 ```
 
 </details>
@@ -42,8 +42,8 @@ excise --version  # excise 1.0.0
 <summary><strong>crates.io</strong></summary>
 
 ```console
-cargo install excise --version 1.0.0 --locked
-excise --version  # excise 1.0.0
+cargo install excise --version 1.2.0 --locked
+excise --version  # excise 1.2.0
 ```
 
 </details>
@@ -51,7 +51,7 @@ excise --version  # excise 1.0.0
 <details>
 <summary><strong>Pre-built Binaries</strong></summary>
 
-Download the [v1.0.0 release](https://github.com/findyourexit/excise/releases/tag/v1.0.0) for macOS, Linux, and Windows on Apple silicon, Intel, or Arm systems.
+Download the [v1.2.0 release](https://github.com/findyourexit/excise/releases/tag/v1.2.0) for macOS, Linux, and Windows on Apple silicon, Intel, or Arm systems.
 
 Only x86_64 Linux, AArch64 macOS, and x86_64 Windows have full platform support because they are tested on those platforms. The other archives are build-only and best effort. See the [Support Policy](SUPPORT.md).
 
@@ -61,7 +61,7 @@ Only x86_64 Linux, AArch64 macOS, and x86_64 Windows have full platform support 
 <summary><strong>Build From Source</strong></summary>
 
 ```console
-git clone --branch v1.0.0 --depth 1 https://github.com/findyourexit/excise.git
+git clone --branch v1.2.0 --depth 1 https://github.com/findyourexit/excise.git
 cd excise
 cargo install --path . --locked
 excise --version
@@ -70,7 +70,7 @@ excise --version
 Nix users can run the tagged release without changing its lock file:
 
 ```console
-nix run github:findyourexit/excise/v1.0.0 -- --format table /path/to/inspect
+nix run github:findyourexit/excise/v1.2.0 -- --format table /path/to/inspect
 ```
 
 </details>
@@ -148,7 +148,7 @@ Read the [permanent deletion contract](docs/safety/deletion.md), [space accounti
 
 ## Support Policy
 
-| Target | v1.0.0 status | Evidence |
+| Target | v1 stable status | Evidence |
 |---|---|---|
 | x86_64 Linux (`x86_64-unknown-linux-gnu`) | Supported | Testing on Linux, terminal testing, and release archive |
 | AArch64 macOS (`aarch64-apple-darwin`) | Supported | Testing on macOS, terminal testing, and release archive |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,16 +4,18 @@ Excise permanently deletes files and folders. Data-loss defects are therefore se
 
 ## Supported Versions
 
-Excise supports the latest stable release, currently `1.0.0`. The `0.3.x` line was early testing and is superseded. Report safety defects against the affected stable release or development commit. Do not trust superseded releases with irreplaceable data.
+Excise supports the latest stable release, currently `1.2.0`. The `0.3.x` line was early testing and is superseded. Report safety defects against the affected stable release or development commit. Do not trust superseded releases with irreplaceable data.
 
 | Version | Status |
 |---|---|
-| `1.0.0` | Supported stable line |
-| `0.3.0` | Superseded early testing. Upgrade to `1.0.0`. |
-| `0.2.0` | Superseded early testing. Upgrade to `1.0.0`. |
-| `0.1.2` | Superseded early testing. Upgrade to `1.0.0`. |
-| `0.1.1` | Superseded early testing. Upgrade to `1.0.0`. |
-| `0.1.0` | Superseded stable line. Upgrade to `1.0.0`. |
+| `1.2.0` | Supported stable line |
+| `1.1.x` | Superseded stable releases. Upgrade to `1.2.0`. |
+| `1.0.x` | Superseded stable releases. Upgrade to `1.2.0`. |
+| `0.3.0` | Superseded early testing. Upgrade to `1.2.0`. |
+| `0.2.0` | Superseded early testing. Upgrade to `1.2.0`. |
+| `0.1.2` | Superseded early testing. Upgrade to `1.2.0`. |
+| `0.1.1` | Superseded early testing. Upgrade to `1.2.0`. |
+| `0.1.0` | Superseded early testing. Upgrade to `1.2.0`. |
 | `main` | Development only |
 
 ## Report Privately

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -18,13 +18,13 @@ A terminal session guard owns raw input mode, the separate screen, cursor visibi
 
 ### Main Loop
 
-The main loop polls terminal input with a bounded timeout. It processes input and worker events before drawing visual effects. It redraws only when state has changed. It limits active effects to 30 frames per second and drops overdue frames. A new transition replaces an older transition with the same purpose.
+The main loop polls terminal input with a bounded timeout. It renders each folder drill before it resumes queued scanner work, applies staged scan batches one entry per input poll, and uses bounded-channel backpressure while treemap geometry is moving. It redraws only when state has changed. It limits active effects to 30 frames per second and drops overdue frames. A new transition replaces an older transition with the same purpose.
 
 ### Scanner
 
 The scanner uses a fixed number of workers and walks directories without recursion. Directory tasks and worker events use queues with fixed limits. When temporary working data reaches its memory limit, the scanner can use a permission-restricted store for the session instead of growing without limit. Backpressure never silently drops an entry.
 
-The default worker count is the smaller of the available processor count and eight. The configured value must be between one and 32. Exclusions and file system boundaries remain visible in the working model. Link targets are never traversed.
+The default worker count leaves one available processor for the owner loop when possible and is clamped from one through eight. The configured value must be between one and 32. Exclusions and file system boundaries remain visible in the working model. Link targets are never traversed.
 
 ### Working Model
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,6 +71,7 @@ right = "d"
 | `runtime.output` | Report destination for noninteractive output | A path |
 
 The default memory limit is 512 MiB or the detected available memory when that is lower. Excise reserves 25 percent as process headroom and limits working data to the remaining 75 percent.
+By default, Excise uses one less than the detected available processor count, clamped from one through eight workers, so interactive input retains a processor when possible.
 
 ## Environment Variables
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -53,9 +53,9 @@ Run the actual terminal lifecycle tests with:
 cargo test --test pty_smoke --locked
 ```
 
-## 1.0.0 release candidate checks
+## Release candidate checks
 
-The `1.0.0` release is the stable CLI, configuration, and report contract. From a clean checkout at the release commit, run the focused checks before requesting the hosted candidate:
+Each stable release preserves the CLI, configuration, and report contract established by `1.0.0`. From a clean checkout at the release commit, run the focused checks before requesting the hosted candidate:
 
 ```console
 (
@@ -76,6 +76,8 @@ For the hosted candidate, dispatch the workflow only from the exact protected `m
 ```console
 set -euo pipefail
 source_sha="$(git rev-parse HEAD)"
+version="$(sed -n 's/^version = "\([^\"]*\)"/\1/p' Cargo.toml | sed -n '1p')"
+test -n "$version"
 candidate_dir="$(mktemp -d "${TMPDIR:-/tmp}/excise-candidate.XXXXXX")"
 trap "$(printf 'rm -rf -- %q' "$candidate_dir")" EXIT
 dispatch_seed="$(date -u +%s)-$$-$RANDOM"
@@ -84,7 +86,7 @@ if command -v sha256sum >/dev/null 2>&1; then
 else
   dispatch_id="$(printf '%s' "$dispatch_seed" | shasum -a 256 | cut -c1-32)"
 fi
-run_url="$(gh workflow run release.yml --repo findyourexit/excise --ref main --field version=1.0.0 --field source_sha="$source_sha" --field dispatch_id="$dispatch_id")"
+run_url="$(gh workflow run release.yml --repo findyourexit/excise --ref main --field version="$version" --field source_sha="$source_sha" --field dispatch_id="$dispatch_id")"
 run_id="${run_url##*/}"
 if [[ ! "$run_id" =~ ^[0-9]+$ ]]; then
   run_id="$(
@@ -145,29 +147,29 @@ The workflow rejects a moving or unprotected source ref, checks the exact SHA an
   fi
   jq -e '.packages | length > 1' excise.spdx.json
   jq -e '.packages[] | select(.name == "serde")' excise.spdx.json
-  jq -e --arg version 1.0.0 '([.packages[] | select(.name == "excise" and .versionInfo == $version)] | length == 1)' excise.spdx.json
+  jq -e --arg version "$version" '([.packages[] | select(.name == "excise" and .versionInfo == $version)] | length == 1)' excise.spdx.json
   archives=(
-    excise-x86_64-unknown-linux-gnu-v1.0.0.tar.gz
-    excise-aarch64-unknown-linux-gnu-v1.0.0.tar.gz
-    excise-x86_64-apple-darwin-v1.0.0.tar.gz
-    excise-aarch64-apple-darwin-v1.0.0.tar.gz
-    excise-x86_64-pc-windows-msvc-v1.0.0.zip
-    excise-aarch64-pc-windows-msvc-v1.0.0.zip
+    excise-x86_64-unknown-linux-gnu-v${version}.tar.gz
+    excise-aarch64-unknown-linux-gnu-v${version}.tar.gz
+    excise-x86_64-apple-darwin-v${version}.tar.gz
+    excise-aarch64-apple-darwin-v${version}.tar.gz
+    excise-x86_64-pc-windows-msvc-v${version}.zip
+    excise-aarch64-pc-windows-msvc-v${version}.zip
   )
   for archive in "${archives[@]}"; do
     test -s "$archive"
   done
   for target in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu x86_64-apple-darwin aarch64-apple-darwin; do
-    archive="excise-${target}-v1.0.0.tar.gz"
-    root="excise-${target}-v1.0.0"
+    archive="excise-${target}-v${version}.tar.gz"
+    root="excise-${target}-v${version}"
     tar -tzf "$archive" | grep -Fqx "$root/excise"
     tar -tzf "$archive" | grep -Fqx "$root/LICENSE"
     tar -tzf "$archive" | grep -Fqx "$root/generated/man/excise.1"
     tar -tzf "$archive" | grep -Fqx "$root/schemas/scan-report.schema.json"
   done
   for target in x86_64-pc-windows-msvc aarch64-pc-windows-msvc; do
-    archive="excise-${target}-v1.0.0.zip"
-    root="excise-${target}-v1.0.0"
+    archive="excise-${target}-v${version}.zip"
+    root="excise-${target}-v${version}"
     unzip -t "$archive" >/dev/null
     unzip -Z1 "$archive" | grep -Fqx "$root/excise.exe"
     unzip -Z1 "$archive" | grep -Fqx "$root/LICENSE"
@@ -187,8 +189,8 @@ The workflow rejects a moving or unprotected source ref, checks the exact SHA an
 After reviewing the candidate, create the annotated release tag with the reviewed candidate run ID in its message, then push it:
 
 ```console
-git tag -a v1.0.0 "$source_sha" -m "candidate-run-id: $run_id"
-git push origin v1.0.0
+cargo create-release-tag "$version" "$source_sha" "$run_id"
+git push origin "v$version"
 ```
 
 The push-triggered workflow requires that exact annotated-tag candidate ID; never substitute a different candidate run or a lightweight tag.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,12 +42,12 @@ nix build
 ./result/bin/excise /path/to/inspect
 ```
 
-## Install 1.0.0 From A Release Channel
+## Install 1.2.0 From A Release Channel
 
-The `1.0.0` package is published on crates.io and can also be built locally. It is not one of the pre-built GitHub archives:
+The `1.2.0` package is published on crates.io and can also be built locally. It is not one of the pre-built GitHub archives:
 
 ```console
-cargo install excise --version 1.0.0 --locked
+cargo install excise --version 1.2.0 --locked
 excise --version
 ```
 
@@ -88,7 +88,7 @@ Use a temporary directory appropriate to your platform on Windows.
 
 Keep the default confirmation enabled for first use. Select a real file or directory and press `Backspace` to begin a permanent deletion plan. You do not need to wait for the full scan to finish; entries that have been fully examined are already deletable while scanning continues. Review the escaped path, file identity, and number of planned entries. The scan root, a file system or drive root, synthetic `Shared` and `Other` entries, aggregate entries, and incomplete or uncertain subtrees are not deletion targets. Press `Esc` to cancel.
 
-Files confirm with `Enter` or `y`. While the identity plan is still being built, pressing `Enter` pre-arms confirmation for files and reduced-guardrail entries; the deletion starts as soon as the plan is ready without a separate confirm step. Safe printable directories require their exact leaf name followed by `Enter`. Hostile or untypeable names require a generated challenge. `--disable-delete-confirmation` enables a visible, session-only reduced confirmation mode that accepts `Enter` or `y` for all entries except hostile names. It does not remove the other safeguards and is not saved. Prefer an ordinary user for first use. Root and Administrator accounts receive a warning and do not change the identity checks.
+Files and safe printable directories confirm with `Enter` or `y`. While the identity plan is still being built, pressing `Enter` pre-arms confirmation for those entries and reduced-guardrail entries; the deletion starts as soon as the plan is ready without a separate confirm step. Hostile or untypeable names require a generated challenge. `--disable-delete-confirmation` enables a visible, session-only reduced confirmation mode that accepts `Enter` or `y` for all entries except hostile names. It does not remove the other safeguards and is not saved. Prefer an ordinary user for first use. Root and Administrator accounts receive a warning and do not change the identity checks.
 
 Every planned entry is listed independently and checked again immediately before deletion. Changed, replaced, missing, or newly created entries are never silently deleted. A run can therefore be partial. There is no trash or undo.
 
@@ -100,7 +100,7 @@ The interactive interface requires standard input and output connected to a term
 
 ### Current Map Behavior
 
-The dense half-block map, animated focus border, heat ramp, overflow summary, and directed map transitions are included in the published `1.0.0` release. Build the current source or install `1.0.0` to use them.
+The dense half-block map, animated focus border, heat ramp, overflow summary, and directed map transitions are included in the stable release. Build the current source or install `1.2.0` to use them.
 
 The interactive view uses a dense map and animated focus border on capable terminals. `--ascii`, monochrome mode, and reduced motion preserve the same selection, scope, and deletion information when visual effects are unavailable or undesirable.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -36,7 +36,7 @@ The approved `0.2.0` publication used:
 
 ## The 0.3.0 Early-Testing Release
 
-The `0.3.0` release packaged the private Rust API boundary and compatibility-policy work described in the changelog. It was a breaking minor release because provisional Rust module paths were removed from the default public surface. Its destructive behavior was provisional, and its publication record is historical and immutable. The active candidate, verification, and promotion procedure below targets `1.0.0`.
+The `0.3.0` release packaged the private Rust API boundary and compatibility-policy work described in the changelog. It was a breaking minor release because provisional Rust module paths were removed from the default public surface. Its destructive behavior was provisional, and its publication record is historical and immutable. The active candidate, verification, and promotion procedure below applies to the stable v1 line.
 
 ## The 1.0.0 Stable Release
 
@@ -132,6 +132,8 @@ The manually dispatched `Release candidate artifacts` workflow in `.github/workf
 ```console
 set -euo pipefail
 source_sha="$(git rev-parse HEAD)"
+version="$(sed -n 's/^version = "\([^\"]*\)"/\1/p' Cargo.toml | sed -n '1p')"
+test -n "$version"
 candidate_dir="$(mktemp -d "${TMPDIR:-/tmp}/excise-candidate.XXXXXX")"
 trap "$(printf 'rm -rf -- %q' "$candidate_dir")" EXIT
 dispatch_seed="$(date -u +%s)-$$-$RANDOM"
@@ -140,7 +142,7 @@ if command -v sha256sum >/dev/null 2>&1; then
 else
   dispatch_id="$(printf '%s' "$dispatch_seed" | shasum -a 256 | cut -c1-32)"
 fi
-run_url="$(gh workflow run release.yml --repo findyourexit/excise --ref main --field version=1.0.0 --field source_sha="$source_sha" --field dispatch_id="$dispatch_id")"
+run_url="$(gh workflow run release.yml --repo findyourexit/excise --ref main --field version="$version" --field source_sha="$source_sha" --field dispatch_id="$dispatch_id")"
 run_id="${run_url##*/}"
 if [[ ! "$run_id" =~ ^[0-9]+$ ]]; then
   run_id="$(
@@ -201,7 +203,7 @@ The candidate contains six immutable target archives, `checksums.sha256`, and `e
   fi
   jq -e '.packages | length > 1' excise.spdx.json
   jq -e '.packages[] | select(.name == "serde")' excise.spdx.json
-  jq -e --arg version 1.0.0 '([.packages[] | select(.name == "excise" and .versionInfo == $version)] | length == 1)' excise.spdx.json
+  jq -e --arg version "$version" '([.packages[] | select(.name == "excise" and .versionInfo == $version)] | length == 1)' excise.spdx.json
   for archive in excise-*.tar.gz; do tar -tzf "$archive" >/dev/null; done
   for archive in excise-*.zip; do unzip -t "$archive" >/dev/null; done
   for subject in excise-*.tar.gz excise-*.zip checksums.sha256 excise.spdx.json; do
@@ -220,11 +222,11 @@ Confirm that every archive contains its target binary, `LICENSE`, `generated/man
 
 Only after the candidate bundle passes every verification, create the immutable release tag from the reviewed source checkout. The tag must be annotated, point to the candidate's exact source SHA, and carry the successful candidate workflow run ID in a message formatted as `candidate-run-id: $run_id`.
 
-For the current `1.1.0` release, use the `source_sha` and `run_id` captured in the hosted-candidate step, then push the tag that triggers the release workflow:
+Use the `version`, `source_sha`, and `run_id` captured in the hosted-candidate step, then push the tag that triggers the release workflow:
 
 ```console
-cargo create-release-tag 1.1.0 "$source_sha" "$run_id"
-git push origin v1.1.0
+cargo create-release-tag "$version" "$source_sha" "$run_id"
+git push origin "v$version"
 ```
 
 Do **not** use `gh release create` to create this tag: it creates a lightweight tag, which fails the release-validation gate before publication.
@@ -258,19 +260,19 @@ The crates.io package follows the release commit's Cargo exclusions (`.cargo`, `
 
 ## Nix & cargo-binstall Verification
 
-The tagged Nix flake is a source-build channel, while cargo-binstall downloads target-specific release archives. Verify the channels independently:
+With `version` set to the published manifest version, verify the tagged Nix flake and cargo-binstall archive independently:
 
 ```console
-nix flake check github:findyourexit/excise/v1.0.0
-nix eval --raw "github:findyourexit/excise/v1.0.0#packages.$(nix eval --raw --impure --expr builtins.currentSystem).default.version"
-nix run github:findyourexit/excise/v1.0.0 -- --version
-nix run github:findyourexit/excise/v1.0.0 -- --format table /path/to/inspect
+nix flake check "github:findyourexit/excise/v${version}"
+nix eval --raw "github:findyourexit/excise/v${version}#packages.$(nix eval --raw --impure --expr builtins.currentSystem).default.version"
+nix run "github:findyourexit/excise/v${version}" -- --version
+nix run "github:findyourexit/excise/v${version}" -- --format table /path/to/inspect
 (
   set -euo pipefail
   binstall_dir="$(mktemp -d "${TMPDIR:-/tmp}/excise-binstall.XXXXXX")"
   readonly binstall_dir
   trap 'rm -rf -- "$binstall_dir"' EXIT
-  cargo binstall --no-confirm --force --install-path "$binstall_dir" --version 1.0.0 excise
+  cargo binstall --no-confirm --force --install-path "$binstall_dir" --version "$version" excise
   "$binstall_dir/excise" --version
 )
 ```
@@ -292,7 +294,7 @@ brew info findyourexit/tap/excise
 excise --version
 ```
 
-`brew fetch` checks the formula's archive URL and SHA-256. `brew audit` checks formula policy. `brew test` runs the formula's version and JSON scan smoke checks. `brew info` confirms the selected version and tap. Also inspect the rendered formula with `brew cat findyourexit/tap/excise`. Every URL must be a `releases/download/v1.0.0/` asset and every checksum must match `checksums.sha256`. The source formula in `packaging/homebrew-core/excise.rb.in` has different build semantics and must not be used as evidence that Homebrew Core has accepted the package.
+`brew fetch` checks the formula's archive URL and SHA-256. `brew audit` checks formula policy. `brew test` runs the formula's version and JSON scan smoke checks. `brew info` confirms the selected version and tap. Also inspect the rendered formula with `brew cat findyourexit/tap/excise`. Every URL must be a `releases/download/v${version}/` asset and every checksum must match `checksums.sha256`. The source formula in `packaging/homebrew-core/excise.rb.in` has different build semantics and must not be used as evidence that Homebrew Core has accepted the package.
 
 ## Credentials & Approvals
 
@@ -320,7 +322,7 @@ gh workflow run release.yml \
   --field version="$version" \
   --field source_sha="$source_sha" \
   --field dispatch_id="$recovery_id" \
-  --field tag=v1.0.0 \
+  --field tag="v$version" \
   --field candidate_run_id="$run_id"
 ```
 

--- a/docs/safety/deletion.md
+++ b/docs/safety/deletion.md
@@ -25,14 +25,13 @@ Consent covers only the identities in the plan. It never covers a new entry that
 
 ## Confirmation
 
-- Files confirm with `Enter` or `y` in the confirmation dialog.
-- Safe printable directories require their exact leaf name followed by `Enter` by default.
+- Files and safe printable directories confirm with `Enter` or `y` in the confirmation dialog.
 - Hostile or untypeable names show an escaped full path and identity. They require a generated challenge such as `DELETE K7M4`.
 - A session-only reduced mode accepts `Enter` or `y` for all entries except hostile names.
 - Reduced mode is visible and is never saved.
 - Root and Administrator accounts receive a visible warning. The identity checks remain unchanged.
 
-While the identity plan is being built, pressing `Enter` pre-arms confirmation for single-key challenges (files and reduced-guardrail entries). When the plan completes with a single-key challenge, execution begins immediately without showing the separate confirm dialog. The irreversible action does not start until the plan is complete and the pre-arming key has been given. For typed-name and generated challenges, the confirm dialog is always shown and the user must type the required input before execution begins.
+While the identity plan is being built, pressing `Enter` pre-arms confirmation for single-key challenges (files, safe printable directories, and reduced-guardrail entries). When the plan completes with a single-key challenge, execution begins immediately without showing the separate confirm dialog. The irreversible action does not start until the plan is complete and the pre-arming key has been given. For generated challenges, the confirm dialog is always shown and the user must type the required input before execution begins.
 
 ## Execution
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/generated/man/excise.1
+++ b/generated/man/excise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH excise 1  "excise 1.1.1"
+.TH excise 1  "excise 1.2.0"
 .SH NAME
 excise
 .SH SYNOPSIS
@@ -122,4 +122,4 @@ Print version
 [\fIfolder\fR]
 Folder to scan
 .SH VERSION
-v1.1.1
+v1.2.0


### PR DESCRIPTION
## Summary

Prepare the v1.2.0 minor release for the merged deletion-flow, scan responsiveness, and model-compaction improvements.

## Changes

- Bump the package and both lockfiles to `1.2.0`.
- Add complete dated release notes for the user-visible deletion, progress, navigation, worker-default, and compaction changes since `v1.1.1`.
- Update onboarding, deletion-safety, configuration, architecture, current install, security, and issue-template documentation.
- Replace hard-coded candidate, tag, Nix, cargo-binstall, and Homebrew version values in the developer runbooks with the manifest-derived version.
- Regenerate every generated asset; the versioned manual page changes and all shell completions were checked for drift.

## Safety and compatibility

- Deletion still builds and revalidates an identity plan before mutation; hostile or untypeable names still require a generated challenge.
- CLI flags, configuration/report schemas, platform classifications, and supported command-line contracts are unchanged. The default scanner worker count now leaves one processor for the owner loop when possible, capped at eight.
- This is a minor release because it adds user-visible interactive behavior without removing the stable CLI, configuration, or report interfaces.

## Verification

- [x] `cargo generate`
- [x] `cargo check-generated`
- [x] `bash -n` across all 20 console blocks in `docs/development.md` and `docs/releasing.md`
- [x] `cargo verify`
- [x] `cargo package --locked --list`
- [x] `cargo publish --locked --dry-run`
- [x] `cargo dist-local`; the final local `aarch64-apple-darwin` archive checksum, CycloneDX inventory, required payload, archived README, and `excise --version` were verified as `1.2.0`.
- [ ] Hosted pull-request checks
