### PR TITLE
docs: add x eget installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ excise --version  # excise 1.2.3
 </details>
 
 <details>
+<summary><strong>X-CMD</strong></summary>
+
+Alternatively, install it with [x-cmd](https://www.x-cmd.com/mod/eget), which downloads the pre-built binary from GitHub Releases:
+
+```bash
+x eget use findyourexit/excise
+```
+
+</details>
+
+<details>
 <summary><strong>Pre-built Binaries</strong></summary>
 
 Download the [v1.2.3 release](https://github.com/findyourexit/excise/releases/tag/v1.2.3) for macOS, Linux, and Windows on Apple silicon, Intel, or Arm systems.


### PR DESCRIPTION

## Summary

Add `x eget` as an installation method for excise.

`x eget` allows users to install excise by downloading its pre-built binary directly from the project's GitHub Releases:

```sh
x eget use findyourexit/excise
```

## Verification

<!-- List exact commands and relevant manual scenarios with results. -->

- [ ] Focused tests cover new behavior and plausible regressions.
- [x] `cargo fmt --all -- --check` passes.
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` passes.
- [x] `cargo test --workspace --locked` passes.
- [x] User-facing documentation and generated artifacts are current.

