### PR TITLE
test(fuzz): cover bounded directory plan spill

### DIFF
--- a/fuzz/fuzz_targets/deletion_plan.rs
+++ b/fuzz/fuzz_targets/deletion_plan.rs
@@ -98,7 +98,7 @@ fn exercise(data: &[u8]) -> Result<(), Box<dyn Error>> {
         maximum_bytes,
     );
     match (mode, result) {
-        (0, Ok(plan)) => {
+        (0 | 3, Ok(plan)) => {
             let soft = AtomicBool::new(data.get(2).is_some_and(|byte| byte & 1 != 0));
             let hard = AtomicBool::new(data.get(2).is_some_and(|byte| byte & 2 != 0));
             let report = execute_plan(root.path(), plan, &soft, &hard);
@@ -111,11 +111,10 @@ fn exercise(data: &[u8]) -> Result<(), Box<dyn Error>> {
             assert_eq!(classified as usize, report.entries.len());
             assert_eq!(report.precise, !hard.load(std::sync::atomic::Ordering::Acquire));
         }
-        (0, Err(DeletionPlanError::Changed)) => {
+        (0 | 3, Err(DeletionPlanError::Changed)) => {
             // Rejecting an inconsistent snapshot is a valid safety outcome.
         }
         (1 | 2, Err(DeletionPlanError::Changed)) => {}
-        (3, Err(DeletionPlanError::MemoryLimit { limit: 1 })) => {}
         (mode, result) => panic!("unexpected deletion plan result for mode {mode}: {result:?}"),
     }
     assert!(outside_file.exists());

--- a/fuzz/seeds/deletion_plan/directory-spill
+++ b/fuzz/seeds/deletion_plan/directory-spill
@@ -1,0 +1,1 @@
+srd  n`steds


### PR DESCRIPTION
## Problem

The `v1.2.2` tag fuzz run [33872937998](https://github.com/findyourexit/excise/actions/runs/33872937998) found a stale fuzz oracle, not a deletion-safety violation. Its mode with a one-byte resident plan budget still expected `DeletionPlanError::MemoryLimit`, although the bounded-directory-plan change intentionally spills directory records into the shared, bounded temporary store and returns a valid plan.

## Change

- Treat a successful mode-3 directory plan as valid and run it through the normal result-accounting assertions.
- Keep `Changed` as the valid concurrent-filesystem outcome for that mode.
- Add the discovered 13-byte input as a deterministic seed so this contract is replayed by both local and hosted fuzz smoke runs.

## Verification

- Reproduced the previous assertion failure from `crash-5aaf64ee460abf738aa7226e6375bfff6241a981` on `v1.2.2`.
- Replayed the same input successfully after the fix.
- Ran a 60-second workflow-equivalent `deletion_plan` fuzz smoke with the complete seed corpus.
- `cargo verify`.