### PR TITLE
perf(model): avoid rebuilds during cap compaction

### DIFF
--- a/benches/core.rs
+++ b/benches/core.rs
@@ -1,9 +1,13 @@
+use std::collections::HashSet;
 use std::ffi::OsString;
+use std::fs;
 use std::hint::black_box;
+use std::path::Path;
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use excise::geometry::{FileMetadata, FileType, TreeMap};
-use excise::model::NodeId;
+use excise::model::{Arena, MIN_PROCESS_MIB, MemoryBudget, NodeId};
+use excise::native_path::identity_for;
 use ratatui::layout::Rect;
 
 fn files(count: usize) -> Vec<FileMetadata> {
@@ -27,6 +31,80 @@ fn files(count: usize) -> Vec<FileMetadata> {
         .collect()
 }
 
+const CAP_TIME_DIRECTORIES: usize = 128;
+const CAP_TIME_LEAVES_PER_DIRECTORY: usize = 32;
+
+fn add_path(arena: &mut Arena, path: &Path) {
+    let metadata =
+        fs::symlink_metadata(path).expect("benchmark fixture metadata should be readable");
+    let identity = identity_for(path, &metadata)
+        .expect("benchmark fixture identity should be readable")
+        .expect("benchmark fixture should not contain links");
+    arena
+        .add_entry(path, &metadata, identity)
+        .expect("benchmark fixture entry should be retained");
+}
+
+fn populate_cap_time_fixture(root: &Path) {
+    for directory_index in 0..CAP_TIME_DIRECTORIES {
+        let directory = root.join(format!("directory-{directory_index:03}"));
+        fs::create_dir(&directory).expect("benchmark fixture directory should be created");
+        for leaf_index in 0..CAP_TIME_LEAVES_PER_DIRECTORY {
+            fs::write(directory.join(format!("leaf-{leaf_index:03}")), b"x")
+                .expect("benchmark fixture file should be written");
+        }
+    }
+}
+
+fn cap_time_arena(root: &Path) -> Arena {
+    let mut arena = Arena::new(
+        root.to_path_buf(),
+        MemoryBudget::from_mib(MIN_PROCESS_MIB)
+            .expect("benchmark model budget should be available"),
+    )
+    .expect("benchmark arena should be created");
+    for directory_index in 0..CAP_TIME_DIRECTORIES {
+        let directory = root.join(format!("directory-{directory_index:03}"));
+        add_path(&mut arena, &directory);
+        for leaf_index in 0..CAP_TIME_LEAVES_PER_DIRECTORY {
+            add_path(&mut arena, &directory.join(format!("leaf-{leaf_index:03}")));
+        }
+    }
+    arena
+}
+
+fn compact_all_cold_subtrees(arena: &mut Arena) -> usize {
+    let pinned = HashSet::from([arena.root()]);
+    let mut compacted = 0;
+    while arena
+        .aggregate_cold_subtree(&pinned)
+        .expect("benchmark compaction should succeed")
+    {
+        compacted += 1;
+    }
+    compacted
+}
+
+fn benchmark_cap_time_compaction(c: &mut Criterion) {
+    let root = tempfile::tempdir().expect("benchmark root should be created");
+    populate_cap_time_fixture(root.path());
+    let mut group = c.benchmark_group("model/cap-time-compaction");
+    group.throughput(Throughput::Elements(
+        u64::try_from(CAP_TIME_DIRECTORIES * CAP_TIME_LEAVES_PER_DIRECTORY)
+            .expect("benchmark input should fit u64"),
+    ));
+    group.bench_function("128x32", |bencher| {
+        bencher.iter_batched_ref(
+            || cap_time_arena(root.path()),
+            |arena| {
+                black_box((compact_all_cold_subtrees(arena), arena.memory_used()));
+            },
+            BatchSize::LargeInput,
+        );
+    });
+    group.finish();
+}
+
 fn benchmark_treemap(c: &mut Criterion) {
     let input = files(100_000);
     c.bench_function("treemap/layout/100k/190x48", |bencher| {
@@ -38,5 +116,5 @@ fn benchmark_treemap(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, benchmark_treemap);
+criterion_group!(benches, benchmark_treemap, benchmark_cap_time_compaction);
 criterion_main!(benches);

--- a/src/model/arena.rs
+++ b/src/model/arena.rs
@@ -773,14 +773,13 @@ impl Arena {
             return Ok(false);
         };
         let candidate_parent = self.node(candidate).and_then(|node| node.parent);
-        let children = self.children(candidate).to_vec();
         let mut metrics = self
             .node(candidate)
             .map_or(NodeMetrics::default(), |node| node.metrics);
         metrics.descendants = metrics.descendants.saturating_add(1);
         let untracked = self.untracked_metrics_for_subtree(candidate);
         let mut removed = Vec::new();
-        for child in children {
+        for &child in self.children(candidate) {
             self.collect_subtree_ids(child, &mut removed);
         }
         // The model may already be at its hard limit precisely when it needs to
@@ -836,7 +835,12 @@ impl Arena {
             self.decrement_retained_child_count(parent);
         }
         self.insert_untracked_metrics(candidate, untracked);
-        self.rebuild_metrics();
+        // Optional eviction caches must yield their budget before the scanner
+        // retries the cap-limited insertion that triggered this compaction.
+        self.clear_eviction_stashes();
+        // `metrics` preserves the candidate's former subtree total and folds its
+        // former concrete child count into the synthetic summary. Its ancestors
+        // therefore remain exact without collecting and sorting every live node.
         Ok(true)
     }
 
@@ -2846,6 +2850,15 @@ mod tests {
             .count()
     }
 
+    fn metric_snapshot(arena: &Arena) -> Vec<(NodeId, NodeMetrics)> {
+        let mut metrics = arena
+            .nodes()
+            .map(|node| (node.id, node.metrics))
+            .collect::<Vec<_>>();
+        metrics.sort_by_key(|(id, _)| *id);
+        metrics
+    }
+
     #[test]
     fn finalization_and_deletion_rebuild_exact_metrics() {
         let root = tempfile::tempdir().expect("model root should exist");
@@ -2942,6 +2955,94 @@ mod tests {
             .complete_directory(&cold.join("nested"), None)
             .expect("completion below a compacted subtree should be harmless");
         assert_eq!(arena.children(pinned_id).len(), 1);
+    }
+
+    #[test]
+    fn repeated_cold_compaction_keeps_metrics_exact_at_the_model_limit() {
+        let root = tempfile::tempdir().expect("model root should exist");
+        let cold_exact = root.path().join("cold-exact");
+        let cold_unknown = root.path().join("cold-unknown");
+        let pinned = root.path().join("pinned");
+        let exact_leaf = cold_exact.join("exact");
+        let unknown_leaf = cold_unknown.join("unknown");
+        let pinned_leaf = pinned.join("pinned");
+        for directory in [&cold_exact, &cold_unknown, &pinned] {
+            fs::create_dir(directory).expect("fixture directory should be created");
+        }
+        fs::write(&exact_leaf, b"exact").expect("exact fixture should be written");
+        fs::write(&unknown_leaf, b"unknown").expect("unknown fixture should be written");
+        fs::write(&pinned_leaf, b"pinned").expect("pinned fixture should be written");
+
+        let mut arena = test_arena(root.path());
+        let root_id = arena.root();
+        let cold_exact_id = add_path(&mut arena, &cold_exact).expect("cold exact should retain");
+        add_path(&mut arena, &exact_leaf).expect("exact leaf should retain");
+        let cold_unknown_id =
+            add_path(&mut arena, &cold_unknown).expect("cold unknown should retain");
+        add_path(&mut arena, &unknown_leaf).expect("unknown leaf should retain");
+        arena
+            .record_unscanned(
+                &unknown_leaf,
+                UnscannedReason::Metadata("fixture metadata unavailable".to_string()),
+            )
+            .expect("unknown leaf should retain its bound");
+        let pinned_id = add_path(&mut arena, &pinned).expect("pinned directory should retain");
+        add_path(&mut arena, &pinned_leaf).expect("pinned leaf should retain");
+        arena.finalize().expect("fixture model should finalize");
+
+        let expected_root_metrics = arena.node(root_id).expect("root should exist").metrics;
+        assert_eq!(expected_root_metrics.apparent_bytes, 18);
+        assert_eq!(expected_root_metrics.allocated_bytes.upper, None);
+        assert_eq!(expected_root_metrics.reclaimable_bytes.upper, None);
+        let pinned_path = arena
+            .path_ids(&pinned_leaf)
+            .expect("pinned path should be retained");
+        let pinned_nodes = HashSet::from([root_id, pinned_id]);
+
+        for candidate in [cold_exact_id, cold_unknown_id] {
+            arena
+                .consume_remaining_budget_for_test()
+                .expect("fixture should reach the model limit");
+            assert!(
+                arena
+                    .aggregate_cold_subtree(&pinned_nodes)
+                    .expect("cold subtree should compact at the model limit")
+            );
+            let node = arena.node(candidate).expect("aggregate should remain");
+            assert_eq!(node.kind, NodeKind::Synthetic(SyntheticKind::Aggregate));
+            assert_eq!(
+                arena.node(root_id).expect("root should remain").metrics,
+                expected_root_metrics,
+                "compaction must preserve exact and unknown ancestor accounting"
+            );
+            assert_eq!(
+                arena.path_ids(&pinned_leaf),
+                Some(pinned_path.clone()),
+                "pinned navigation must remain intact"
+            );
+            assert!(
+                arena.memory_used() <= arena.memory_limit(),
+                "compaction must not exceed the hard model budget"
+            );
+            if candidate == cold_unknown_id {
+                assert_eq!(node.metrics.allocated_bytes.upper, None);
+                assert!(arena.untracked_metrics.contains_key(&candidate));
+            }
+
+            let incremental_metrics = metric_snapshot(&arena);
+            arena.rebuild();
+            assert_eq!(
+                metric_snapshot(&arena),
+                incremental_metrics,
+                "compaction metrics must already match a full rebuild"
+            );
+        }
+
+        assert!(
+            !arena
+                .aggregate_cold_subtree(&pinned_nodes)
+                .expect("only the deterministic cold candidates should compact")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Avoid a global model-metrics rebuild after every cold-subtree compaction while a scan retries cap-limited insertions.

## Changes

- Preserve the collapsed subtree's exact aggregate metrics and ancestor totals incrementally instead of collecting and depth-sorting every live node.
- Preserve the existing global eviction-cache release before the retry, and remove the transient clone of the candidate's direct-child buffer.
- Add a 128-directory × 32-leaf Criterion workload plus a hard-budget regression covering exact and unknown bounds, deterministic retention, and pinned paths.

## Safety and compatibility

The compaction still rekeys identities, preserves the hard model budget, and flushes optional eviction caches before allocation retries. `IdentityRecord` and the generic temporary-storage policy are unchanged. The remaining candidate selection and identity-remap scans intentionally retain their existing deterministic behavior; this avoids an unbudgeted per-node cache.

## Verification

- `cargo test --lib model::arena::tests::repeated_cold_compaction_keeps_metrics_exact_at_the_model_limit --locked` — passed.
- `cargo test --lib compaction --locked` — 8 passed.
- `cargo test --lib root_scan_compacts --locked` — 2 passed.
- `cargo test --lib leaving_deep_navigation_reclaims_a_summarized_branch_at_memory_limit --locked` — passed.
- `cargo bench --bench core --features internal --locked -- model/cap-time-compaction --noplot` — baseline 11.374–11.460 ms; final 5.694–5.728 ms, about 50.0% lower midpoint time.

Formatting, linting, and the project-wide suite were intentionally not run; this task requested focused validation only.