### PR TITLE
fix: preserve compaction capacity for unreadable entries

### DIFF
--- a/src/model/arena.rs
+++ b/src/model/arena.rs
@@ -463,16 +463,26 @@ impl Arena {
                 self.remove_nodes_with_accounting(removed)?;
             } else {
                 let unknown = matches!(reason, UnscannedReason::Metadata(_));
-                if let Some(node) = self.node_mut(existing) {
-                    node.state = unscanned_state(&reason);
-                    node.unscanned_reason = Some(reason);
-                    if scoped_zero {
-                        node.metrics = NodeMetrics::default();
-                    } else if unknown {
-                        node.metrics.allocated_bytes.upper = None;
-                        node.metrics.reclaimable_bytes.upper = None;
-                    }
+                let state = unscanned_state(&reason);
+                let mut metrics =
+                    self.node(existing)
+                        .map(|node| node.metrics)
+                        .ok_or_else(|| {
+                            ModelError::Invariant("unscanned node disappeared".to_string())
+                        })?;
+                if scoped_zero {
+                    metrics = NodeMetrics::default();
+                } else if unknown {
+                    metrics.allocated_bytes.upper = None;
+                    metrics.reclaimable_bytes.upper = None;
                 }
+                self.reserve_untracked_compaction_slot(existing, metrics)?;
+                let node = self.node_mut(existing).ok_or_else(|| {
+                    ModelError::Invariant("unscanned node disappeared".to_string())
+                })?;
+                node.state = state;
+                node.unscanned_reason = Some(reason);
+                node.metrics = metrics;
                 if scoped_zero {
                     self.rebuild_metrics();
                 }
@@ -534,7 +544,11 @@ impl Arena {
             let other = self.ensure_other(parent)?;
             self.aggregate_child_into_other(victim, other)?;
         }
+        let reserved_untracked = self.reserve_untracked_compaction_slot(parent, metrics)?;
         if self.reserve_child(parent, &name).is_err() {
+            if reserved_untracked {
+                self.remove_untracked_metrics(parent);
+            }
             let other = self.ensure_other(parent)?;
             self.accumulate_untracked_other(parent, other, metrics)?;
             return Ok(());
@@ -565,6 +579,14 @@ impl Arena {
         node.metrics = metrics;
         node.unscanned_reason = Some(reason);
         self.insert_node(id, node)?;
+        if reserved_untracked {
+            let reservation = self
+                .untracked_metrics
+                .remove(&parent)
+                .expect("untracked reservation should remain available");
+            let previous = self.untracked_metrics.insert(id, reservation);
+            debug_assert!(previous.is_none());
+        }
         self.lookup.insert((parent, name), id);
         self.push_child(parent, id)?;
         self.propagate_add(parent, metrics);
@@ -2065,6 +2087,25 @@ impl Arena {
             node.metrics.add(metrics);
             node.metrics.descendants = node.metrics.descendants.saturating_add(1);
         }
+    }
+    // A concrete unscanned node keeps its metrics until compaction. Reserving
+    // this slot before the hard limit lets compaction re-key it without a new
+    // allocation.
+    fn reserve_untracked_compaction_slot(
+        &mut self,
+        id: NodeId,
+        metrics: NodeMetrics,
+    ) -> Result<bool, ModelError> {
+        if id == self.root {
+            return Ok(false);
+        }
+        self.reserve_untracked_slot(
+            id,
+            UntrackedMetrics {
+                allocated_bytes: metrics.allocated_bytes,
+                reclaimable_bytes: metrics.reclaimable_bytes,
+            },
+        )
     }
 
     fn reserve_untracked_slot(

--- a/src/state/files/file_tree.rs
+++ b/src/state/files/file_tree.rs
@@ -843,6 +843,93 @@ mod tests {
     }
 
     #[test]
+    fn root_scan_compacts_unscanned_leaf_at_model_limit() {
+        let root = tempfile::tempdir().expect("model root should exist");
+        let cold = root.path().join("cold");
+        let unreadable = cold.join("unreadable");
+        let pending = root.path().join("pending");
+        fs::create_dir(&cold).expect("cold directory should be created");
+        fs::write(&pending, b"pending").expect("pending file should be created");
+
+        let mut tree = FileTree::new(
+            root.path().to_path_buf(),
+            true,
+            crate::model::MIN_PROCESS_MIB,
+        )
+        .expect("file tree should be created");
+        add(&mut tree, &cold);
+        tree.record_unscanned(
+            &unreadable,
+            UnscannedReason::Metadata("fixture metadata unavailable".to_string()),
+        )
+        .expect("unreadable leaf should be represented");
+
+        tree.arena
+            .consume_remaining_budget_for_test()
+            .expect("fixture should consume its model budget");
+        add(&mut tree, &pending);
+        tree.finalize().expect("model should finalize");
+        let (used, limit, _) = tree.model_stats();
+        assert!(used <= limit, "compaction must preserve the model limit");
+
+        let compacted = node_id_at(&tree, &cold);
+        assert_eq!(
+            tree.node_kind(compacted),
+            Some(NodeKind::Synthetic(SyntheticKind::Aggregate))
+        );
+        assert_eq!(
+            tree.node(compacted)
+                .expect("aggregate should remain")
+                .metrics
+                .allocated_bytes
+                .upper,
+            None,
+            "the aggregated unreadable leaf must retain its unknown bound"
+        );
+        assert!(tree.path_for_id(node_id_at(&tree, &pending)).is_some());
+    }
+
+    #[test]
+    fn root_scan_compacts_existing_unreadable_directory_at_model_limit() {
+        let root = tempfile::tempdir().expect("model root should exist");
+        let cold = root.path().join("cold");
+        let unreadable = cold.join("unreadable");
+        let pending = root.path().join("pending");
+        fs::create_dir(&cold).expect("cold directory should be created");
+        fs::create_dir(&unreadable).expect("unreadable directory should be created");
+        fs::write(&pending, b"pending").expect("pending file should be created");
+
+        let mut tree = FileTree::new(
+            root.path().to_path_buf(),
+            true,
+            crate::model::MIN_PROCESS_MIB,
+        )
+        .expect("file tree should be created");
+        add(&mut tree, &cold);
+        add(&mut tree, &unreadable);
+        tree.record_unscanned(
+            &unreadable,
+            UnscannedReason::Metadata("fixture metadata unavailable".to_string()),
+        )
+        .expect("unreadable directory should be represented");
+
+        tree.arena
+            .consume_remaining_budget_for_test()
+            .expect("fixture should consume its model budget");
+        add(&mut tree, &pending);
+        tree.finalize().expect("model should finalize");
+        let (used, limit, _) = tree.model_stats();
+        assert!(used <= limit, "compaction must preserve the model limit");
+
+        let compacted = node_id_at(&tree, &cold);
+        assert_eq!(
+            tree.node_kind(compacted),
+            Some(NodeKind::Synthetic(SyntheticKind::Aggregate))
+        );
+        assert!(tree.path_for_id(node_id_at(&tree, &pending)).is_some());
+    }
+
+    #[test]
     fn cancelled_focused_rescan_discards_staging_without_touching_live_tree() {
         let root = tempfile::tempdir().expect("rescan root should exist");
         let target = root.path().join("target");


### PR DESCRIPTION
## Summary

Prevent a root scan from terminating when an unreadable path reaches the default 384 MiB model-data limit.

## Changes

- Reserve the billed untracked-summary slot while a concrete unreadable entry is still retained.
- Re-key that reservation during cold-subtree compaction, avoiding a fresh allocation at the hard limit.
- Add regressions for unseen and already-materialized unreadable paths at the model limit.

## Safety and compatibility

- Keeps the configured hard memory limit and existing aggregation/accounting behavior.
- No deletion behavior, CLI/configuration/report schema, generated artifact, or accessibility change.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-targets --locked`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --locked` (469 passed)
- [x] `cargo run --locked --package xtask -- check-generated`
- [x] `cargo build --release --package excise --locked`
- [x] `EXCISE_PTY_BUDGETS=1 EXCISE_PTY_BINARY=…/target/release/excise cargo test --test pty_smoke --locked` (7 passed)
- [x] `cargo package --package excise --locked`
- [x] `cargo deny check`

User-facing documentation and generated artifacts are current.