### PR TITLE
release: prepare `v1.2.1`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
     id: version
     attributes:
       label: Excise version or commit
-      placeholder: "v1.2.0 or 0123456789abcdef"
+      placeholder: "v1.2.1 or 0123456789abcdef"
     validations:
       required: true
   - type: dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable Excise changes are documented here. The format follows [Keep a Chang
 
 Excise preserves the historical Diskonaut changelog below. Diskonaut versions and tags are not Excise releases.
 
+## [1.2.1] - 2026-09-02
+
+### Fixed
+
+* The tagged Nix flake now derives its package version from `Cargo.toml`. The immutable `v1.2.0` flake built the correct executable but exposed `1.0.0`; this corrective release exposes `1.2.1`.
+
 ## [1.2.0] - 2026-09-02
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Surgical terminal storage navigator"
 keywords = ["disk-usage", "filesystem", "terminal", "tui"]
 categories = ["command-line-utilities", "filesystem"]
 
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Aram Drevekenin <aram@poor.dev>", "Tom Larcher <tom.larcher@gmail.com>"]
 readme = "README.md"
 homepage = "https://github.com/findyourexit/excise"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It is an independent fork and spiritual successor to [Diskonaut](https://github.
 ```console
 brew tap findyourexit/tap
 brew install findyourexit/tap/excise
-excise --version  # excise 1.2.0
+excise --version  # excise 1.2.1
 ```
 
 </details>
@@ -42,8 +42,8 @@ excise --version  # excise 1.2.0
 <summary><strong>crates.io</strong></summary>
 
 ```console
-cargo install excise --version 1.2.0 --locked
-excise --version  # excise 1.2.0
+cargo install excise --version 1.2.1 --locked
+excise --version  # excise 1.2.1
 ```
 
 </details>
@@ -51,7 +51,7 @@ excise --version  # excise 1.2.0
 <details>
 <summary><strong>Pre-built Binaries</strong></summary>
 
-Download the [v1.2.0 release](https://github.com/findyourexit/excise/releases/tag/v1.2.0) for macOS, Linux, and Windows on Apple silicon, Intel, or Arm systems.
+Download the [v1.2.1 release](https://github.com/findyourexit/excise/releases/tag/v1.2.1) for macOS, Linux, and Windows on Apple silicon, Intel, or Arm systems.
 
 Only x86_64 Linux, AArch64 macOS, and x86_64 Windows have full platform support because they are tested on those platforms. The other archives are build-only and best effort. See the [Support Policy](SUPPORT.md).
 
@@ -61,7 +61,7 @@ Only x86_64 Linux, AArch64 macOS, and x86_64 Windows have full platform support 
 <summary><strong>Build From Source</strong></summary>
 
 ```console
-git clone --branch v1.2.0 --depth 1 https://github.com/findyourexit/excise.git
+git clone --branch v1.2.1 --depth 1 https://github.com/findyourexit/excise.git
 cd excise
 cargo install --path . --locked
 excise --version
@@ -70,7 +70,7 @@ excise --version
 Nix users can run the tagged release without changing its lock file:
 
 ```console
-nix run github:findyourexit/excise/v1.2.0 -- --format table /path/to/inspect
+nix run github:findyourexit/excise/v1.2.1 -- --format table /path/to/inspect
 ```
 
 </details>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,18 +4,19 @@ Excise permanently deletes files and folders. Data-loss defects are therefore se
 
 ## Supported Versions
 
-Excise supports the latest stable release, currently `1.2.0`. The `0.3.x` line was early testing and is superseded. Report safety defects against the affected stable release or development commit. Do not trust superseded releases with irreplaceable data.
+Excise supports the latest stable release, currently `1.2.1`. The `0.3.x` line was early testing and is superseded. Report safety defects against the affected stable release or development commit. Do not trust superseded releases with irreplaceable data.
 
 | Version | Status |
 |---|---|
-| `1.2.0` | Supported stable line |
-| `1.1.x` | Superseded stable releases. Upgrade to `1.2.0`. |
-| `1.0.x` | Superseded stable releases. Upgrade to `1.2.0`. |
-| `0.3.0` | Superseded early testing. Upgrade to `1.2.0`. |
-| `0.2.0` | Superseded early testing. Upgrade to `1.2.0`. |
-| `0.1.2` | Superseded early testing. Upgrade to `1.2.0`. |
-| `0.1.1` | Superseded early testing. Upgrade to `1.2.0`. |
-| `0.1.0` | Superseded early testing. Upgrade to `1.2.0`. |
+| `1.2.1` | Supported stable line |
+| `1.2.0` | Superseded release. Upgrade to `1.2.1`. |
+| `1.1.x` | Superseded stable releases. Upgrade to `1.2.1`. |
+| `1.0.x` | Superseded stable releases. Upgrade to `1.2.1`. |
+| `0.3.0` | Superseded early testing. Upgrade to `1.2.1`. |
+| `0.2.0` | Superseded early testing. Upgrade to `1.2.1`. |
+| `0.1.2` | Superseded early testing. Upgrade to `1.2.1`. |
+| `0.1.1` | Superseded early testing. Upgrade to `1.2.1`. |
+| `0.1.0` | Superseded early testing. Upgrade to `1.2.1`. |
 | `main` | Development only |
 
 ## Report Privately

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,12 +42,12 @@ nix build
 ./result/bin/excise /path/to/inspect
 ```
 
-## Install 1.2.0 From A Release Channel
+## Install 1.2.1 From A Release Channel
 
-The `1.2.0` package is published on crates.io and can also be built locally. It is not one of the pre-built GitHub archives:
+The `1.2.1` package is published on crates.io and can also be built locally. It is not one of the pre-built GitHub archives:
 
 ```console
-cargo install excise --version 1.2.0 --locked
+cargo install excise --version 1.2.1 --locked
 excise --version
 ```
 
@@ -100,7 +100,7 @@ The interactive interface requires standard input and output connected to a term
 
 ### Current Map Behavior
 
-The dense half-block map, animated focus border, heat ramp, overflow summary, and directed map transitions are included in the stable release. Build the current source or install `1.2.0` to use them.
+The dense half-block map, animated focus border, heat ramp, overflow summary, and directed map transitions are included in the stable release. Build the current source or install `1.2.1` to use them.
 
 The interactive view uses a dense map and animated focus border on capable terminals. `--ascii`, monochrome mode, and reduced motion preserve the same selection, scope, and deletion information when visual effects are unavailable or undesirable.
 

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
         let pkgs = nixpkgs.legacyPackages.${system};
         in pkgs.rustPlatform.buildRustPackage {
           pname = "excise";
-          version = "1.0.0";
+          version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
           src = pkgs.lib.cleanSource self;
           cargoLock.lockFile = ./Cargo.lock;
           preCheck = ''

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/generated/man/excise.1
+++ b/generated/man/excise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH excise 1  "excise 1.2.0"
+.TH excise 1  "excise 1.2.1"
 .SH NAME
 excise
 .SH SYNOPSIS
@@ -122,4 +122,4 @@ Print version
 [\fIfolder\fR]
 Folder to scan
 .SH VERSION
-v1.2.0
+v1.2.1


### PR DESCRIPTION
## Summary

Prepare the corrective v1.2.1 release. It fixes the tagged Nix flake metadata defect discovered during v1.2.0 publication verification.

## Changes

- Derive the Nix package version directly from `Cargo.toml`, preventing package metadata from drifting from the release manifest.
- Bump the package, both lockfiles, generated manual page, current-release install instructions, security policy, and bug-report placeholder to `1.2.1`.
- Add a dated release note that accurately records the immutable v1.2.0 Nix issue and its correction in v1.2.1.

## Safety and compatibility

- `v1.2.0` remains immutable. This follows the documented corrective-release process rather than moving a published tag or asset.
- The patch changes Nix package metadata only; the CLI, configuration, report schemas, deletion safeguards, supported targets, and release artifacts remain unchanged.

## Verification

- [x] `cargo generate`
- [x] `cargo check-generated`
- [x] `cargo verify`
- [x] `nix --extra-experimental-features 'nix-command flakes' flake check .`
- [x] `nix --extra-experimental-features 'nix-command flakes' eval --raw .#packages.aarch64-darwin.default.version` → `1.2.1`
- [x] `nix --extra-experimental-features 'nix-command flakes' run . -- --version` → `excise 1.2.1`
- [x] `cargo package --locked --list`
- [x] `cargo publish --locked --dry-run`
- [x] `cargo dist-local`; host archive checksum, CycloneDX inventory, payload, provenance, formula, and binary version verified as `1.2.1`.
- [ ] Hosted pull-request checks
