### PR TITLE
release: prepare `v1.2.2`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
     id: version
     attributes:
       label: Excise version or commit
-      placeholder: "v1.2.1 or 0123456789abcdef"
+      placeholder: "v1.2.2 or 0123456789abcdef"
     validations:
       required: true
   - type: dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@ Excise preserves the historical Diskonaut changelog below. Diskonaut versions an
 
 ## [Unreleased]
 
+## [1.2.2] - 2026-09-04
+
 ### Fixed
 
 * Scanner directory-task, identity, and directory-deletion-plan/result spill files now share a fixed per-session temporary-storage limit. Deletion plan and outcome records are authenticated with a process-private key and, on Windows, held in atomically created exclusive files outside the selected target; capacity or storage-read failures produce a safe incomplete outcome instead of an unbounded report, while an unretainable directory plan stops before confirmation without deleting an entry.
 * Scanner directory-completion events that arrive after model compaction now safely no-op instead of terminating a long root scan with an invalid-model-path error.
 * Full-system scans now release an exhausted private identity spill database and continue with explicit unknown physical-allocation and reclaimability bounds, instead of terminating after the bounded temporary-storage limit is reached.
+* Full-system scans no longer fail when compaction aggregates an unreadable entry at the configured model-memory limit; the aggregate reuses an already billed summary slot instead of requiring a new allocation.
+* Repeated hard-link observations are coalesced through compaction and remapping, keeping participant storage bounded while preserving exact link accounting.
+* Model-memory compaction preserves collapsed subtree and ancestor metrics incrementally instead of rebuilding global metrics for every cap-limited insertion retry.
 
 ## [1.2.1] - 2026-09-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Surgical terminal storage navigator"
 keywords = ["disk-usage", "filesystem", "terminal", "tui"]
 categories = ["command-line-utilities", "filesystem"]
 
