### PR TITLE
fix: pin cargo verify fuzz toolchain

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -31,25 +31,30 @@ jobs:
         run: |
           test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
           printf 'Release SHA: %s\n' "$RELEASE_SHA"
+      - name: Read pinned fuzz toolchain
+        run: |
+          set -euo pipefail
+          fuzz_toolchain="$(cargo run --quiet --locked --package xtask -- fuzz-toolchain)"
+          printf 'FUZZ_TOOLCHAIN=%s\n' "$fuzz_toolchain" >> "$GITHUB_ENV"
       - name: Install pinned nightly and cargo-fuzz
         run: |
-          rustup toolchain install nightly-2026-08-18 --profile minimal
-          cargo +nightly-2026-08-18 install cargo-fuzz --version 0.13.2 --locked
+          rustup toolchain install "$FUZZ_TOOLCHAIN" --profile minimal
+          cargo "+$FUZZ_TOOLCHAIN" install cargo-fuzz --version 0.13.2 --locked
       - name: Run bounded fuzz smoke targets
         run: |
           mkdir -p fuzz/corpus/{treemap,accounting,filter,deletion_state,deletion_plan,report}
-          cargo +nightly-2026-08-18 fuzz run truncate -- -max_total_time=60 -max_len=4096
-          cargo +nightly-2026-08-18 fuzz run config -- -max_total_time=60 -max_len=4096
-          cargo +nightly-2026-08-18 fuzz run native_path -- -max_total_time=60 -max_len=4096
-          cargo +nightly-2026-08-18 fuzz run terminal_state -- -max_total_time=60 -max_len=4096
-          cargo +nightly-2026-08-18 fuzz run tachyonfx -- -max_total_time=60 -max_len=4096
-          cargo +nightly-2026-08-18 fuzz run runtime_events -- -max_total_time=30 -max_len=256
-          cargo +nightly-2026-08-18 fuzz run treemap fuzz/corpus/treemap fuzz/seeds/treemap -- -max_total_time=60 -max_len=4096
-          cargo +nightly-2026-08-18 fuzz run accounting fuzz/corpus/accounting fuzz/seeds/accounting -- -max_total_time=60 -max_len=4096
-          cargo +nightly-2026-08-18 fuzz run filter fuzz/corpus/filter fuzz/seeds/filter -- -max_total_time=60 -max_len=4096
-          cargo +nightly-2026-08-18 fuzz run deletion_state fuzz/corpus/deletion_state fuzz/seeds/deletion_state -- -max_total_time=60 -max_len=4096
-          cargo +nightly-2026-08-18 fuzz run deletion_plan fuzz/corpus/deletion_plan fuzz/seeds/deletion_plan -- -max_total_time=60 -max_len=256
-          cargo +nightly-2026-08-18 fuzz run report fuzz/corpus/report fuzz/seeds/report -- -max_total_time=60 -max_len=16384
+          cargo "+$FUZZ_TOOLCHAIN" fuzz run truncate -- -max_total_time=60 -max_len=4096
+          cargo "+$FUZZ_TOOLCHAIN" fuzz run config -- -max_total_time=60 -max_len=4096
+          cargo "+$FUZZ_TOOLCHAIN" fuzz run native_path -- -max_total_time=60 -max_len=4096
+          cargo "+$FUZZ_TOOLCHAIN" fuzz run terminal_state -- -max_total_time=60 -max_len=4096
+          cargo "+$FUZZ_TOOLCHAIN" fuzz run tachyonfx -- -max_total_time=60 -max_len=4096
+          cargo "+$FUZZ_TOOLCHAIN" fuzz run runtime_events -- -max_total_time=30 -max_len=256
+          cargo "+$FUZZ_TOOLCHAIN" fuzz run treemap fuzz/corpus/treemap fuzz/seeds/treemap -- -max_total_time=60 -max_len=4096
+          cargo "+$FUZZ_TOOLCHAIN" fuzz run accounting fuzz/corpus/accounting fuzz/seeds/accounting -- -max_total_time=60 -max_len=4096
+          cargo "+$FUZZ_TOOLCHAIN" fuzz run filter fuzz/corpus/filter fuzz/seeds/filter -- -max_total_time=60 -max_len=4096
+          cargo "+$FUZZ_TOOLCHAIN" fuzz run deletion_state fuzz/corpus/deletion_state fuzz/seeds/deletion_state -- -max_total_time=60 -max_len=4096
+          cargo "+$FUZZ_TOOLCHAIN" fuzz run deletion_plan fuzz/corpus/deletion_plan fuzz/seeds/deletion_plan -- -max_total_time=60 -max_len=256
+          cargo "+$FUZZ_TOOLCHAIN" fuzz run report fuzz/corpus/report fuzz/seeds/report -- -max_total_time=60 -max_len=16384
 
       - name: Preserve crash artifacts
         if: failure()

