### PR TITLE
release: prepare `v1.2.3`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
     id: version
     attributes:
       label: Excise version or commit
-      placeholder: "v1.2.2 or 0123456789abcdef"
+      placeholder: "v1.2.3 or 0123456789abcdef"
     validations:
       required: true
   - type: dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Excise preserves the historical Diskonaut changelog below. Diskonaut versions an
 
 ## [Unreleased]
 
+## [1.2.3] - 2026-09-04
+
+### Fixed
+
+* Directory-deletion-plan fuzz coverage now accepts the intended bounded temporary-storage spill path and replays its regression case.
+
 ## [1.2.2] - 2026-09-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Surgical terminal storage navigator"
 keywords = ["disk-usage", "filesystem", "terminal", "tui"]
 categories = ["command-line-utilities", "filesystem"]
 
-version = "1.2.2"
+version = "1.2.3"
 authors = ["Aram Drevekenin <aram@poor.dev>", "Tom Larcher <tom.larcher@gmail.com>"]
 readme = "README.md"
 homepage = "https://github.com/findyourexit/excise"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It is an independent fork and spiritual successor to [Diskonaut](https://github.
 ```console
 brew tap findyourexit/tap
 brew install findyourexit/tap/excise
-excise --version  # excise 1.2.2
+excise --version  # excise 1.2.3
 ```
 
 </details>
@@ -42,8 +42,8 @@ excise --version  # excise 1.2.2
 <summary><strong>crates.io</strong></summary>
 
 ```console
-cargo install excise --version 1.2.2 --locked
-excise --version  # excise 1.2.2
+cargo install excise --version 1.2.3 --locked
+excise --version  # excise 1.2.3
 ```
 
 </details>
@@ -51,7 +51,7 @@ excise --version  # excise 1.2.2
 <details>
 <summary><strong>Pre-built Binaries</strong></summary>
 
-Download the [v1.2.2 release](https://github.com/findyourexit/excise/releases/tag/v1.2.2) for macOS, Linux, and Windows on Apple silicon, Intel, or Arm systems.
+Download the [v1.2.3 release](https://github.com/findyourexit/excise/releases/tag/v1.2.3) for macOS, Linux, and Windows on Apple silicon, Intel, or Arm systems.
 
 Only x86_64 Linux, AArch64 macOS, and x86_64 Windows have full platform support because they are tested on those platforms. The other archives are build-only and best effort. See the [Support Policy](SUPPORT.md).
 
@@ -61,7 +61,7 @@ Only x86_64 Linux, AArch64 macOS, and x86_64 Windows have full platform support 
 <summary><strong>Build From Source</strong></summary>
 
 ```console
-git clone --branch v1.2.2 --depth 1 https://github.com/findyourexit/excise.git
+git clone --branch v1.2.3 --depth 1 https://github.com/findyourexit/excise.git
 cd excise
 cargo install --path . --locked
 excise --version
@@ -70,7 +70,7 @@ excise --version
 Nix users can run the tagged release without changing its lock file:
 
 ```console
-nix run github:findyourexit/excise/v1.2.2 -- --format table /path/to/inspect
+nix run github:findyourexit/excise/v1.2.3 -- --format table /path/to/inspect
 ```
 
 </details>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,20 +4,21 @@ Excise permanently deletes files and folders. Data-loss defects are therefore se
 
 ## Supported Versions
 
-Excise supports the latest stable release, currently `1.2.2`. The `0.3.x` line was early testing and is superseded. Report safety defects against the affected stable release or development commit. Do not trust superseded releases with irreplaceable data.
+Excise supports the latest stable release, currently `1.2.3`. The `0.3.x` line was early testing and is superseded. Report safety defects against the affected stable release or development commit. Do not trust superseded releases with irreplaceable data.
 
 | Version | Status |
 |---|---|
-| `1.2.2` | Supported stable line |
-| `1.2.1` | Superseded release. Upgrade to `1.2.2`. |
-| `1.2.0` | Superseded release. Upgrade to `1.2.2`. |
-| `1.1.x` | Superseded stable releases. Upgrade to `1.2.2`. |
-| `1.0.x` | Superseded stable releases. Upgrade to `1.2.2`. |
-| `0.3.0` | Superseded early testing. Upgrade to `1.2.2`. |
-| `0.2.0` | Superseded early testing. Upgrade to `1.2.2`. |
-| `0.1.2` | Superseded early testing. Upgrade to `1.2.2`. |
-| `0.1.1` | Superseded early testing. Upgrade to `1.2.2`. |
-| `0.1.0` | Superseded early testing. Upgrade to `1.2.2`. |
+| `1.2.3` | Supported stable line |
+| `1.2.2` | Superseded release. Upgrade to `1.2.3`. |
+| `1.2.1` | Superseded release. Upgrade to `1.2.3`. |
+| `1.2.0` | Superseded release. Upgrade to `1.2.3`. |
+| `1.1.x` | Superseded stable releases. Upgrade to `1.2.3`. |
+| `1.0.x` | Superseded stable releases. Upgrade to `1.2.3`. |
+| `0.3.0` | Superseded early testing. Upgrade to `1.2.3`. |
+| `0.2.0` | Superseded early testing. Upgrade to `1.2.3`. |
+| `0.1.2` | Superseded early testing. Upgrade to `1.2.3`. |
+| `0.1.1` | Superseded early testing. Upgrade to `1.2.3`. |
+| `0.1.0` | Superseded early testing. Upgrade to `1.2.3`. |
 | `main` | Development only |
 
 ## Report Privately

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,12 +42,12 @@ nix build
 ./result/bin/excise /path/to/inspect
 ```
 
-## Install 1.2.2 From A Release Channel
+## Install 1.2.3 From A Release Channel
 
-The `1.2.2` package is published on crates.io and can also be built locally. It is not one of the pre-built GitHub archives:
+The `1.2.3` package is published on crates.io and can also be built locally. It is not one of the pre-built GitHub archives:
 
 ```console
-cargo install excise --version 1.2.2 --locked
+cargo install excise --version 1.2.3 --locked
 excise --version
 ```
 
@@ -100,7 +100,7 @@ The interactive interface requires standard input and output connected to a term
 
 ### Current Map Behavior
 
-The dense half-block map, animated focus border, heat ramp, overflow summary, and directed map transitions are included in the stable release. Build the current source or install `1.2.2` to use them.
+The dense half-block map, animated focus border, heat ramp, overflow summary, and directed map transitions are included in the stable release. Build the current source or install `1.2.3` to use them.
 
 The interactive view uses a dense map and animated focus border on capable terminals. `--ascii`, monochrome mode, and reduced motion preserve the same selection, scope, and deletion information when visual effects are unavailable or undesirable.
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "base64",

--- a/generated/man/excise.1
+++ b/generated/man/excise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH excise 1  "excise 1.2.2"
+.TH excise 1  "excise 1.2.3"
 .SH NAME
 excise
 .SH SYNOPSIS
@@ -125,4 +125,4 @@ Print version
 [\fIfolder\fR]
 Folder to scan
 .SH VERSION
-v1.2.2
+v1.2.3


### PR DESCRIPTION
## Summary

Prepare corrective `v1.2.3` after the `v1.2.2` tagged fuzz smoke exposed a stale test expectation.

- Bump the package and both lockfiles to `1.2.3`, regenerate the man page, and update current-version install, support, and issue-report documentation.
- Move the new fuzz-regression coverage note into dated release notes.

## Release rationale

[`#69`](https://github.com/findyourexit/excise/pull/69) fixes the test oracle and saves the deterministic 13-byte case from the failed [`v1.2.2` fuzz run](https://github.com/findyourexit/excise/actions/runs/33872937998). It does not change deletion behavior: a directory plan that exceeds its resident budget is intentionally permitted to use the existing bounded, authenticated temporary spill path. `v1.2.3` records and distributes that verified regression coverage on a fresh immutable tag.

## Local release rehearsal

- `cargo verify`
- `cargo package --locked --list`
- `cargo publish --locked --dry-run`
- `cargo dist-local`, including local checksum, SPDX metadata, and archive-content verification

Hosted CI must pass before promotion.