-version = "1.2.1"
+version = "1.2.2"
 authors = ["Aram Drevekenin <aram@poor.dev>", "Tom Larcher <tom.larcher@gmail.com>"]
 readme = "README.md"
 homepage = "https://github.com/findyourexit/excise"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It is an independent fork and spiritual successor to [Diskonaut](https://github.
 ```console
 brew tap findyourexit/tap
 brew install findyourexit/tap/excise
-excise --version  # excise 1.2.1
+excise --version  # excise 1.2.2
 ```
 
 </details>
@@ -42,8 +42,8 @@ excise --version  # excise 1.2.1
 <summary><strong>crates.io</strong></summary>
 
 ```console
-cargo install excise --version 1.2.1 --locked
-excise --version  # excise 1.2.1
+cargo install excise --version 1.2.2 --locked
+excise --version  # excise 1.2.2
 ```
 
 </details>
@@ -51,7 +51,7 @@ excise --version  # excise 1.2.1
 <details>
 <summary><strong>Pre-built Binaries</strong></summary>
 
-Download the [v1.2.1 release](https://github.com/findyourexit/excise/releases/tag/v1.2.1) for macOS, Linux, and Windows on Apple silicon, Intel, or Arm systems.
+Download the [v1.2.2 release](https://github.com/findyourexit/excise/releases/tag/v1.2.2) for macOS, Linux, and Windows on Apple silicon, Intel, or Arm systems.
 
 Only x86_64 Linux, AArch64 macOS, and x86_64 Windows have full platform support because they are tested on those platforms. The other archives are build-only and best effort. See the [Support Policy](SUPPORT.md).
 
@@ -61,7 +61,7 @@ Only x86_64 Linux, AArch64 macOS, and x86_64 Windows have full platform support 
 <summary><strong>Build From Source</strong></summary>
 
 ```console
-git clone --branch v1.2.1 --depth 1 https://github.com/findyourexit/excise.git
+git clone --branch v1.2.2 --depth 1 https://github.com/findyourexit/excise.git
 cd excise
 cargo install --path . --locked
 excise --version
@@ -70,7 +70,7 @@ excise --version
 Nix users can run the tagged release without changing its lock file:
 
 ```console
-nix run github:findyourexit/excise/v1.2.1 -- --format table /path/to/inspect
+nix run github:findyourexit/excise/v1.2.2 -- --format table /path/to/inspect
 ```
 
 </details>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,19 +4,20 @@ Excise permanently deletes files and folders. Data-loss defects are therefore se
 
 ## Supported Versions
 
-Excise supports the latest stable release, currently `1.2.1`. The `0.3.x` line was early testing and is superseded. Report safety defects against the affected stable release or development commit. Do not trust superseded releases with irreplaceable data.
+Excise supports the latest stable release, currently `1.2.2`. The `0.3.x` line was early testing and is superseded. Report safety defects against the affected stable release or development commit. Do not trust superseded releases with irreplaceable data.
 
 | Version | Status |
 |---|---|
-| `1.2.1` | Supported stable line |
-| `1.2.0` | Superseded release. Upgrade to `1.2.1`. |
-| `1.1.x` | Superseded stable releases. Upgrade to `1.2.1`. |
-| `1.0.x` | Superseded stable releases. Upgrade to `1.2.1`. |
-| `0.3.0` | Superseded early testing. Upgrade to `1.2.1`. |
-| `0.2.0` | Superseded early testing. Upgrade to `1.2.1`. |
-| `0.1.2` | Superseded early testing. Upgrade to `1.2.1`. |
-| `0.1.1` | Superseded early testing. Upgrade to `1.2.1`. |
-| `0.1.0` | Superseded early testing. Upgrade to `1.2.1`. |
+| `1.2.2` | Supported stable line |
+| `1.2.1` | Superseded release. Upgrade to `1.2.2`. |
+| `1.2.0` | Superseded release. Upgrade to `1.2.2`. |
+| `1.1.x` | Superseded stable releases. Upgrade to `1.2.2`. |
+| `1.0.x` | Superseded stable releases. Upgrade to `1.2.2`. |
+| `0.3.0` | Superseded early testing. Upgrade to `1.2.2`. |
+| `0.2.0` | Superseded early testing. Upgrade to `1.2.2`. |
+| `0.1.2` | Superseded early testing. Upgrade to `1.2.2`. |
+| `0.1.1` | Superseded early testing. Upgrade to `1.2.2`. |
+| `0.1.0` | Superseded early testing. Upgrade to `1.2.2`. |
 | `main` | Development only |
 
 ## Report Privately

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,12 +42,12 @@ nix build
 ./result/bin/excise /path/to/inspect
 ```
 
-## Install 1.2.1 From A Release Channel
+## Install 1.2.2 From A Release Channel
 
-The `1.2.1` package is published on crates.io and can also be built locally. It is not one of the pre-built GitHub archives:
+The `1.2.2` package is published on crates.io and can also be built locally. It is not one of the pre-built GitHub archives:
 
 ```console
-cargo install excise --version 1.2.1 --locked
+cargo install excise --version 1.2.2 --locked
 excise --version
 ```
 
@@ -100,7 +100,7 @@ The interactive interface requires standard input and output connected to a term
 
 ### Current Map Behavior
 
-The dense half-block map, animated focus border, heat ramp, overflow summary, and directed map transitions are included in the stable release. Build the current source or install `1.2.1` to use them.
+The dense half-block map, animated focus border, heat ramp, overflow summary, and directed map transitions are included in the stable release. Build the current source or install `1.2.2` to use them.
 
 The interactive view uses a dense map and animated focus border on capable terminals. `--ascii`, monochrome mode, and reduced motion preserve the same selection, scope, and deletion information when visual effects are unavailable or undesirable.
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -113,6 +113,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bon"
 version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +281,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +357,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "darling"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +429,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "directories"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -475,6 +513,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_json",
+ "sha2",
  "sysinfo",
  "tachyonfx",
  "tempfile",
@@ -545,6 +584,16 @@ dependencies = [
  "io-lifetimes 2.0.4",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1282,6 +1331,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1501,6 +1561,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,6 +1600,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/fuzz/fuzz_targets/config.rs
+++ b/fuzz/fuzz_targets/config.rs
@@ -2,7 +2,7 @@
 
 use std::path::PathBuf;
 
-use excise::config::{Cli, EnvironmentOverrides, RuntimeConfig, parse_file_config};
+use excise::config::{parse_file_config, Cli, EnvironmentOverrides, RuntimeConfig};
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
@@ -17,6 +17,7 @@ fuzz_target!(|data: &[u8]| {
             cross_filesystems: false,
             exclusions: Vec::new(),
             memory_mib: None,
+            temporary_storage_mib: None,
             reduced_motion: false,
             theme: None,
             ascii: false,

--- a/fuzz/fuzz_targets/deletion_state.rs
+++ b/fuzz/fuzz_targets/deletion_state.rs
@@ -9,7 +9,7 @@ use excise::deletion::{
 };
 use excise::model::{EntrySnapshot, NodeId, NodeKind};
 use excise::native_path::NativeIdentity;
-use excise::{FileToDelete, geometry::FileType};
+use excise::{geometry::FileType, FileToDelete};
 use file_id::FileId;
 use libfuzzer_sys::fuzz_target;
 
@@ -48,7 +48,7 @@ fuzz_target!(|data: &[u8]| {
         root_relative_path: PathBuf::from("target"),
         estimated_bytes: entries.len().saturating_mul(256),
         scan_root: PathBuf::from("root"),
-        entries,
+        entries: entries.into(),
         soft_cancelled: false,
         precise: true,
     };

--- a/fuzz/fuzz_targets/runtime_events.rs
+++ b/fuzz/fuzz_targets/runtime_events.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use excise::error::AppError;
 use excise::input::{InputEvent, InputSource};
-use excise::runtime::{RuntimeSettings, VirtualClock, run};
+use excise::runtime::{run, RuntimeSettings, VirtualClock};
 use libfuzzer_sys::fuzz_target;
 use ratatui::backend::TestBackend;
 
@@ -69,6 +69,7 @@ fuzz_target!(|data: &[u8]| {
         cross_filesystems: false,
         exclusions: Vec::new(),
         memory_mib: excise::model::DEFAULT_PROCESS_MIB,
+        temporary_storage_mib: 2,
         apparent_size: true,
         disable_delete_confirmation: false,
         reduced_motion: true,

--- a/generated/man/excise.1
+++ b/generated/man/excise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH excise 1  "excise 1.2.1"
+.TH excise 1  "excise 1.2.2"
 .SH NAME
 excise
 .SH SYNOPSIS
@@ -125,4 +125,4 @@ Print version
 [\fIfolder\fR]
 Folder to scan
 .SH VERSION
-v1.2.1
+v1.2.2


### PR DESCRIPTION
## Summary

Prepare the stable `v1.2.2` patch release after the root-scan reliability and bounded-storage remediation series.

- Move the complete user-visible repair set into dated release notes: cap-time unreadable-entry compaction, hard-link participant coalescing, incremental compaction metrics, shared temporary storage, bounded directory deletion records, late completion tolerance, and safe identity-spill exhaustion handling.
- Bump the manifest and both lockfiles, generated manual page, current install instructions, supported-version policy, and issue-template version to `1.2.2`.
- Restore compilation of all fuzz targets affected by the new temporary-storage setting and bounded deletion-result container; update the fuzz lockfile for the current root dependency graph.

## Safety and compatibility

This is a patch release. The already-reviewed changes preserve the model memory cap, retain exact accounting where identity state is available, and explicitly mark allocation and reclaimability unknown when the bounded identity store is exhausted. That uncertain state cannot authorize permanent deletion. The additive temporary-storage configuration remains documented in the generated CLI artifacts and configuration guide.

## Local release rehearsal

- `cargo verify`
- `cargo check --manifest-path fuzz/Cargo.toml --locked`
- `cargo package --locked --list`
- `cargo publish --locked --dry-run`
- `cargo dist-local`, including local archive checksum, SPDX component, and archive-content validation

Hosted CI remains required before merge.