--- a/docs/development.md
+++ b/docs/development.md
@@ -203,7 +203,7 @@ The push-triggered workflow requires that exact annotated-tag candidate ID; neve
 - actionlint 1.7.12;
 - lychee 0.24.2;
 - Node.js/npm for Renovate 44.34.0 validation;
-- cargo-fuzz 0.13.2 with `nightly-2026-08-18`; and
+- cargo-fuzz 0.13.2 with the pinned fuzz toolchain; and
 - all host-installable targets listed above.
 
 ```console
@@ -241,11 +241,12 @@ Invoking `vhs tapes/demo.tape` directly writes an unoptimised 24 fps sequence to
 
 ## Fuzzing
 
-The `fuzz` package is intentionally outside the main workspace. List and run targets with cargo-fuzz:
+The `fuzz` package is intentionally outside the main workspace. `cargo verify` and hosted fuzzing query the same toolchain selector from `xtask`, so update only `FUZZ_TOOLCHAIN` when rolling the pinned nightly. List and run targets with cargo-fuzz:
 
 ```console
-cargo +nightly-2026-08-18 fuzz list
-cargo +nightly-2026-08-18 fuzz run native_path -- -max_total_time=60 -max_len=4096
+fuzz_toolchain="$(cargo run --quiet --locked --package xtask -- fuzz-toolchain)"
+cargo "+$fuzz_toolchain" fuzz list
+cargo "+$fuzz_toolchain" fuzz run native_path -- -max_total_time=60 -max_len=4096
 ```
 
 Crash artifacts and evolving corpora are ignored. Curated seeds under `fuzz/seeds` are reviewed source fixtures.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -21,6 +21,7 @@ const SCOOP_TEMPLATE: &str = "packaging/scoop/excise.json.in";
 const WINGET_TEMPLATE: &str = "packaging/winget/FindYourExit.Excise.yaml.in";
 const HOMEBREW_TEMPLATE: &str = "packaging/homebrew/Formula/excise.rb.in";
 
+const FUZZ_TOOLCHAIN: &str = "nightly-2026-08-18";
 #[derive(Clone, Copy)]
 struct UnixReleaseAsset {
     target: &'static str,
@@ -96,6 +97,10 @@ fn dispatch() -> Result<(), Box<dyn Error>> {
     let _ = args.next();
     match args.next().as_deref() {
         Some("verify") => verify(),
+        Some("fuzz-toolchain") => {
+            println!("{FUZZ_TOOLCHAIN}");
+            Ok(())
+        }
         Some("generate") => write_generated(),
         Some("check-generated") => check_generated(),
         Some("check-distribution") => check_distribution_contract(&release_version()?),
@@ -105,7 +110,7 @@ fn dispatch() -> Result<(), Box<dyn Error>> {
         Some("demo") => render_demo(),
         Some("create-release-tag") => create_release_tag(args),
         _ => Err(io::Error::other(
-            "usage: cargo xtask <verify|generate|check-generated|check-distribution|check-support-matrix|render-homebrew|dist-local|demo|create-release-tag>",
+            "usage: cargo xtask <verify|fuzz-toolchain|generate|check-generated|check-distribution|check-support-matrix|render-homebrew|dist-local|demo|create-release-tag>",
         )
         .into()),
     }
@@ -796,7 +801,15 @@ fn run_fuzz_target(target: &str, iterations: u32) -> Result<(), Box<dyn Error>> 
     let corpus = format!("fuzz/corpus/{target}");
     let seed = format!("fuzz/seeds/{target}");
     fs::create_dir_all(&corpus)?;
-    let mut args = vec!["run", "nightly", "cargo", "fuzz", "run", target, &corpus];
+    let mut args = vec![
+        "run",
+        FUZZ_TOOLCHAIN,
+        "cargo",
+        "fuzz",
+        "run",
+        target,
+        &corpus,
+    ];
     if Path::new(&seed).is_dir() {
         args.push(&seed);
     }


### PR DESCRIPTION
## Summary

Makes local fuzz verification use the same dated nightly as hosted fuzzing.

## Changes

- Centralize the pinned fuzz toolchain selector in `xtask`.
- Make `cargo verify`, the fuzz workflow, and development guidance use that selector.

## Safety and compatibility

Fuzz target semantics and bounded run counts are unchanged. The change removes compiler drift between local and hosted safety checks.

## Verification

- `cargo fmt --all -- --check`
- `actionlint .github/workflows/fuzz.yml`
- `cargo test --locked --package xtask`
- `cargo clippy --locked --package xtask -- -D warnings`
- Pinned-nightly `native_path` fuzz smoke

CI will provide the full cross-platform verification.