### PR TITLE
fix: bound temporary spill storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable Excise changes are documented here. The format follows [Keep a Chang
 
 Excise preserves the historical Diskonaut changelog below. Diskonaut versions and tags are not Excise releases.
 
+## [Unreleased]
+
+### Fixed
+
+* Scanner directory-task spill and identity spill files now share a fixed per-session temporary-storage limit. Capacity is reserved before a file grows, released after cleanup, and exhaustion reports an actionable incomplete scan or identity-accounting error instead of silently dropping work or claiming an exact result.
+
 ## [1.2.1] - 2026-09-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Configuration takes values in this order: command line, environment, versioned T
 ## What Excise Does
 
 - **Careful space accounting:** Excise keeps the disk space assigned to files separate from their file length. It counts files with more than one name once and keeps unknown values unknown.
-- **Clear limits:** Scan queues, worker counts, memory use, temporary file records, reports, and interface history have explicit limits.
+- **Clear limits:** Scan queues, worker counts, memory use, per-session temporary storage, reports, and interface history have explicit limits.
 - **Safe review before deletion:** Deletion plans record the files and folders that were reviewed. Excise does not follow links, checks for changes before deletion, and never includes new entries silently.
 - **Reliable terminal behavior:** The terminal is restored after normal exit, errors, panics, cancellation, and forced interruption.
 - **Accessible interaction:** Keyboard controls, narrow layouts, plain ASCII output, monochrome output, and reduced motion preserve the important safety information.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -22,7 +22,7 @@ The main loop polls terminal input with a bounded timeout. It renders each folde
 
 ### Scanner
 
-The scanner uses a fixed number of workers and walks directories without recursion. Directory tasks and worker events use queues with fixed limits. When temporary working data reaches its memory limit, the scanner can use a permission-restricted store for the session instead of growing without limit. Backpressure never silently drops an entry.
+The scanner uses a fixed number of workers and walks directories without recursion. Directory tasks and worker events use queues with fixed limits. Queued directory tasks and identity spill files share one per-session temporary-storage limit, reserve capacity before their files grow, and release it after shrinking or cleanup. A capacity breach reports an actionable failure and never turns incomplete work into an exact result; backpressure never silently drops an entry.
 
 The default worker count leaves one available processor for the owner loop when possible and is clamped from one through eight. The configured value must be between one and 32. Exclusions and file system boundaries remain visible in the working model. Link targets are never traversed.
 
@@ -36,7 +36,7 @@ The default process memory limit is 512 MiB. Working data may use 75 percent of 
 
 ### Space Accounting
 
-The identity table counts files with more than one name once within the scan scope. When exact identity data exceeds the memory limit, a permission-restricted store for the current session keeps the minimum records needed for accounting. Unknown values remain bounds rather than becoming guessed numbers.
+The identity table counts files with more than one name once within the scan scope. When exact identity data exceeds the memory limit, a permission-restricted store for the current session keeps the minimum records needed for accounting within the shared temporary-storage limit. Unknown values remain bounds rather than becoming guessed numbers.
 
 ### Deletion
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,7 @@ exclusions = [".git/", "target/"]
 
 [model]
 process_memory_mib = 512
+temporary_storage_mib = 512
 
 [runtime]
 reduced_motion = false
@@ -62,6 +63,7 @@ right = "d"
 | `scanner.cross_filesystems` | Traverse beyond the starting file system | true or false |
 | `scanner.exclusions` | Ordered gitignore-style patterns | An array of strings |
 | `model.process_memory_mib` | Whole-process memory limit | At least 128 MiB and no more than detected memory |
+| `model.temporary_storage_mib` | Combined scanner-task and identity temporary storage per session | At least 2 MiB |
 | `runtime.reduced_motion` | Disable nonessential transitions | true or false |
 | `runtime.theme` | Built-in color theme | See `excise --help` for names |
 | `runtime.ascii` | Use ASCII symbols and borders | true or false |
@@ -71,6 +73,7 @@ right = "d"
 | `runtime.output` | Report destination for noninteractive output | A path |
 
 The default memory limit is 512 MiB or the detected available memory when that is lower. Excise reserves 25 percent as process headroom and limits working data to the remaining 75 percent.
+The default temporary-storage limit is 512 MiB per session. `model.temporary_storage_mib`, `EXCISE_TEMPORARY_STORAGE_MIB`, and `--temporary-storage-mib` set one shared cap for queued scanner directory tasks and private identity spill files. If it fills, Excise reports the incomplete scan as uncertain or stops exact identity accounting with an actionable error; it never reports the incomplete result as exact.
 By default, Excise uses one less than the detected available processor count, clamped from one through eight workers, so interactive input retains a processor when possible.
 
 ## Environment Variables
@@ -85,6 +88,7 @@ By default, Excise uses one less than the detected available processor count, cl
 | `EXCISE_CROSS_FILESYSTEMS` | `scanner.cross_filesystems` |
 | `EXCISE_EXCLUDE` | Exclusion patterns separated by semicolons |
 | `EXCISE_MEMORY_MIB` | `model.process_memory_mib` |
+| `EXCISE_TEMPORARY_STORAGE_MIB` | `model.temporary_storage_mib` |
 | `EXCISE_REDUCED_MOTION` | `runtime.reduced_motion` |
 | `EXCISE_THEME` | `runtime.theme` |
 | `EXCISE_ASCII` | `runtime.ascii` |

--- a/docs/safety/accounting.md
+++ b/docs/safety/accounting.md
@@ -44,7 +44,9 @@ Version 1.0 counts file identities rather than physical storage blocks. Copy-on-
 
 ## Memory & Temporary Storage
 
-Identity tracking can use a permission-restricted, session-only temporary store when the records do not fit in memory. If exact tracking cannot continue safely, Excise stops with an actionable error rather than weakening the accounting definition.
+Each scan session has one fixed temporary-storage budget, 512 MiB by default, shared by queued scanner directory tasks and private identity spill files. The session marker and every owned file reserve capacity before they grow, release it only after the file is shrunk or removed, and remain inside the existing private-path and active-session checks.
+
+If queued scanner work cannot reserve capacity, the scanner reports an actionable failure and does not complete that partial scan as exact. If identity persistence cannot reserve capacity, exact accounting stops with an actionable error rather than weakening the accounting definition. Capacity failures neither drop queued work silently nor leave owned temporary files outside the session accounting.
 
 ## Map Invariants
 

--- a/generated/completions/_excise
+++ b/generated/completions/_excise
@@ -20,6 +20,7 @@ _excise() {
 '--event-buffer=[Bounded worker-event capacity (16-4096)]:COUNT:_default' \
 '*--exclude=[Ordered gitignore-style exclusion pattern]:PATTERN:_default' \
 '--memory-mib=[Whole-process memory envelope in MiB]:MIB:_default' \
+'--temporary-storage-mib=[Combined scanner-task and identity temporary storage limit per session (2+)]:MIB:_default' \
 '--theme=[Built-in semantic color theme]:THEME:(excise-dark excise-light high-contrast monochrome dracula tokyo-night catppuccin-mocha catppuccin-latte gruvbox-dark gruvbox-light nord solarized-dark solarized-light one-dark monokai)' \
 '--keymap=[Keyboard preset. Arrows and safety keys always work]:PRESET:(vim custom emacs)' \
 '--format=[Output mode. Table and JSON never acquire a terminal]:FORMAT:(tui table json)' \

--- a/generated/completions/_excise.ps1
+++ b/generated/completions/_excise.ps1
@@ -26,6 +26,7 @@ Register-ArgumentCompleter -Native -CommandName 'excise' -ScriptBlock {
             [CompletionResult]::new('--event-buffer', '--event-buffer', [CompletionResultType]::ParameterName, 'Bounded worker-event capacity (16-4096)')
             [CompletionResult]::new('--exclude', '--exclude', [CompletionResultType]::ParameterName, 'Ordered gitignore-style exclusion pattern')
             [CompletionResult]::new('--memory-mib', '--memory-mib', [CompletionResultType]::ParameterName, 'Whole-process memory envelope in MiB')
+            [CompletionResult]::new('--temporary-storage-mib', '--temporary-storage-mib', [CompletionResultType]::ParameterName, 'Combined scanner-task and identity temporary storage limit per session (2+)')
             [CompletionResult]::new('--theme', '--theme', [CompletionResultType]::ParameterName, 'Built-in semantic color theme')
             [CompletionResult]::new('--keymap', '--keymap', [CompletionResultType]::ParameterName, 'Keyboard preset. Arrows and safety keys always work')
             [CompletionResult]::new('--format', '--format', [CompletionResultType]::ParameterName, 'Output mode. Table and JSON never acquire a terminal')

--- a/generated/completions/excise.bash
+++ b/generated/completions/excise.bash
@@ -23,7 +23,7 @@ _excise() {
 
     case "${cmd}" in
         excise)
-            opts="-a -d -h -V --config --apparent-size --scan-threads --event-buffer --cross-filesystems --exclude --memory-mib --reduced-motion --theme --ascii --mouse --keymap --format --output --disable-delete-confirmation --help --version"
+            opts="-a -d -h -V --config --apparent-size --scan-threads --event-buffer --cross-filesystems --exclude --memory-mib --temporary-storage-mib --reduced-motion --theme --ascii --mouse --keymap --format --output --disable-delete-confirmation --help --version"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -46,6 +46,10 @@ _excise() {
                     return 0
                     ;;
                 --memory-mib)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --temporary-storage-mib)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/generated/completions/excise.elv
+++ b/generated/completions/excise.elv
@@ -23,6 +23,7 @@ set edit:completion:arg-completer[excise] = {|@words|
             cand --event-buffer 'Bounded worker-event capacity (16-4096)'
             cand --exclude 'Ordered gitignore-style exclusion pattern'
             cand --memory-mib 'Whole-process memory envelope in MiB'
+            cand --temporary-storage-mib 'Combined scanner-task and identity temporary storage limit per session (2+)'
             cand --theme 'Built-in semantic color theme'
             cand --keymap 'Keyboard preset. Arrows and safety keys always work'
             cand --format 'Output mode. Table and JSON never acquire a terminal'

--- a/generated/completions/excise.fish
+++ b/generated/completions/excise.fish
@@ -3,6 +3,7 @@ complete -c excise -l scan-threads -d 'Scanner worker count (1-32)' -r
 complete -c excise -l event-buffer -d 'Bounded worker-event capacity (16-4096)' -r
 complete -c excise -l exclude -d 'Ordered gitignore-style exclusion pattern' -r
 complete -c excise -l memory-mib -d 'Whole-process memory envelope in MiB' -r
+complete -c excise -l temporary-storage-mib -d 'Combined scanner-task and identity temporary storage limit per session (2+)' -r
 complete -c excise -l theme -d 'Built-in semantic color theme' -r -f -a "excise-dark\t''
 excise-light\t''
 high-contrast\t''

--- a/generated/man/excise.1
+++ b/generated/man/excise.1
@@ -4,7 +4,7 @@
 .SH NAME
 excise
 .SH SYNOPSIS
-\fBexcise\fR [\fB\-\-config\fR] [\fB\-a\fR|\fB\-\-apparent\-size\fR] [\fB\-\-scan\-threads\fR] [\fB\-\-event\-buffer\fR] [\fB\-\-cross\-filesystems\fR] [\fB\-\-exclude\fR] [\fB\-\-memory\-mib\fR] [\fB\-\-reduced\-motion\fR] [\fB\-\-theme\fR] [\fB\-\-ascii\fR] [\fB\-\-mouse\fR] [\fB\-\-keymap\fR] [\fB\-\-format\fR] [\fB\-\-output\fR] [\fB\-d\fR|\fB\-\-disable\-delete\-confirmation\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIfolder\fR]
+\fBexcise\fR [\fB\-\-config\fR] [\fB\-a\fR|\fB\-\-apparent\-size\fR] [\fB\-\-scan\-threads\fR] [\fB\-\-event\-buffer\fR] [\fB\-\-cross\-filesystems\fR] [\fB\-\-exclude\fR] [\fB\-\-memory\-mib\fR] [\fB\-\-temporary\-storage\-mib\fR] [\fB\-\-reduced\-motion\fR] [\fB\-\-theme\fR] [\fB\-\-ascii\fR] [\fB\-\-mouse\fR] [\fB\-\-keymap\fR] [\fB\-\-format\fR] [\fB\-\-output\fR] [\fB\-d\fR|\fB\-\-disable\-delete\-confirmation\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIfolder\fR]
 .SH DESCRIPTION
 .SH OPTIONS
 .TP
@@ -28,6 +28,9 @@ Ordered gitignore\-style exclusion pattern
 .TP
 \fB\-\-memory\-mib\fR \fI<MIB>\fR
 Whole\-process memory envelope in MiB
+.TP
+\fB\-\-temporary\-storage\-mib\fR \fI<MIB>\fR
+Combined scanner\-task and identity temporary storage limit per session (2+)
 .TP
 \fB\-\-reduced\-motion\fR
 Disable nonessential motion

--- a/src/app.rs
+++ b/src/app.rs
@@ -26,6 +26,7 @@ use crate::report::{
 use crate::state::files::FileTree;
 use crate::state::tiles::{Board, FileType, Pivot};
 use crate::state::{FileToDelete, UiEffects};
+use crate::temporary_storage::TemporaryStorage;
 use crate::theme::Theme;
 use crate::ui::Display;
 use crate::ui::palette::ColorCycle;
@@ -170,13 +171,41 @@ where
         custom_keys: Option<CustomKeyBindings>,
         mouse_enabled: bool,
     ) -> Result<Self, AppError> {
+        Self::new_with_root_identity_and_temporary_storage(
+            terminal_backend,
+            path_in_filesystem,
+            root_identity,
+            show_apparent_size,
+            disable_delete_confirmation,
+            process_memory_mib,
+            keymap,
+            custom_keys,
+            mouse_enabled,
+            TemporaryStorage::default(),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new_with_root_identity_and_temporary_storage(
+        terminal_backend: B,
+        path_in_filesystem: PathBuf,
+        root_identity: NativeIdentity,
+        show_apparent_size: bool,
+        disable_delete_confirmation: bool,
+        process_memory_mib: usize,
+        keymap: KeyPreset,
+        custom_keys: Option<CustomKeyBindings>,
+        mouse_enabled: bool,
+        temporary_storage: TemporaryStorage,
+    ) -> Result<Self, AppError> {
         let display = Display::new(terminal_backend)?;
         let board = Board::new();
-        let file_tree = FileTree::new_with_root_identity(
+        let file_tree = FileTree::new_with_root_identity_and_temporary_storage(
             path_in_filesystem,
             root_identity,
             show_apparent_size,
             process_memory_mib,
+            temporary_storage,
         )
         .map_err(model_error)?;
         Ok(Self::from_parts(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,6 +61,7 @@ pub(crate) fn run_main() -> i32 {
         cross_filesystems: config.cross_filesystems,
         exclusions: config.exclusions,
         memory_mib: config.memory_mib,
+        temporary_storage_mib: config.temporary_storage_mib,
         apparent_size: config.apparent_size,
         disable_delete_confirmation: config.disable_delete_confirmation,
         reduced_motion: config.reduced_motion,

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::AppError;
 use crate::native_path::{safe_display_path_text, safe_display_text};
+use crate::temporary_storage::{DEFAULT_TEMPORARY_STORAGE_MIB, MIN_TEMPORARY_STORAGE_MIB};
 use crate::theme::ThemeId;
 
 fn config_error(message: impl std::fmt::Display) -> AppError {
@@ -22,6 +23,7 @@ pub const CONFIG_VERSION: u16 = 1;
 const DEFAULT_EVENT_BUFFER: usize = 256;
 const MAX_SCANNER_THREADS: usize = 32;
 const DEFAULT_MAX_SCANNER_THREADS: usize = 8;
+const MAX_TEMPORARY_STORAGE_MIB: usize = usize::MAX / (1024 * 1024);
 
 fn default_scan_threads(available: usize) -> usize {
     available
@@ -185,6 +187,9 @@ pub struct Cli {
     #[arg(long, value_name = "MIB")]
     /// Whole-process memory envelope in MiB
     pub memory_mib: Option<usize>,
+    #[arg(long, value_name = "MIB")]
+    /// Combined scanner-task and identity temporary storage limit per session (2+)
+    pub temporary_storage_mib: Option<usize>,
     #[arg(long)]
     /// Disable nonessential motion
     pub reduced_motion: bool,
@@ -239,6 +244,7 @@ pub struct ScannerFileConfig {
 #[serde(deny_unknown_fields)]
 pub struct ModelFileConfig {
     pub process_memory_mib: Option<usize>,
+    pub temporary_storage_mib: Option<usize>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
@@ -264,6 +270,7 @@ pub struct EnvironmentOverrides {
     pub cross_filesystems: Option<bool>,
     pub exclusions: Vec<String>,
     pub memory_mib: Option<usize>,
+    pub temporary_storage_mib: Option<usize>,
     pub monochrome: bool,
     pub theme: Option<ThemeId>,
     pub ascii: Option<bool>,
@@ -282,6 +289,7 @@ pub struct RuntimeConfig {
     pub cross_filesystems: bool,
     pub exclusions: Vec<String>,
     pub memory_mib: usize,
+    pub temporary_storage_mib: usize,
     pub apparent_size: bool,
     pub reduced_motion: bool,
     pub monochrome: bool,
@@ -373,6 +381,11 @@ impl RuntimeConfig {
             .or(environment.memory_mib)
             .or_else(|| file_model.and_then(|model| model.process_memory_mib))
             .unwrap_or(crate::model::DEFAULT_PROCESS_MIB.min(maximum_memory_mib));
+        let temporary_storage_mib = cli
+            .temporary_storage_mib
+            .or(environment.temporary_storage_mib)
+            .or_else(|| file_model.and_then(|model| model.temporary_storage_mib))
+            .unwrap_or(DEFAULT_TEMPORARY_STORAGE_MIB);
         validate_range("scanner threads", scan_threads, 1, MAX_SCANNER_THREADS)?;
         validate_range("event buffer", event_buffer, 16, 4096)?;
         validate_range(
@@ -380,6 +393,12 @@ impl RuntimeConfig {
             memory_mib,
             crate::model::MIN_PROCESS_MIB,
             maximum_memory_mib,
+        )?;
+        validate_range(
+            "temporary storage",
+            temporary_storage_mib,
+            MIN_TEMPORARY_STORAGE_MIB,
+            MAX_TEMPORARY_STORAGE_MIB,
         )?;
 
         let apparent_size = cli.apparent_size
@@ -448,6 +467,7 @@ impl RuntimeConfig {
             scan_threads,
             event_buffer,
             memory_mib,
+            temporary_storage_mib,
             apparent_size,
             cross_filesystems,
             exclusions,
@@ -497,6 +517,7 @@ impl EnvironmentOverrides {
                 })
                 .unwrap_or_default(),
             memory_mib: parse_usize_env("EXCISE_MEMORY_MIB")?,
+            temporary_storage_mib: parse_usize_env("EXCISE_TEMPORARY_STORAGE_MIB")?,
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ pub mod runtime;
 mod runtime;
 #[allow(dead_code)]
 mod state;
+mod temporary_storage;
 #[cfg(any(feature = "fuzzing", feature = "internal"))]
 pub mod terminal;
 #[cfg(not(any(feature = "fuzzing", feature = "internal")))]
@@ -141,6 +142,7 @@ pub(crate) fn start<B>(
         cross_filesystems: false,
         exclusions: Vec::new(),
         memory_mib: crate::model::DEFAULT_PROCESS_MIB,
+        temporary_storage_mib: crate::temporary_storage::DEFAULT_TEMPORARY_STORAGE_MIB,
         apparent_size: show_apparent_size,
         disable_delete_confirmation,
         reduced_motion: true,

--- a/src/model/arena.rs
+++ b/src/model/arena.rs
@@ -15,6 +15,7 @@ use super::{
 };
 use crate::native_path::{NativeIdentity, identity_for};
 use crate::os::physical_size;
+use crate::temporary_storage::TemporaryStorage;
 
 const NODE_SLOT_BYTES: usize = size_of::<Option<Node>>();
 const RETAINED_CHILD_SLOT_BYTES: usize = size_of::<u32>();
@@ -87,6 +88,7 @@ pub struct Arena {
     root_path: PathBuf,
     budget: MemoryBudget,
     identities: IdentityStore,
+    temporary_storage: TemporaryStorage,
     duplicate_identities: HashSet<FileId>,
     untracked_metrics: HashMap<NodeId, UntrackedMetrics>,
     access_tick: u64,
@@ -120,7 +122,15 @@ const EVICTION_STASH_ALLOCATION: usize = EVICTION_STASH_OVERHEAD
     reason = "Arena operations share ModelError as their uniform boundary for filesystem paths, bounded storage, and identity persistence. Repeating that contract on each method obscures the model API."
 )]
 impl Arena {
-    pub fn new(root_path: PathBuf, mut budget: MemoryBudget) -> Result<Self, ModelError> {
+    pub fn new(root_path: PathBuf, budget: MemoryBudget) -> Result<Self, ModelError> {
+        Self::new_with_temporary_storage(root_path, budget, TemporaryStorage::default())
+    }
+
+    pub(crate) fn new_with_temporary_storage(
+        root_path: PathBuf,
+        mut budget: MemoryBudget,
+        temporary_storage: TemporaryStorage,
+    ) -> Result<Self, ModelError> {
         let identity_budget = budget.model_limit() / 4;
         budget.reserve(identity_budget)?;
         let root_name: Arc<OsStr> = root_path
@@ -144,8 +154,12 @@ impl Arena {
             root,
             root_path,
             budget,
-            identities: IdentityStore::new(identity_budget)?,
+            identities: IdentityStore::new_with_temporary_storage(
+                identity_budget,
+                &temporary_storage,
+            )?,
             duplicate_identities: HashSet::new(),
+            temporary_storage,
             untracked_metrics: HashMap::new(),
             access_tick: 0,
             max_children_per_directory: DEFAULT_MAX_CHILDREN,
@@ -201,6 +215,11 @@ impl Arena {
     #[must_use]
     pub fn identity_spill_path(&self) -> Option<&Path> {
         self.identities.spill_path()
+    }
+
+    #[must_use]
+    pub(crate) fn temporary_storage(&self) -> TemporaryStorage {
+        self.temporary_storage.clone()
     }
 
     #[must_use]
@@ -913,7 +932,10 @@ impl Arena {
             .map(|node| node.id)
             .collect::<Vec<_>>();
         let identities = self.rebuild_identities_without(&removed, link_counts)?;
-        let identity_scratch = IdentityStore::new(self.identities.memory_limit())?;
+        let identity_scratch = IdentityStore::new_with_temporary_storage(
+            self.identities.memory_limit(),
+            &self.temporary_storage,
+        )?;
         let mut removal_order = removed.clone();
         removal_order.sort_by_key(|id| self.depth(*id));
         self.remove_nodes(removal_order);
@@ -1135,7 +1157,10 @@ impl Arena {
         let mut identities = self.rebuild_focused_identities(target, &removed)?;
         merge_staged_identities(&mut identities, &mut staging, target)?;
         identities.visit_records(|_, _| Ok(()))?;
-        let identity_scratch = IdentityStore::new(self.identities.memory_limit())?;
+        let identity_scratch = IdentityStore::new_with_temporary_storage(
+            self.identities.memory_limit(),
+            &self.temporary_storage,
+        )?;
         let children = staged_children
             .into_iter()
             .map(|child| staged_live_id(&staging.nodes, staging.root, child, target))
@@ -1404,7 +1429,8 @@ impl Arena {
         removed: &[NodeId],
     ) -> Result<IdentityStore, ModelError> {
         let identity_limit = self.identities.memory_limit().min(self.budget.headroom());
-        let mut rebuilt = IdentityStore::new(identity_limit)?;
+        let mut rebuilt =
+            IdentityStore::new_with_temporary_storage(identity_limit, &self.temporary_storage)?;
         self.identities.visit_records(|file_id, record| {
             if let Some(record) = remove_replaced_participants(record, target, removed) {
                 merge_identity_record(&mut rebuilt, &file_id, record)?;
@@ -1419,7 +1445,8 @@ impl Arena {
         link_counts: &HashMap<FileId, Option<u64>>,
     ) -> Result<IdentityStore, ModelError> {
         let identity_limit = self.identities.memory_limit().min(self.budget.headroom());
-        let mut rebuilt = IdentityStore::new(identity_limit)?;
+        let mut rebuilt =
+            IdentityStore::new_with_temporary_storage(identity_limit, &self.temporary_storage)?;
         self.identities.visit_records(|file_id, record| {
             if let Some(mut record) = remove_deleted_participants(record, removed) {
                 if let Some(link_count) = link_counts.get(&file_id) {

--- a/src/model/identity_store.rs
+++ b/src/model/identity_store.rs
@@ -4,7 +4,7 @@ use std::io::{Read as _, Write as _};
 use std::mem::size_of;
 use std::ops::Bound;
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use file_id::FileId;
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use tempfile::{Builder as TempBuilder, TempDir};
 
 use super::{ByteBounds, ModelError, NodeId};
+use crate::temporary_storage::{BoundedFileBackend, TemporaryStorage, TemporaryStorageReservation};
 
 const IDENTITIES: TableDefinition<&[u8], &[u8]> = TableDefinition::new("identities");
 const IDENTITY_ENTRY_OVERHEAD: usize = size_of::<IdentityRecord>() + 96;
@@ -99,6 +100,9 @@ struct SessionDirectory {
     temporary: TempDir,
     #[cfg(windows)]
     handle: crate::os::windows::PrivateDirectoryHandle,
+    // Retained for Drop so marker bytes remain charged for this session's lifetime.
+    _marker_reservation: TemporaryStorageReservation,
+    database_reservation: Arc<Mutex<TemporaryStorageReservation>>,
 }
 
 impl Drop for IdentityStore {
@@ -116,9 +120,20 @@ struct SessionMarker {
 }
 
 impl SessionDirectory {
-    fn new() -> Result<Self, ModelError> {
+    fn new(temporary_storage: &TemporaryStorage) -> Result<Self, ModelError> {
         #[cfg(not(windows))]
         {
+            let marker = SessionMarker::new()?;
+            let marker_contents = marker.serialize();
+            let marker_bytes = u64::try_from(marker_contents.len()).map_err(|_| {
+                ModelError::Identity("spill session marker size does not fit in u64".to_string())
+            })?;
+            let marker_reservation = temporary_storage
+                .reservation(marker_bytes)
+                .map_err(identity_error)?;
+            let database_reservation = Arc::new(Mutex::new(
+                temporary_storage.reservation(0).map_err(identity_error)?,
+            ));
             let temporary = TempBuilder::new()
                 .prefix(SESSION_PREFIX)
                 .rand_bytes(32)
@@ -127,13 +142,14 @@ impl SessionDirectory {
             let path = temporary.path().to_path_buf();
             restrict_private_directory(&path)?;
             verify_private_directory(&path)?;
-            let marker = SessionMarker::new()?;
-            write_session_marker(&path, &marker)?;
+            write_session_marker(&path, &marker_contents)?;
             verify_active_session(&path, &marker)?;
             Ok(Self {
                 path,
                 marker,
                 temporary,
+                _marker_reservation: marker_reservation,
+                database_reservation,
             })
         }
 
@@ -141,31 +157,41 @@ impl SessionDirectory {
         {
             let parent = std::env::temp_dir();
             for _ in 0..SESSION_CREATE_ATTEMPTS {
+                let marker = SessionMarker::new()?;
+                let marker_contents = marker.serialize();
+                let marker_bytes = u64::try_from(marker_contents.len()).map_err(|_| {
+                    ModelError::Identity(
+                        "spill session marker size does not fit in u64".to_string(),
+                    )
+                })?;
+                let marker_reservation = temporary_storage
+                    .reservation(marker_bytes)
+                    .map_err(identity_error)?;
+                let database_reservation = Arc::new(Mutex::new(
+                    temporary_storage.reservation(0).map_err(identity_error)?,
+                ));
                 let path = parent.join(format!("{SESSION_PREFIX}{}", random_session_token()?));
                 let mut handle = match crate::os::windows::create_private_directory(&path) {
                     Ok(handle) => handle,
                     Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
                     Err(error) => return Err(identity_error(error)),
                 };
-                let marker = match SessionMarker::new().and_then(|marker| {
-                    write_session_marker(&path, &marker)?;
-                    verify_active_session(&path, &marker)?;
-                    Ok(marker)
-                }) {
-                    Ok(marker) => marker,
-                    Err(error) => {
-                        return match remove_verified_session_held(&path, &mut handle) {
-                            Ok(()) => Err(error),
-                            Err(cleanup_error) => Err(ModelError::Identity(format!(
-                                "{error}; private spill-session cleanup also failed: {cleanup_error}"
-                            ))),
-                        };
-                    }
-                };
+                if let Err(error) = write_session_marker(&path, &marker_contents)
+                    .and_then(|()| verify_active_session(&path, &marker))
+                {
+                    return match remove_verified_session_held(&path, &mut handle) {
+                        Ok(()) => Err(error),
+                        Err(cleanup_error) => Err(ModelError::Identity(format!(
+                            "{error}; private spill-session cleanup also failed: {cleanup_error}"
+                        ))),
+                    };
+                }
                 return Ok(Self {
                     path,
                     marker,
                     handle,
+                    _marker_reservation: marker_reservation,
+                    database_reservation,
                 });
             }
             Err(ModelError::Identity(
@@ -182,6 +208,10 @@ impl SessionDirectory {
 
     fn is_verified(&self) -> bool {
         verify_active_session(&self.path, &self.marker).is_ok()
+    }
+
+    fn database_reservation(&self) -> Arc<Mutex<TemporaryStorageReservation>> {
+        Arc::clone(&self.database_reservation)
     }
 }
 
@@ -202,10 +232,18 @@ impl Drop for SessionDirectory {
 )]
 impl IdentityStore {
     pub fn new(memory_limit: usize) -> Result<Self, ModelError> {
+        let temporary_storage = TemporaryStorage::default();
+        Self::new_with_temporary_storage(memory_limit, &temporary_storage)
+    }
+
+    pub(crate) fn new_with_temporary_storage(
+        memory_limit: usize,
+        temporary_storage: &TemporaryStorage,
+    ) -> Result<Self, ModelError> {
         cleanup_stale_sessions_once();
         Ok(Self {
             storage: Storage::Memory(HashMap::new()),
-            session: SessionDirectory::new()?,
+            session: SessionDirectory::new(temporary_storage)?,
             memory_limit,
             estimated_bytes: 0,
         })
@@ -513,21 +551,23 @@ impl IdentityStore {
                 return Ok(());
             };
             let path = self.session.path().join(IDENTITY_DATABASE_FILE);
-            {
-                OpenOptions::new()
-                    .read(true)
-                    .write(true)
-                    .create_new(true)
-                    .open(&path)
-                    .map_err(identity_error)?;
-            }
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create_new(true)
+                .open(&path)
+                .map_err(identity_error)?;
             restrict_private_file(&path)?;
             verify_private_file(&path)?;
 
             let cache_size = (self.memory_limit / 4).clamp(64 * 1024, 16 * 1024 * 1024);
             let mut builder = RedbBuilder::new();
             builder.set_cache_size(cache_size);
-            let database = builder.create(&path).map_err(identity_error)?;
+            let backend = BoundedFileBackend::new(file, self.session.database_reservation())
+                .map_err(identity_error)?;
+            let database = builder
+                .create_with_backend(backend)
+                .map_err(identity_error)?;
             let transaction = database.begin_write().map_err(identity_error)?;
             {
                 let mut table = transaction.open_table(IDENTITIES).map_err(identity_error)?;
@@ -860,14 +900,14 @@ impl SessionMarker {
     }
 }
 
-fn write_session_marker(directory: &Path, marker: &SessionMarker) -> Result<(), ModelError> {
+fn write_session_marker(directory: &Path, contents: &str) -> Result<(), ModelError> {
     let path = directory.join(SESSION_MARKER_FILE);
     let mut file = OpenOptions::new()
         .write(true)
         .create_new(true)
         .open(&path)
         .map_err(identity_error)?;
-    file.write_all(marker.serialize().as_bytes())
+    file.write_all(contents.as_bytes())
         .map_err(identity_error)?;
     file.sync_data().map_err(identity_error)?;
     restrict_private_file(&path)?;
@@ -1060,8 +1100,11 @@ mod tests {
 
     #[test]
     fn spill_is_permission_restricted_and_removed_on_drop() {
+        const TEMPORARY_STORAGE_LIMIT: u64 = 2 * 1024 * 1024;
+        let temporary_storage = TemporaryStorage::with_limit_bytes(TEMPORARY_STORAGE_LIMIT);
         let spill_path = {
-            let mut store = IdentityStore::new(1).expect("private session should initialize");
+            let mut store = IdentityStore::new_with_temporary_storage(1, &temporary_storage)
+                .expect("private session should initialize");
             store
                 .observe(
                     &FileId::new_inode(1, 1),
@@ -1072,6 +1115,8 @@ mod tests {
                 )
                 .expect("identity should spill");
             assert!(store.is_spilled());
+            assert!(temporary_storage.used() > MAX_MARKER_BYTES);
+            assert!(temporary_storage.used() <= TEMPORARY_STORAGE_LIMIT);
             let path = store
                 .spill_path()
                 .expect("spill path should exist")
@@ -1096,6 +1141,42 @@ mod tests {
             }
             path
         };
+        assert!(!spill_path.exists());
+        assert_eq!(temporary_storage.used(), 0);
+    }
+
+    #[test]
+    fn identity_spill_enforces_the_session_limit_and_cleans_up_after_failure() {
+        let temporary_storage = TemporaryStorage::with_limit_bytes(MAX_MARKER_BYTES);
+        let spill_path = {
+            let mut store = IdentityStore::new_with_temporary_storage(1, &temporary_storage)
+                .expect("private session marker should fit the test limit");
+            let path = store
+                .internal_scan_paths()
+                .pop()
+                .expect("active private session should be tracked");
+            let error = store
+                .observe(
+                    &FileId::new_inode(13, 1),
+                    Some(1),
+                    ByteBounds::exact(4096),
+                    None,
+                    None,
+                )
+                .expect_err("identity spill must fail before exceeding its session limit");
+            assert!(matches!(error, ModelError::Identity(_)));
+            assert!(
+                error
+                    .to_string()
+                    .contains("temporary storage capacity exhausted")
+            );
+            assert!(error.to_string().contains("--temporary-storage-mib"));
+            assert_eq!(store.len(), 0);
+            assert!(!store.is_spilled());
+            assert!(temporary_storage.used() <= MAX_MARKER_BYTES);
+            path
+        };
+        assert_eq!(temporary_storage.used(), 0);
         assert!(!spill_path.exists());
     }
     #[test]
@@ -1309,7 +1390,8 @@ mod tests {
         let path = parent.join(name);
         std::fs::create_dir(&path).expect("stale session directory should be created");
         restrict_private_directory(&path).expect("stale session directory should be private");
-        write_session_marker(&path, marker).expect("stale session marker should be written");
+        write_session_marker(&path, &marker.serialize())
+            .expect("stale session marker should be written");
         if with_database {
             let database = path.join(IDENTITY_DATABASE_FILE);
             std::fs::write(&database, b"interrupted redb state")

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -28,6 +28,7 @@ use crate::native_path::{
 use crate::outcome::{OperationOutcome, RunSummary};
 use crate::report::{ScanReport, ScanReportState, scan_report_state};
 use crate::state::files::FileTree;
+use crate::temporary_storage::TemporaryStorage;
 use crate::theme::ThemeId;
 
 const WORKER_POLL_INTERVAL: Duration = Duration::from_millis(10);
@@ -46,6 +47,7 @@ pub struct RuntimeSettings {
     pub cross_filesystems: bool,
     pub exclusions: Vec<String>,
     pub memory_mib: usize,
+    pub temporary_storage_mib: usize,
     pub apparent_size: bool,
     pub disable_delete_confirmation: bool,
     pub reduced_motion: bool,
@@ -82,6 +84,7 @@ where
     clock: Box<dyn Clock>,
     animation: AnimationScheduler,
     settings: RuntimeSettings,
+    temporary_storage: TemporaryStorage,
     summary: RunSummary,
     scan_active: bool,
     /// Scan data relevant to the displayed folder arrived since its last refresh.
@@ -111,7 +114,9 @@ where
     B: Backend,
 {
     let now = clock.now();
-    let app = App::new_with_root_identity(
+    let temporary_storage = TemporaryStorage::from_mib(settings.temporary_storage_mib)
+        .map_err(|error| AppError::Config(error.to_string()))?;
+    let app = App::new_with_root_identity_and_temporary_storage(
         terminal_backend,
         settings.root.clone(),
         settings.root_identity.clone(),
@@ -121,6 +126,7 @@ where
         settings.keymap,
         settings.custom_keys.clone(),
         settings.mouse,
+        temporary_storage.clone(),
     )?;
     let workers = WorkerPool::start(
         scanner::ScannerOptions {
@@ -130,6 +136,7 @@ where
             cross_filesystems: settings.cross_filesystems,
             exclusions: settings.exclusions.clone(),
             internal_paths: app.internal_scan_paths(),
+            temporary_storage: temporary_storage.clone(),
         },
         settings.event_capacity,
     )?;
@@ -142,6 +149,7 @@ where
         clock,
         animation,
         settings,
+        temporary_storage,
         summary: RunSummary::default(),
         scan_active: true,
         scan_view_dirty: false,
@@ -317,6 +325,7 @@ where
                     cross_filesystems: self.settings.cross_filesystems,
                     exclusions: self.settings.exclusions.clone(),
                     internal_paths: self.app.internal_scan_paths(),
+                    temporary_storage: self.temporary_storage.clone(),
                 })?;
                 self.scan_active = true;
                 self.rescan_active = true;
@@ -762,6 +771,7 @@ where
             cross_filesystems: self.settings.cross_filesystems,
             exclusions: self.settings.exclusions.clone(),
             internal_paths: self.app.internal_scan_paths(),
+            temporary_storage: self.temporary_storage.clone(),
         })?;
         self.scan_active = true;
         self.rescan_active = true;
@@ -937,11 +947,14 @@ fn display_reason(reason: &crate::model::UnscannedReason) -> String {
 /// Returns a scanner, model, or worker error after all owned workers stop.
 #[allow(clippy::too_many_lines, clippy::needless_pass_by_value)]
 pub fn scan_headless(settings: RuntimeSettings) -> Result<OperationOutcome<ScanReport>, AppError> {
-    let mut tree = FileTree::new_with_root_identity(
+    let temporary_storage = TemporaryStorage::from_mib(settings.temporary_storage_mib)
+        .map_err(|error| AppError::Config(error.to_string()))?;
+    let mut tree = FileTree::new_with_root_identity_and_temporary_storage(
         settings.root.clone(),
         settings.root_identity.clone(),
         settings.apparent_size,
         settings.memory_mib,
+        temporary_storage.clone(),
     )
     .map_err(|error| AppError::Model(error.to_string()))?;
     let workers = WorkerPool::start(
@@ -952,6 +965,7 @@ pub fn scan_headless(settings: RuntimeSettings) -> Result<OperationOutcome<ScanR
             cross_filesystems: settings.cross_filesystems,
             exclusions: settings.exclusions.clone(),
             internal_paths: tree.internal_scan_paths(),
+            temporary_storage,
         },
         settings.event_capacity,
     )?;
@@ -1146,6 +1160,7 @@ mod tests {
                 cross_filesystems: false,
                 exclusions: Vec::new(),
                 internal_paths: app.internal_scan_paths(),
+                temporary_storage: TemporaryStorage::default(),
             },
             1,
         )
@@ -1164,6 +1179,7 @@ mod tests {
                 cross_filesystems: false,
                 exclusions: Vec::new(),
                 memory_mib: crate::model::DEFAULT_PROCESS_MIB,
+                temporary_storage_mib: crate::temporary_storage::DEFAULT_TEMPORARY_STORAGE_MIB,
                 apparent_size: false,
                 disable_delete_confirmation: false,
                 reduced_motion: true,
@@ -1177,6 +1193,7 @@ mod tests {
                 config_path: None,
                 monochrome_locked: true,
             },
+            temporary_storage: TemporaryStorage::default(),
             summary: RunSummary::default(),
             scan_active: true,
             scan_view_dirty: false,
@@ -1271,6 +1288,7 @@ mod tests {
                 cross_filesystems: false,
                 exclusions: Vec::new(),
                 memory_mib: crate::model::DEFAULT_PROCESS_MIB,
+                temporary_storage_mib: crate::temporary_storage::DEFAULT_TEMPORARY_STORAGE_MIB,
                 apparent_size: false,
                 disable_delete_confirmation: false,
                 reduced_motion: true,
@@ -1284,6 +1302,7 @@ mod tests {
                 config_path: None,
                 monochrome_locked: true,
             },
+            temporary_storage: TemporaryStorage::default(),
             summary: RunSummary::default(),
             scan_active: true,
             scan_view_dirty: false,

--- a/src/runtime/scanner.rs
+++ b/src/runtime/scanner.rs
@@ -16,6 +16,7 @@ use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use super::worker::{ScannedEntry, WorkerEvent, send_event};
 use crate::model::UnscannedReason;
 use crate::native_path::{EncodedNativePath, NativeIdentity, NativePath, identity_for};
+use crate::temporary_storage::{TemporaryStorage, TemporaryStorageReservation};
 
 // The owner stages each batch and applies one entry per input poll. Keep batches
 // bounded so backpressure stays small while the map is navigating.
@@ -24,6 +25,7 @@ const BATCH_SIZE: usize = 32;
 const TASK_QUEUE_PER_WORKER: usize = 8;
 const MAX_SPILLED_TASK_BYTES: usize = 1024 * 1024;
 const SPILL_LENGTH_BYTES: u64 = 8;
+const TASK_SPILL_COMPACTION_BYTES: u64 = 64 * 1024;
 #[cfg(windows)]
 type TaskSpillFile = tempfile::NamedTempFile;
 #[cfg(not(windows))]
@@ -37,6 +39,7 @@ pub struct ScannerOptions {
     pub cross_filesystems: bool,
     pub exclusions: Vec<String>,
     pub internal_paths: Vec<PathBuf>,
+    pub temporary_storage: TemporaryStorage,
 }
 
 #[derive(Clone)]
@@ -63,10 +66,11 @@ struct TaskSpill {
     next_read: u64,
     next_write: u64,
     pending: usize,
+    reservation: TemporaryStorageReservation,
 }
 
 impl TaskSpill {
-    fn new() -> io::Result<(Self, Option<PathBuf>)> {
+    fn new(temporary_storage: &TemporaryStorage) -> io::Result<(Self, Option<PathBuf>)> {
         #[cfg(windows)]
         let (file, spill_path) = {
             let file = tempfile::NamedTempFile::new()?;
@@ -84,6 +88,7 @@ impl TaskSpill {
                 next_read: 0,
                 next_write: 0,
                 pending: 0,
+                reservation: temporary_storage.reservation(0)?,
             },
             spill_path,
         ))
@@ -114,6 +119,7 @@ impl TaskSpill {
             .checked_add(1)
             .ok_or_else(|| io::Error::other("scanner task spill count overflow"))?;
 
+        self.reservation.grow_to(next_write)?;
         self.file.seek(SeekFrom::Start(self.next_write))?;
         self.file.write_all(&payload_len.to_le_bytes())?;
         self.file.write_all(&payload)?;
@@ -164,18 +170,82 @@ impl TaskSpill {
         if self.pending == 0 {
             self.next_read = 0;
             self.next_write = 0;
-            #[cfg(windows)]
-            let _ = self.file.as_file().set_len(0);
-            #[cfg(not(windows))]
-            let _ = self.file.set_len(0);
+            self.truncate(0)?;
+            self.reservation.shrink_to(0);
+        } else {
+            self.compact_after_read()?;
         }
         Ok(Some(DirectoryTask { path, identity }))
+    }
+
+    fn truncate(&mut self, len: u64) -> io::Result<()> {
+        #[cfg(windows)]
+        {
+            self.file.as_file().set_len(len)
+        }
+        #[cfg(not(windows))]
+        {
+            self.file.set_len(len)
+        }
+    }
+
+    fn compact_after_read(&mut self) -> io::Result<()> {
+        let remaining = self
+            .next_write
+            .checked_sub(self.next_read)
+            .ok_or_else(|| io::Error::other("scanner task spill offsets are out of order"))?;
+        if remaining == 0 {
+            return Err(io::Error::other(
+                "scanner task spill has queued tasks without record data",
+            ));
+        }
+        let compact_after = self.reservation.bytes().min(TASK_SPILL_COMPACTION_BYTES);
+        if self.next_read < compact_after && self.next_read < remaining {
+            return Ok(());
+        }
+
+        let buffer_len = usize::try_from(remaining.min(TASK_SPILL_COMPACTION_BYTES))
+            .map_err(|_| io::Error::other("scanner task spill compaction buffer is too large"))?;
+        let mut buffer = vec![0_u8; buffer_len];
+        let mut source = self.next_read;
+        let mut destination = 0_u64;
+        let mut bytes_left = remaining;
+        while bytes_left > 0 {
+            let chunk =
+                usize::try_from(bytes_left.min(TASK_SPILL_COMPACTION_BYTES)).map_err(|_| {
+                    io::Error::other("scanner task spill compaction chunk is too large")
+                })?;
+            self.file.seek(SeekFrom::Start(source))?;
+            self.file.read_exact(&mut buffer[..chunk])?;
+            self.file.seek(SeekFrom::Start(destination))?;
+            self.file.write_all(&buffer[..chunk])?;
+            let chunk = u64::try_from(chunk)
+                .map_err(|_| io::Error::other("scanner task spill compaction chunk overflow"))?;
+            source = source
+                .checked_add(chunk)
+                .ok_or_else(|| io::Error::other("scanner task spill offset overflow"))?;
+            destination = destination
+                .checked_add(chunk)
+                .ok_or_else(|| io::Error::other("scanner task spill offset overflow"))?;
+            bytes_left = bytes_left
+                .checked_sub(chunk)
+                .ok_or_else(|| io::Error::other("scanner task spill compaction underflow"))?;
+        }
+        self.truncate(remaining)?;
+        self.reservation.shrink_to(remaining);
+        self.next_read = 0;
+        self.next_write = remaining;
+        Ok(())
     }
 }
 
 impl TaskQueue {
-    fn new(root: PathBuf, capacity: usize) -> io::Result<(Self, Option<PathBuf>)> {
-        let (spill, spill_path) = TaskSpill::new()?;
+    fn new(
+        root: PathBuf,
+        capacity: usize,
+        temporary_storage: &TemporaryStorage,
+    ) -> io::Result<(Self, Option<PathBuf>)> {
+        let (spill, spill_path) = TaskSpill::new(temporary_storage)?;
         Ok((
             Self {
                 state: Mutex::new(QueueState {
@@ -350,6 +420,7 @@ pub(super) fn run(options: ScannerOptions, sender: &Sender<WorkerEvent>, cancell
         cross_filesystems,
         exclusions: exclusion_patterns,
         internal_paths,
+        temporary_storage,
     } = options;
     if let Err(message) = validate_scan_root(&root, root_identity.as_ref()) {
         let _ = send_event(
@@ -447,6 +518,7 @@ pub(super) fn run(options: ScannerOptions, sender: &Sender<WorkerEvent>, cancell
     let (queue, task_spill_path) = match TaskQueue::new(
         root.clone(),
         threads.saturating_mul(TASK_QUEUE_PER_WORKER).max(1),
+        &temporary_storage,
     ) {
         Ok(queue) => queue,
         Err(error) => {
@@ -1264,8 +1336,9 @@ mod tests {
 
     #[test]
     fn task_queue_spills_overflow_without_growing_the_resident_queue() {
-        let (queue, task_spill_path) = TaskQueue::new(PathBuf::from("/scan-root"), 1)
-            .expect("scanner task spill should be available");
+        let (queue, task_spill_path) =
+            TaskQueue::new(PathBuf::from("/scan-root"), 1, &TemporaryStorage::default())
+                .expect("scanner task spill should be available");
         #[cfg(windows)]
         {
             let task_spill_path = task_spill_path.expect("Windows task spill should be named");
@@ -1303,9 +1376,182 @@ mod tests {
     }
 
     #[test]
+    fn task_queue_enforces_a_total_spill_limit_and_reclaims_drained_records() {
+        let root = PathBuf::from("/scan-root");
+        let task = DirectoryTask {
+            path: root.join("queued"),
+            identity: None,
+        };
+        let payload = serde_json::to_vec(&(
+            NativePath::new(task.path.clone()).encode(),
+            task.identity.clone(),
+        ))
+        .expect("task fixture should serialize");
+        let record_bytes = SPILL_LENGTH_BYTES
+            .checked_add(u64::try_from(payload.len()).expect("task fixture length should fit"))
+            .expect("task fixture record size should fit");
+        let temporary_storage = TemporaryStorage::with_limit_bytes(record_bytes);
+        let (queue, _) = TaskQueue::new(root.clone(), 1, &temporary_storage)
+            .expect("scanner task queue should open");
+
+        queue
+            .schedule(task.clone())
+            .expect("one spill record should fit the session limit");
+        let error = queue
+            .schedule(task)
+            .expect_err("a second spill record must not exceed the session limit");
+        assert_eq!(error.kind(), io::ErrorKind::StorageFull);
+        assert!(error.to_string().contains("--temporary-storage-mib"));
+        {
+            let state = queue
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            assert_eq!(state.tasks.len(), 1);
+            assert_eq!(state.spill.pending, 1);
+        }
+        assert_eq!(temporary_storage.used(), record_bytes);
+
+        let cancelled = AtomicBool::new(false);
+        let failed = AtomicBool::new(false);
+        let root_invalid = AtomicBool::new(false);
+        let root_task = queue
+            .take(&cancelled, &failed, &root_invalid)
+            .expect("resident task should be available")
+            .expect("resident task should exist");
+        assert_eq!(root_task.path, root);
+        queue.complete();
+        let queued_task = queue
+            .take(&cancelled, &failed, &root_invalid)
+            .expect("spilled task should be available")
+            .expect("spilled task should exist");
+        assert_eq!(queued_task.path, root.join("queued"));
+        queue.complete();
+        assert_eq!(temporary_storage.used(), 0);
+    }
+
+    #[test]
+    fn task_spill_compacts_consumed_records_before_the_queue_drains() {
+        let root = PathBuf::from("/scan-root");
+        let task = DirectoryTask {
+            path: root.join("queued"),
+            identity: None,
+        };
+        let payload = serde_json::to_vec(&(
+            NativePath::new(task.path.clone()).encode(),
+            task.identity.clone(),
+        ))
+        .expect("task fixture should serialize");
+        let record_bytes = SPILL_LENGTH_BYTES
+            .checked_add(u64::try_from(payload.len()).expect("task fixture length should fit"))
+            .expect("task fixture record size should fit");
+        let temporary_storage = TemporaryStorage::with_limit_bytes(
+            record_bytes
+                .checked_mul(2)
+                .expect("two task records should fit in the test limit"),
+        );
+        let (queue, _) = TaskQueue::new(root.clone(), 1, &temporary_storage)
+            .expect("scanner task queue should open");
+        queue
+            .schedule(task.clone())
+            .expect("first spill record should fit");
+        queue
+            .schedule(task.clone())
+            .expect("second spill record should fit");
+
+        let cancelled = AtomicBool::new(false);
+        let failed = AtomicBool::new(false);
+        let root_invalid = AtomicBool::new(false);
+        queue
+            .take(&cancelled, &failed, &root_invalid)
+            .expect("resident task should be available")
+            .expect("resident task should exist");
+        queue.complete();
+        queue
+            .take(&cancelled, &failed, &root_invalid)
+            .expect("first spilled task should be available")
+            .expect("first spilled task should exist");
+        queue.complete();
+        assert_eq!(temporary_storage.used(), record_bytes);
+
+        queue
+            .schedule(task.clone())
+            .expect("resident capacity should remain bounded");
+        queue
+            .schedule(task)
+            .expect("compaction should free capacity for the next spill record");
+        assert_eq!(
+            temporary_storage.used(),
+            record_bytes.checked_mul(2).expect("test limit should fit")
+        );
+        drop(queue);
+        assert_eq!(temporary_storage.used(), 0);
+    }
+
+    #[test]
+    fn scanner_reports_temporary_storage_exhaustion_without_completing_the_root() {
+        use crossbeam_channel::unbounded;
+
+        let root = tempfile::tempdir().expect("scan root should exist");
+        for index in 0..=TASK_QUEUE_PER_WORKER {
+            fs::create_dir(root.path().join(format!("directory-{index}")))
+                .expect("directory fixture should be created");
+        }
+        let (sender, events) = unbounded();
+        let cancelled = AtomicBool::new(false);
+        run(
+            ScannerOptions {
+                root: root.path().to_path_buf(),
+                root_identity: None,
+                threads: 1,
+                cross_filesystems: false,
+                exclusions: Vec::new(),
+                internal_paths: Vec::new(),
+                temporary_storage: TemporaryStorage::with_limit_bytes(0),
+            },
+            &sender,
+            &cancelled,
+        );
+
+        let mut saw_capacity_error = false;
+        let mut completed_root = false;
+        let mut finished = false;
+        for event in events.try_iter() {
+            match event {
+                WorkerEvent::ScanFailed { message, .. } => {
+                    saw_capacity_error |= message.contains("temporary storage capacity exhausted")
+                        && message.contains("--temporary-storage-mib");
+                }
+                WorkerEvent::ScanDirectoryComplete { path, .. } => {
+                    completed_root |= path == root.path();
+                }
+                WorkerEvent::ScanFinished { cancelled } => finished |= !cancelled,
+                WorkerEvent::ScanBatch { .. }
+                | WorkerEvent::ScanUnscanned { .. }
+                | WorkerEvent::DeletionPlanned { .. }
+                | WorkerEvent::DeletionRevalidated { .. }
+                | WorkerEvent::DeletionFinished { .. } => {}
+            }
+        }
+        assert!(
+            saw_capacity_error,
+            "temporary-storage exhaustion should be actionable"
+        );
+        assert!(
+            finished,
+            "scanner should report a terminal event after failure"
+        );
+        assert!(
+            !completed_root,
+            "a capacity failure must not report the partially queued root as complete"
+        );
+    }
+
+    #[test]
     fn task_queue_rejects_corrupt_spill_paths_outside_root() {
         let root = PathBuf::from("/scan-root");
-        let (queue, _) = TaskQueue::new(root.clone(), 1).expect("scanner task queue should open");
+        let (queue, _) = TaskQueue::new(root.clone(), 1, &TemporaryStorage::default())
+            .expect("scanner task queue should open");
         let cancelled = AtomicBool::new(false);
         let failed = AtomicBool::new(false);
         let root_invalid = AtomicBool::new(false);
@@ -1393,7 +1639,7 @@ mod tests {
             .expect("descendant identity should be available");
         replace_directory_with_link(&descendant, &displaced, outside.path());
 
-        let (queue, _) = TaskQueue::new(root.path().to_path_buf(), 1)
+        let (queue, _) = TaskQueue::new(root.path().to_path_buf(), 1, &TemporaryStorage::default())
             .expect("scanner task queue should be available");
         let (sender, events) = bounded(4);
         let cancelled = AtomicBool::new(false);
@@ -1458,7 +1704,7 @@ mod tests {
             .expect("descendant identity should be available");
         replace_after_next_validation(descendant.clone(), displaced, outside.path().to_path_buf());
 
-        let (queue, _) = TaskQueue::new(root.path().to_path_buf(), 1)
+        let (queue, _) = TaskQueue::new(root.path().to_path_buf(), 1, &TemporaryStorage::default())
             .expect("scanner task queue should be available");
         let (sender, events) = bounded(8);
         let cancelled = AtomicBool::new(false);
@@ -1548,7 +1794,7 @@ mod tests {
         let escaped_path = descendant.join("outside-only");
         fs::write(&outside_only, b"outside").expect("outside fixture should be written");
 
-        let (queue, _) = TaskQueue::new(root.path().to_path_buf(), 1)
+        let (queue, _) = TaskQueue::new(root.path().to_path_buf(), 1, &TemporaryStorage::default())
             .expect("scanner task queue should be available");
         let (sender, events) = bounded(8);
         let cancelled = AtomicBool::new(false);
@@ -1637,7 +1883,7 @@ mod tests {
         tree.add_entry(&metadata, &descendant, identity.clone())
             .expect("descendant should be represented");
 
-        let (queue, _) = TaskQueue::new(root.path().to_path_buf(), 1)
+        let (queue, _) = TaskQueue::new(root.path().to_path_buf(), 1, &TemporaryStorage::default())
             .expect("scanner task queue should be available");
         let (sender, events) = bounded(8);
         let cancelled = AtomicBool::new(false);

--- a/src/runtime/worker.rs
+++ b/src/runtime/worker.rs
@@ -409,6 +409,7 @@ mod tests {
             cross_filesystems: false,
             exclusions: Vec::new(),
             internal_paths: Vec::new(),
+            temporary_storage: crate::temporary_storage::TemporaryStorage::default(),
         }
     }
 

--- a/src/state/files/file_tree.rs
+++ b/src/state/files/file_tree.rs
@@ -14,6 +14,7 @@ use crate::model::{
 };
 use crate::native_path::NativeIdentity;
 use crate::state::tiles::{FileMetadata, files_in_folder};
+use crate::temporary_storage::TemporaryStorage;
 use file_id::FileId;
 
 struct RescanStage {
@@ -42,8 +43,26 @@ impl FileTree {
         show_apparent_size: bool,
         process_memory_mib: usize,
     ) -> Result<Self, ModelError> {
+        Self::new_with_temporary_storage(
+            path_in_filesystem,
+            show_apparent_size,
+            process_memory_mib,
+            TemporaryStorage::default(),
+        )
+    }
+
+    pub(crate) fn new_with_temporary_storage(
+        path_in_filesystem: PathBuf,
+        show_apparent_size: bool,
+        process_memory_mib: usize,
+        temporary_storage: TemporaryStorage,
+    ) -> Result<Self, ModelError> {
         let budget = MemoryBudget::from_mib(process_memory_mib)?;
-        let arena = Arena::new(path_in_filesystem.clone(), budget)?;
+        let arena = Arena::new_with_temporary_storage(
+            path_in_filesystem.clone(),
+            budget,
+            temporary_storage,
+        )?;
         Ok(Self {
             current_path: vec![arena.root()],
             arena,
@@ -64,9 +83,30 @@ impl FileTree {
         show_apparent_size: bool,
         process_memory_mib: usize,
     ) -> Result<Self, ModelError> {
+        Self::new_with_root_identity_and_temporary_storage(
+            path_in_filesystem,
+            root_identity,
+            show_apparent_size,
+            process_memory_mib,
+            TemporaryStorage::default(),
+        )
+    }
+
+    pub(crate) fn new_with_root_identity_and_temporary_storage(
+        path_in_filesystem: PathBuf,
+        root_identity: NativeIdentity,
+        show_apparent_size: bool,
+        process_memory_mib: usize,
+        temporary_storage: TemporaryStorage,
+    ) -> Result<Self, ModelError> {
         validate_scan_root_identity(&path_in_filesystem, &root_identity)
             .map_err(|error| ModelError::Invariant(error.to_string()))?;
-        let mut tree = Self::new(path_in_filesystem, show_apparent_size, process_memory_mib)?;
+        let mut tree = Self::new_with_temporary_storage(
+            path_in_filesystem,
+            show_apparent_size,
+            process_memory_mib,
+            temporary_storage,
+        )?;
         tree.root_identity = Some(root_identity.clone());
         tree.arena.set_root_identity(root_identity);
         Ok(tree)
@@ -478,7 +518,11 @@ impl FileTree {
         let budget = MemoryBudget::from_model_limit(remaining)?;
         self.rescan = Some(RescanStage {
             target_id,
-            arena: Arena::new(target, budget)?,
+            arena: Arena::new_with_temporary_storage(
+                target,
+                budget,
+                self.arena.temporary_storage(),
+            )?,
             filter,
             filter_root,
         });

--- a/src/temporary_storage.rs
+++ b/src/temporary_storage.rs
@@ -1,0 +1,328 @@
+use std::fs::File;
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use redb::StorageBackend;
+
+pub(crate) const DEFAULT_TEMPORARY_STORAGE_MIB: usize = 512;
+pub(crate) const MIN_TEMPORARY_STORAGE_MIB: usize = 2;
+const MIB: u64 = 1024 * 1024;
+
+#[derive(Clone, Debug)]
+pub(crate) struct TemporaryStorage {
+    state: Arc<TemporaryStorageState>,
+}
+
+#[derive(Debug)]
+struct TemporaryStorageState {
+    limit: u64,
+    used: AtomicU64,
+}
+
+impl Default for TemporaryStorage {
+    fn default() -> Self {
+        Self::from_mib(DEFAULT_TEMPORARY_STORAGE_MIB)
+            .expect("default temporary storage limit should fit in u64")
+    }
+}
+
+impl TemporaryStorage {
+    pub(crate) fn from_mib(mib: usize) -> io::Result<Self> {
+        let bytes = u64::try_from(mib)
+            .ok()
+            .and_then(|mib| mib.checked_mul(MIB))
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "temporary storage limit does not fit in bytes",
+                )
+            })?;
+        Ok(Self::with_limit_bytes(bytes))
+    }
+
+    #[must_use]
+    pub(crate) fn with_limit_bytes(limit: u64) -> Self {
+        Self {
+            state: Arc::new(TemporaryStorageState {
+                limit,
+                used: AtomicU64::new(0),
+            }),
+        }
+    }
+
+    pub(crate) fn reserve(&self, bytes: u64) -> io::Result<()> {
+        let mut used = self.state.used.load(Ordering::Acquire);
+        loop {
+            let required = used.checked_add(bytes).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::StorageFull,
+                    format!(
+                        "temporary storage capacity exhausted: more than {} bytes are required; increase --temporary-storage-mib",
+                        self.state.limit
+                    ),
+                )
+            })?;
+            if required > self.state.limit {
+                return Err(io::Error::new(
+                    io::ErrorKind::StorageFull,
+                    format!(
+                        "temporary storage capacity exhausted: {required} bytes exceed the {} byte session limit; increase --temporary-storage-mib",
+                        self.state.limit
+                    ),
+                ));
+            }
+            match self.state.used.compare_exchange_weak(
+                used,
+                required,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return Ok(()),
+                Err(current) => used = current,
+            }
+        }
+    }
+
+    pub(crate) fn reservation(&self, bytes: u64) -> io::Result<TemporaryStorageReservation> {
+        self.reserve(bytes)?;
+        Ok(TemporaryStorageReservation {
+            storage: self.clone(),
+            bytes,
+        })
+    }
+
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) fn used(&self) -> u64 {
+        self.state.used.load(Ordering::Acquire)
+    }
+
+    fn release(&self, bytes: u64) {
+        let mut used = self.state.used.load(Ordering::Acquire);
+        loop {
+            let Some(remaining) = used.checked_sub(bytes) else {
+                panic!("temporary storage accounting underflow");
+            };
+            match self.state.used.compare_exchange_weak(
+                used,
+                remaining,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return,
+                Err(current) => used = current,
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct TemporaryStorageReservation {
+    storage: TemporaryStorage,
+    bytes: u64,
+}
+
+impl TemporaryStorageReservation {
+    #[must_use]
+    pub(crate) const fn bytes(&self) -> u64 {
+        self.bytes
+    }
+
+    pub(crate) fn grow_to(&mut self, bytes: u64) -> io::Result<()> {
+        if bytes <= self.bytes {
+            return Ok(());
+        }
+        self.storage.reserve(bytes - self.bytes)?;
+        self.bytes = bytes;
+        Ok(())
+    }
+
+    pub(crate) fn shrink_to(&mut self, bytes: u64) {
+        if bytes >= self.bytes {
+            return;
+        }
+        self.storage.release(self.bytes - bytes);
+        self.bytes = bytes;
+    }
+}
+
+impl Drop for TemporaryStorageReservation {
+    fn drop(&mut self) {
+        self.storage.release(self.bytes);
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct BoundedFileBackend {
+    file: Mutex<BoundedFile>,
+    reservation: Arc<Mutex<TemporaryStorageReservation>>,
+}
+
+#[derive(Debug)]
+struct BoundedFile {
+    file: File,
+    length: u64,
+}
+
+impl BoundedFileBackend {
+    pub(crate) fn new(
+        file: File,
+        reservation: Arc<Mutex<TemporaryStorageReservation>>,
+    ) -> io::Result<Self> {
+        let length = file.metadata()?.len();
+        {
+            let mut reservation = reservation
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if reservation.bytes() != 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "temporary storage database reservation was not empty",
+                ));
+            }
+            reservation.grow_to(length)?;
+        }
+        Ok(Self {
+            file: Mutex::new(BoundedFile { file, length }),
+            reservation,
+        })
+    }
+}
+
+impl StorageBackend for BoundedFileBackend {
+    fn len(&self) -> io::Result<u64> {
+        let file = self
+            .file
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        Ok(file.length)
+    }
+
+    fn read(&self, offset: u64, len: usize) -> io::Result<Vec<u8>> {
+        let mut file = self
+            .file
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let end = offset
+            .checked_add(u64::try_from(len).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "temporary storage read is too large",
+                )
+            })?)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "temporary storage read overflows",
+                )
+            })?;
+        if end > file.length {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "temporary storage read exceeds the bounded file",
+            ));
+        }
+        let mut bytes = vec![0; len];
+        file.file.seek(SeekFrom::Start(offset))?;
+        file.file.read_exact(&mut bytes)?;
+        Ok(bytes)
+    }
+
+    fn set_len(&self, len: u64) -> io::Result<()> {
+        let mut file = self
+            .file
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        verify_length(&file)?;
+        let mut reservation = self
+            .reservation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if reservation.bytes() != file.length {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "temporary storage database reservation does not match its file",
+            ));
+        }
+        if len > file.length {
+            reservation.grow_to(len)?;
+            if let Err(error) = file.file.set_len(len) {
+                reservation.shrink_to(file.length);
+                return Err(error);
+            }
+        } else if len < file.length {
+            file.file.set_len(len)?;
+            reservation.shrink_to(len);
+        }
+        file.length = len;
+        Ok(())
+    }
+
+    fn sync_data(&self, _eventual: bool) -> io::Result<()> {
+        let file = self
+            .file
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        file.file.sync_data()
+    }
+
+    fn write(&self, offset: u64, bytes: &[u8]) -> io::Result<()> {
+        let mut file = self
+            .file
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let end = offset
+            .checked_add(u64::try_from(bytes.len()).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "temporary storage write is too large",
+                )
+            })?)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "temporary storage write overflows",
+                )
+            })?;
+        if end > file.length {
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "temporary storage write exceeds the reserved file length",
+            ));
+        }
+        file.file.seek(SeekFrom::Start(offset))?;
+        file.file.write_all(bytes)
+    }
+}
+
+fn verify_length(file: &BoundedFile) -> io::Result<()> {
+    if file.file.metadata()?.len() != file.length {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "temporary storage file changed outside its accounting boundary",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reservations_enforce_the_shared_limit_and_release_on_drop() {
+        let storage = TemporaryStorage::with_limit_bytes(8);
+        let first = storage
+            .reservation(5)
+            .expect("first reservation should fit");
+        assert_eq!(storage.used(), 5);
+        let error = storage
+            .reservation(4)
+            .expect_err("reservation beyond the total limit should fail");
+        assert_eq!(error.kind(), io::ErrorKind::StorageFull);
+        assert!(error.to_string().contains("--temporary-storage-mib"));
+        drop(first);
+        assert_eq!(storage.used(), 0);
+    }
+}

--- a/src/tests/cases/config.rs
+++ b/src/tests/cases/config.rs
@@ -58,6 +58,25 @@ fn malformed_scanner_exclusion_is_a_configuration_error() {
 }
 
 #[test]
+fn temporary_storage_limit_must_be_at_least_two_mib() {
+    let error = RuntimeConfig::from_layers(
+        cli(&["excise", "--temporary-storage-mib", "1"]),
+        None,
+        EnvironmentOverrides::default(),
+        PathBuf::from("cwd"),
+        None,
+    )
+    .expect_err("one MiB temporary storage should fail configuration resolution");
+
+    assert!(matches!(error, AppError::Config(_)));
+    assert!(
+        error
+            .to_string()
+            .contains("temporary storage must be between 2")
+    );
+}
+
+#[test]
 fn precedence_is_cli_then_environment_then_file_then_default() {
     let config = RuntimeConfig::from_layers(
         cli(&[
@@ -72,6 +91,8 @@ fn precedence_is_cli_then_environment_then_file_then_default() {
             "--mouse",
             "--keymap",
             "emacs",
+            "--temporary-storage-mib",
+            "4",
             "cli-root",
         ]),
         Some(&FileConfig {
@@ -86,7 +107,10 @@ fn precedence_is_cli_then_environment_then_file_then_default() {
                 reduced_motion: Some(false),
                 ..RuntimeFileConfig::default()
             },
-            model: ModelFileConfig::default(),
+            model: ModelFileConfig {
+                process_memory_mib: Some(crate::model::DEFAULT_PROCESS_MIB),
+                temporary_storage_mib: Some(2),
+            },
         }),
         EnvironmentOverrides {
             root: Some(PathBuf::from("env-root")),
@@ -98,6 +122,7 @@ fn precedence_is_cli_then_environment_then_file_then_default() {
             cross_filesystems: Some(false),
             exclusions: Vec::new(),
             memory_mib: Some(crate::model::DEFAULT_PROCESS_MIB),
+            temporary_storage_mib: Some(3),
             theme: None,
             ascii: None,
             mouse: None,
@@ -113,6 +138,7 @@ fn precedence_is_cli_then_environment_then_file_then_default() {
     assert_eq!(config.root, PathBuf::from("cli-root"));
     assert_eq!(config.scan_threads, 4);
     assert_eq!(config.event_buffer, 64);
+    assert_eq!(config.temporary_storage_mib, 4);
     assert!(config.apparent_size);
     assert!(config.reduced_motion);
     assert!(config.monochrome);

--- a/src/tests/cases/runtime.rs
+++ b/src/tests/cases/runtime.rs
@@ -22,6 +22,7 @@ fn settings(root: &std::path::Path) -> RuntimeSettings {
         cross_filesystems: false,
         exclusions: Vec::new(),
         memory_mib: crate::model::DEFAULT_PROCESS_MIB,
+        temporary_storage_mib: crate::temporary_storage::DEFAULT_TEMPORARY_STORAGE_MIB,
         apparent_size: true,
         disable_delete_confirmation: false,
         reduced_motion: true,


### PR DESCRIPTION
## Summary

Bounds per-session temporary storage used by queued scanner directory tasks and identity spill files, so either path fails explicitly before unbounded disk growth.

## Changes

- Adds one additive `--temporary-storage-mib` / `EXCISE_TEMPORARY_STORAGE_MIB` / `[model].temporary_storage_mib` limit; default 512 MiB, minimum 2 MiB.
- Shares that ledger across runtime scanner queues, identity stores, staged rescans, and identity rebuild scratch stores.
- Reserves capacity before task/database file growth, compacts consumed queued-task records, and releases capacity only after shrinking or removing the private file/session.

## Safety and compatibility

- Scanner exhaustion emits an actionable failure and does not complete the partial root; callers report the result as uncertain rather than exact.
- Identity exhaustion returns an actionable accounting error before persistence can exceed the session budget; no accounting fallback changes hard-link participant semantics.
- Private session-path checks and cleanup behavior remain in place. The configuration addition is backward-compatible with version-1 TOML; generated man page and shell completions are updated.

## Verification

- `cargo test --locked temporary_storage` — 3 focused configuration, scanner-failure, and ledger tests passed.
- `cargo test --locked spill` — 14 focused scanner/identity spill and hard-link regression tests passed.
- `cargo check-generated` — generated CLI artifacts are current.

- [x] Focused tests cover new behavior and plausible regressions.
- [ ] `cargo fmt --all -- --check` passes (not run per task constraint).
- [ ] `cargo clippy --workspace --all-targets --locked -- -D warnings` passes (not run per task constraint).
- [ ] `cargo test --workspace --locked` passes (not run per task constraint).
- [x] User-facing documentation and generated artifacts are current.