### PR TITLE
fix(model): bound hard-link participant storage

### DIFF
--- a/src/model/arena.rs
+++ b/src/model/arena.rs
@@ -661,7 +661,7 @@ impl Arena {
                 let mut participants = record
                     .nodes
                     .iter()
-                    .copied()
+                    .map(|(id, _)| *id)
                     .filter(|id| self.node(*id).is_some())
                     .collect::<Vec<_>>();
                 participants.sort_unstable();
@@ -2582,14 +2582,12 @@ fn remove_replaced_participants(
     let removed_links = record
         .nodes
         .iter()
-        .filter(|id| is_replaced_node(**id, target, removed))
-        .count();
+        .filter(|(id, _)| is_replaced_node(*id, target, removed))
+        .fold(0_u64, |total, (_, links)| total.saturating_add(*links));
     record
         .nodes
-        .retain(|id| !is_replaced_node(*id, target, removed));
-    record.observed_links = record
-        .observed_links
-        .saturating_sub(u64::try_from(removed_links).unwrap_or(u64::MAX));
+        .retain(|(id, _)| !is_replaced_node(*id, target, removed));
+    record.observed_links = record.observed_links.saturating_sub(removed_links);
     if record.nodes.is_empty() {
         return None;
     }
@@ -2597,7 +2595,7 @@ fn remove_replaced_participants(
         .allocation_node
         .is_some_and(|id| is_replaced_node(id, target, removed))
     {
-        record.allocation_node = record.nodes.first().copied();
+        record.allocation_node = record.nodes.first().map(|(id, _)| *id);
     }
     Some(record)
 }
@@ -2608,12 +2606,12 @@ fn remove_deleted_participants(
     let removed_links = record
         .nodes
         .iter()
-        .filter(|id| removed.binary_search(id).is_ok())
-        .count();
-    record.nodes.retain(|id| removed.binary_search(id).is_err());
-    record.observed_links = record
-        .observed_links
-        .saturating_sub(u64::try_from(removed_links).unwrap_or(u64::MAX));
+        .filter(|(id, _)| removed.binary_search(id).is_ok())
+        .fold(0_u64, |total, (_, links)| total.saturating_add(*links));
+    record
+        .nodes
+        .retain(|(id, _)| removed.binary_search(id).is_err());
+    record.observed_links = record.observed_links.saturating_sub(removed_links);
     if record.nodes.is_empty() {
         return None;
     }
@@ -2621,7 +2619,7 @@ fn remove_deleted_participants(
         .allocation_node
         .is_some_and(|id| removed.binary_search(&id).is_ok())
     {
-        record.allocation_node = record.nodes.first().copied();
+        record.allocation_node = record.nodes.first().map(|(id, _)| *id);
     }
     Some(record)
 }
@@ -2632,9 +2630,10 @@ fn remap_staged_record(
     stage_root: NodeId,
     target: NodeId,
 ) -> Result<(), ModelError> {
-    for id in &mut record.nodes {
+    for (id, _) in &mut record.nodes {
         *id = staged_live_id(nodes, stage_root, *id, target)?;
     }
+    record.coalesce_nodes();
     if let Some(id) = record.allocation_node {
         record.allocation_node = Some(staged_live_id(nodes, stage_root, id, target)?);
     }
@@ -2658,6 +2657,7 @@ fn merge_identity_record(
             existing.allocation_node = record.allocation_node;
         }
         existing.nodes.extend(record.nodes);
+        existing.coalesce_nodes();
         store.upsert_record(file_id, &existing)?;
     } else {
         store.upsert_record(file_id, &record)?;
@@ -3414,6 +3414,111 @@ mod tests {
                 .allocated_bytes,
             shared.metrics.allocated_bytes
         );
+    }
+    #[cfg(unix)]
+    #[test]
+    fn spilled_fanout_hard_links_coalesce_remaps_and_delete_exactly() {
+        const COLD_LINKS: u64 = 128;
+        let root = tempfile::tempdir().expect("model root should exist");
+        let cold = root.path().join("cold");
+        fs::create_dir(&cold).expect("cold directory should be created");
+        let first = cold.join("link-000");
+        fs::write(&first, b"payload").expect("fixture should be written");
+        let mut cold_links = vec![first.clone()];
+        for index in 1..COLD_LINKS {
+            let path = cold.join(format!("link-{index:03}"));
+            fs::hard_link(&first, &path).expect("hard link should be created");
+            cold_links.push(path);
+        }
+        let survivor = root.path().join("survivor");
+        fs::hard_link(&first, &survivor).expect("hard link should be created");
+        let metadata = fs::symlink_metadata(&first).expect("fixture metadata should be readable");
+        let file_id = identity_for(&first, &metadata)
+            .expect("fixture identity should be readable")
+            .expect("fixture should not be a symbolic link")
+            .file_id;
+
+        let mut arena = test_arena(root.path());
+        arena.identities = IdentityStore::new(1).expect("identity store should initialize");
+        let cold_id = add_path(&mut arena, &cold).expect("cold directory should be retained");
+        for path in &cold_links {
+            add_path(&mut arena, path).expect("cold hard link should be retained");
+        }
+        let survivor_id = add_path(&mut arena, &survivor).expect("survivor should be retained");
+        assert!(arena.identities.is_spilled());
+        assert!(
+            arena
+                .aggregate_cold_subtree(&HashSet::from([arena.root()]))
+                .expect("cold subtree should compact")
+        );
+
+        let record = arena
+            .identities
+            .get(&file_id)
+            .expect("identity lookup should succeed")
+            .expect("identity should remain");
+        assert_eq!(record.observed_links, COLD_LINKS + 1);
+        assert_eq!(record.nodes, vec![(cold_id, COLD_LINKS), (survivor_id, 1)]);
+        assert_eq!(record.allocation_node, Some(cold_id));
+
+        arena
+            .finalize()
+            .expect("hard links should finalize after compaction");
+        let shared = arena
+            .children(arena.root())
+            .iter()
+            .filter_map(|id| arena.node(*id))
+            .find(|node| node.kind == NodeKind::Synthetic(SyntheticKind::Shared))
+            .expect("shared allocation should remain visible at the common ancestor");
+        let shared_allocation = shared.metrics.allocated_bytes;
+        assert_eq!(shared.parent, Some(arena.root()));
+        assert_eq!(
+            arena
+                .node(cold_id)
+                .expect("cold aggregate should remain")
+                .metrics
+                .allocated_bytes,
+            ByteBounds::exact(0)
+        );
+        assert_eq!(
+            arena
+                .node(survivor_id)
+                .expect("survivor should remain")
+                .metrics
+                .allocated_bytes,
+            ByteBounds::exact(0)
+        );
+
+        assert!(arena.remove_path(&cold));
+        let record = arena
+            .identities
+            .get(&file_id)
+            .expect("identity lookup should succeed")
+            .expect("surviving identity should remain");
+        assert_eq!(record.observed_links, 1);
+        assert_eq!(record.nodes, vec![(survivor_id, 1)]);
+        assert_eq!(record.allocation_node, Some(survivor_id));
+        assert_eq!(
+            arena
+                .node(survivor_id)
+                .expect("survivor should remain")
+                .metrics
+                .allocated_bytes,
+            shared_allocation
+        );
+        assert_eq!(
+            arena
+                .node(arena.root())
+                .expect("root should remain")
+                .metrics
+                .allocated_bytes,
+            shared_allocation
+        );
+        assert!(arena.children(arena.root()).iter().all(|id| {
+            arena
+                .node(*id)
+                .is_none_or(|node| node.kind != NodeKind::Synthetic(SyntheticKind::Shared))
+        }));
     }
 
     #[test]

--- a/src/model/identity_store.rs
+++ b/src/model/identity_store.rs
@@ -35,7 +35,38 @@ pub struct IdentityRecord {
     pub declared_links: Option<u64>,
     pub allocated_bytes: ByteBounds,
     pub allocation_node: Option<NodeId>,
-    pub nodes: Vec<NodeId>,
+    /// Distinct participant nodes paired with their exact observed link counts.
+    pub nodes: Vec<(NodeId, u64)>,
+}
+
+impl IdentityRecord {
+    fn observe_node(&mut self, node: NodeId) {
+        match self
+            .nodes
+            .binary_search_by_key(&node, |(existing, _)| *existing)
+        {
+            Ok(index) => {
+                self.nodes[index].1 = self.nodes[index].1.saturating_add(1);
+            }
+            Err(index) => self.nodes.insert(index, (node, 1)),
+        }
+    }
+
+    pub(crate) fn coalesce_nodes(&mut self) {
+        self.nodes.sort_unstable_by_key(|(node, _)| *node);
+        let mut retained = 0_usize;
+        for index in 0..self.nodes.len() {
+            let (node, links) = self.nodes[index];
+            if retained > 0 && self.nodes[retained - 1].0 == node {
+                let (_, retained_links) = &mut self.nodes[retained - 1];
+                *retained_links = retained_links.saturating_add(links);
+            } else {
+                self.nodes[retained] = (node, links);
+                retained += 1;
+            }
+        }
+        self.nodes.truncate(retained);
+    }
 }
 
 pub struct IdentityStore {
@@ -200,7 +231,7 @@ impl IdentityStore {
         record.observed_links = record.observed_links.saturating_add(1);
         record.declared_links = merge_declared_links(record.declared_links, declared_links);
         if let Some(node) = node {
-            record.nodes.push(node);
+            record.observe_node(node);
         }
 
         if matches!(self.storage, Storage::Memory(_)) {
@@ -577,11 +608,14 @@ fn remap_record_nodes(
     replacement: NodeId,
 ) -> bool {
     let mut changed = false;
-    for node in &mut record.nodes {
-        if removed.binary_search(&*node).is_ok() {
+    for (node, _) in &mut record.nodes {
+        if removed.binary_search(node).is_ok() {
             *node = replacement;
             changed = true;
         }
+    }
+    if changed {
+        record.coalesce_nodes();
     }
     if record
         .allocation_node
@@ -1149,7 +1183,7 @@ mod tests {
             .get(&file_id)
             .expect("identity lookup should succeed")
             .expect("identity should remain");
-        assert_eq!(record.nodes, vec![NodeId(12), NodeId(5)]);
+        assert_eq!(record.nodes, vec![(NodeId(5), 1), (NodeId(12), 1)]);
         assert_eq!(record.allocation_node, Some(NodeId(12)));
     }
 
@@ -1181,9 +1215,52 @@ mod tests {
                 .get(&FileId::new_inode(10, u64::from(index)))
                 .expect("identity lookup should succeed")
                 .expect("identity should remain");
-            assert_eq!(record.nodes, vec![replacement]);
+            assert_eq!(record.nodes, vec![(replacement, 1)]);
             assert_eq!(record.allocation_node, Some(replacement));
         }
+    }
+
+    #[test]
+    fn spilled_repeated_participants_are_coalesced_after_remap() {
+        const OBSERVATIONS: u64 = 1_024;
+        let file_id = FileId::new_inode(11, 11);
+        let mut store = IdentityStore::new(1).expect("private session should initialize");
+        for _ in 0..OBSERVATIONS {
+            store
+                .observe(
+                    &file_id,
+                    Some(OBSERVATIONS),
+                    ByteBounds::exact(4096),
+                    Some(NodeId(4)),
+                    Some(NodeId(4)),
+                )
+                .expect("repeated spilled participant should be stored");
+        }
+        assert!(store.is_spilled());
+
+        store
+            .remap_nodes_for_identity(&file_id, &[NodeId(4)], NodeId(9))
+            .expect("spilled participant should be remapped");
+
+        let Storage::Disk { pending, .. } = &store.storage else {
+            panic!("identity store should spill");
+        };
+        let pending_record = pending
+            .values()
+            .next()
+            .expect("remapped record should be pending");
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending_record.nodes.len(), 1);
+        assert_eq!(pending_record.nodes, vec![(NodeId(9), OBSERVATIONS)]);
+
+        let record = store
+            .get(&file_id)
+            .expect("identity lookup should succeed")
+            .expect("identity should remain");
+        assert_eq!(record.observed_links, OBSERVATIONS);
+        assert_eq!(record.nodes.len(), 1);
+        assert_eq!(record.nodes, vec![(NodeId(9), OBSERVATIONS)]);
+        assert_eq!(record.allocation_node, Some(NodeId(9)));
     }
 
     #[test]
@@ -1218,7 +1295,7 @@ mod tests {
             .get(&file_id)
             .expect("identity lookup should succeed")
             .expect("identity should remain");
-        assert_eq!(record.nodes, vec![NodeId(9)]);
+        assert_eq!(record.nodes, vec![(NodeId(9), 1)]);
         assert_eq!(record.allocation_node, Some(NodeId(9)));
     }
 


### PR DESCRIPTION
## Summary

Bounds hard-link participant storage after repeated aggregation and remapping while preserving exact link accounting.

## Changes

- Store each distinct participant `NodeId` with a `u64` observation multiplicity instead of appending duplicate IDs per observation.
- Coalesce participants after keyed/bulk remapping and staged identity merges.
- Sum participant multiplicities during replacement and deletion rebuilds so `observed_links` and allocation ownership remain exact.
- Add a disk-spilled 128-link fan-out regression that compacts one subtree, checks coalesced state and Shared placement, then deletes the aggregate and checks exact rehoming.
- Add a focused pending-write regression for 1,024 repeated observations of one spilled identity.

## Safety and compatibility

The change preserves every observation count: `observed_links` is still incremented per observation, while participant multiplicity retains the count needed when an aggregate is removed. Allocation ownership is remapped with its participant and rehomes to a surviving participant after deletion; Shared placement still uses the distinct live participant nodes for LCA calculation. Compaction-candidate selection and generic spill policy are unchanged. The spill database is private to a temporary session and removed on drop, so this changes no user-facing persistent schema or migration boundary.

## Verification

- [x] Focused tests cover the fan-out, remap, disk persistence, pending write, Shared placement, allocation-owner, and deletion-accounting paths.
  - `cargo test --lib model::identity_store::tests --locked` — 11 passed.
  - `cargo test --lib hard_link --locked` — 16 passed.
- [ ] `cargo fmt --all -- --check` passes. Not run: task scope explicitly excludes formatters.
- [ ] `cargo clippy --workspace --all-targets --locked -- -D warnings` passes. Not run: task scope explicitly excludes linters.
- [ ] `cargo test --workspace --locked` passes. Not run: task scope explicitly excludes project-wide suites.
- [x] User-facing documentation and generated artifacts are current: the change is internal accounting only.

The new pending-write regression reproduced the defect before this change: one remapped identity retained 1,024 duplicate participant IDs where one coalesced participant is required.