### PR TITLE
fix: tolerate late scan completions after compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Excise preserves the historical Diskonaut changelog below. Diskonaut versions an
 ### Fixed
 
 * Scanner directory-task, identity, and directory-deletion-plan/result spill files now share a fixed per-session temporary-storage limit. Deletion plan and outcome records are authenticated with a process-private key and, on Windows, held in atomically created exclusive files outside the selected target; capacity or storage-read failures produce a safe incomplete outcome instead of an unbounded report, while an unretainable directory plan stops before confirmation without deleting an entry.
+* Scanner directory-completion events that arrive after model compaction now safely no-op instead of terminating a long root scan with an invalid-model-path error.
 
 ## [1.2.1] - 2026-09-02
 

--- a/src/model/arena.rs
+++ b/src/model/arena.rs
@@ -661,7 +661,11 @@ impl Arena {
             }
             return Ok(());
         }
-        if self.path_is_aggregated(path) {
+        // Scanner tasks may finish after this path was compacted or evicted to
+        // make room for a later batch. Completion only updates a retained,
+        // scanning directory, so an in-root late completion is deliberately a
+        // no-op rather than a whole-scan model failure.
+        if path.starts_with(&self.root_path) {
             return Ok(());
         }
         Err(ModelError::InvalidPath(path.to_string_lossy().into_owned()))
@@ -2331,29 +2335,6 @@ impl Arena {
             current = self.find_child(current, component)?;
         }
         Some(current)
-    }
-
-    fn path_is_aggregated(&self, path: &Path) -> bool {
-        let Ok(relative) = path.strip_prefix(&self.root_path) else {
-            return false;
-        };
-        let mut current = self.root;
-        for component in relative {
-            if self
-                .node(current)
-                .is_some_and(|node| node.kind.is_synthetic())
-            {
-                return true;
-            }
-            let Some(next) = self.find_child(current, component) else {
-                return self.children(current).iter().any(|id| {
-                    self.node(*id)
-                        .is_some_and(|node| node.kind == NodeKind::Synthetic(SyntheticKind::Other))
-                });
-            };
-            current = next;
-        }
-        false
     }
 
     fn push_child(&mut self, parent: NodeId, child: NodeId) -> Result<(), ModelError> {

--- a/src/state/files/file_tree.rs
+++ b/src/state/files/file_tree.rs
@@ -1262,6 +1262,50 @@ mod tests {
         );
     }
 
+    #[test]
+    fn late_directory_completion_after_model_eviction_is_ignored() {
+        let root = tempfile::tempdir().expect("scan root should exist");
+        let evicted = root.path().join("evicted");
+        fs::create_dir(&evicted).expect("fixture directory should be created");
+        let metadata = fs::symlink_metadata(&evicted).expect("fixture metadata should exist");
+        let identity = identity_for(&evicted, &metadata)
+            .expect("fixture identity should be readable")
+            .expect("fixture should have an identity");
+        let mut tree = FileTree::new(
+            root.path().to_path_buf(),
+            false,
+            crate::model::MIN_PROCESS_MIB,
+        )
+        .expect("file tree should be created");
+        add(&mut tree, &evicted);
+        assert!(
+            tree.arena
+                .try_remove_path(&evicted)
+                .expect("fixture eviction should rebuild identities")
+        );
+
+        tree.complete_directory(&evicted, Some(&identity))
+            .expect("late scanner completion below the scan root should be ignored");
+        assert!(tree.arena.path_ids(&evicted).is_none());
+    }
+
+    #[test]
+    fn directory_completion_outside_the_scan_root_remains_rejected() {
+        let root = tempfile::tempdir().expect("scan root should exist");
+        let outside = tempfile::tempdir().expect("outside directory should exist");
+        let mut tree = FileTree::new(
+            root.path().to_path_buf(),
+            false,
+            crate::model::MIN_PROCESS_MIB,
+        )
+        .expect("file tree should be created");
+
+        assert!(matches!(
+            tree.complete_directory(outside.path(), None),
+            Err(crate::model::ModelError::InvalidPath(_))
+        ));
+    }
+
     #[cfg(any(unix, windows))]
     #[test]
     fn partial_hard_link_deletion_rebuilds_identity_metrics() {


### PR DESCRIPTION
## Summary

Long root scans can compact or evict a directory while its scanner task is still in flight. The later `ScanDirectoryComplete` event then carried a valid in-root path which no longer existed in the retained model, and the completion handler incorrectly escalated that harmless event into `invalid model path`.

## Change

`Arena::complete_directory` now treats an absent in-root completion as a no-op. It still rejects paths outside the scan root. The change removes the redundant aggregate-path probe and adds both regression cases.

## Reproduction evidence

On the full-system TUI scan with `--temporary-storage-mib 1024`, the previous `/opt/homebrew/Library/Taps/...` invalid-model-path failure was passed; scanning continued under the 384 MiB model cap until the independent identity-spill capacity condition.

## Verification

- `cargo fmt --all -- --check`
- `cargo run --locked --package xtask -- check-generated`
- `cargo check --workspace --all-targets --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` (480 tests before rebase; focused regressions rerun after rebase)
- Release-profile PTY smoke (7 tests)
- `cargo package --package excise --locked`
- `cargo deny check`