### PR TITLE
test: harden pull-request deletion fuzz coverage

### DIFF
--- a/.github/workflows/pr-fuzz.yml
+++ b/.github/workflows/pr-fuzz.yml
@@ -1,0 +1,29 @@
+name: PR deletion-plan safety fuzz
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-deletion-plan-fuzz-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deletion-plan:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Install pinned nightly and cargo-fuzz
+        run: |
+          rustup toolchain install nightly-2026-08-18 --profile minimal
+          cargo +nightly-2026-08-18 install cargo-fuzz --version 0.13.2 --locked
+      - name: Run deterministic bounded deletion-plan safety fuzzing
+        run: |
+          mkdir -p fuzz/corpus/deletion_plan
+          cargo +nightly-2026-08-18 fuzz run deletion_plan fuzz/corpus/deletion_plan fuzz/seeds/deletion_plan -- -runs=2000 -seed=236917 -max_len=256

--- a/fuzz/fuzz_targets/deletion_plan.rs
+++ b/fuzz/fuzz_targets/deletion_plan.rs
@@ -3,18 +3,30 @@
 use std::error::Error;
 use std::ffi::OsString;
 use std::fs::Metadata;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 use std::time::UNIX_EPOCH;
 
+#[cfg(unix)]
+use std::os::unix::ffi::OsStringExt as _;
+
 use excise::deletion::{
-    DeletionPlanError, PlannedKind, PlannedSnapshot, ReviewedEntry, build_plan_cancellable,
-    execute_plan,
+    build_plan_cancellable, execute_plan, DeletionPlanError, PlannedKind, PlannedSnapshot,
+    ReviewedEntry,
 };
 use excise::model::{EntrySnapshot, NodeId, NodeKind};
 use excise::native_path::identity_for;
-use excise::{FileToDelete, geometry::FileType};
+use excise::{geometry::FileType, FileToDelete};
 use libfuzzer_sys::fuzz_target;
+
+const FULL_PLAN_LIMIT_BYTES: usize = 4 * 1024 * 1024;
+const SPILLED_PLAN_LIMIT_BYTES: usize = 1;
+const MAX_DYNAMIC_ENTRIES: usize = 8;
+
+struct FixtureTree {
+    directories: Vec<PathBuf>,
+    files: Vec<PathBuf>,
+}
 
 fuzz_target!(|data: &[u8]| {
     let _ = exercise(data);
@@ -23,26 +35,20 @@ fuzz_target!(|data: &[u8]| {
 fn exercise(data: &[u8]) -> Result<(), Box<dyn Error>> {
     let root = tempfile::tempdir()?;
     let target_path = root.path().join("target");
+    let outside = root.path().join("outside");
     std::fs::create_dir(&target_path)?;
-    for (index, byte) in data.iter().copied().take(12).enumerate() {
-        let path = target_path.join(format!("entry-{index}-{}", byte % 17));
-        if byte % 3 == 0 {
-            std::fs::create_dir(&path)?;
-            std::fs::write(path.join("leaf"), vec![byte; usize::from(byte % 32)])?;
-        } else {
-            std::fs::write(path, vec![byte; usize::from(byte % 32)])?;
-        }
-    }
-
-    let outside = tempfile::tempdir()?;
-    let outside_file = outside.path().join("outside");
+    std::fs::create_dir(&outside)?;
+    let outside_file = outside.join("must-survive");
     std::fs::write(&outside_file, b"outside")?;
+
+    let fixture = create_fixture(&target_path, data)?;
     #[cfg(unix)]
-    if data.get(1).is_some_and(|byte| byte & 1 != 0) {
-        std::os::unix::fs::symlink(&outside_file, target_path.join("outside-link"))?;
-    }
+    let retained_hard_link = add_unix_link_variants(&outside, &fixture, data)?;
+    #[cfg(not(unix))]
+    let retained_hard_link: Option<PathBuf> = None;
 
     let reviewed_entries = reviewed_entries(root.path(), &target_path)?;
+    let reviewed_count = u64::try_from(reviewed_entries.len()).unwrap_or(u64::MAX);
     let root_snapshot = reviewed_entries
         .iter()
         .find(|entry| entry.relative_path == Path::new("target"))
@@ -69,27 +75,14 @@ fn exercise(data: &[u8]) -> Result<(), Box<dyn Error>> {
         reviewed_entries,
     };
 
-    let mode = data.first().copied().unwrap_or(0) % 4;
-    match mode {
-        1 => std::fs::write(target_path.join("late-entry"), b"late")?,
-        2 => {
-            if let Some(entry) = target
-                .reviewed_entries
-                .iter()
-                .find(|entry| entry.snapshot.kind == PlannedKind::File)
-            {
-                let path = root.path().join(&entry.relative_path);
-                let backup = path.with_extension("reviewed-backup");
-                std::fs::rename(&path, backup)?;
-                std::fs::write(path, b"replacement")?;
-            } else {
-                std::fs::write(target_path.join("late-entry"), b"late")?;
-            }
-        }
-        _ => {}
-    }
+    let mode = byte_at(data, 0) % 4;
+    mutate_after_review(mode, &fixture, &outside, data)?;
 
-    let maximum_bytes = if mode == 3 { 1 } else { 4 * 1024 * 1024 };
+    let maximum_bytes = if mode == 3 {
+        SPILLED_PLAN_LIMIT_BYTES
+    } else {
+        FULL_PLAN_LIMIT_BYTES
+    };
     let result = build_plan_cancellable(
         root.path(),
         target,
@@ -99,8 +92,9 @@ fn exercise(data: &[u8]) -> Result<(), Box<dyn Error>> {
     );
     match (mode, result) {
         (0 | 3, Ok(plan)) => {
-            let soft = AtomicBool::new(data.get(2).is_some_and(|byte| byte & 1 != 0));
-            let hard = AtomicBool::new(data.get(2).is_some_and(|byte| byte & 2 != 0));
+            assert_eq!(plan.planned_entries(), reviewed_count);
+            let soft = AtomicBool::new(byte_at(data, 2) & 1 != 0);
+            let hard = AtomicBool::new(byte_at(data, 2) & 2 != 0);
             let report = execute_plan(root.path(), plan, &soft, &hard);
             let classified = report
                 .deleted_entries()
@@ -108,8 +102,15 @@ fn exercise(data: &[u8]) -> Result<(), Box<dyn Error>> {
                 .saturating_add(report.missing_entries())
                 .saturating_add(report.failed_entries())
                 .saturating_add(report.unattempted_entries());
-            assert_eq!(classified as usize, report.entries.len());
-            assert_eq!(report.precise, !hard.load(std::sync::atomic::Ordering::Acquire));
+            assert_eq!(
+                classified,
+                u64::try_from(report.entries.len()).unwrap_or(u64::MAX)
+            );
+            assert!(report.reporting_complete());
+            assert_eq!(
+                report.precise,
+                !hard.load(std::sync::atomic::Ordering::Acquire)
+            );
         }
         (0 | 3, Err(DeletionPlanError::Changed)) => {
             // Rejecting an inconsistent snapshot is a valid safety outcome.
@@ -117,8 +118,155 @@ fn exercise(data: &[u8]) -> Result<(), Box<dyn Error>> {
         (1 | 2, Err(DeletionPlanError::Changed)) => {}
         (mode, result) => panic!("unexpected deletion plan result for mode {mode}: {result:?}"),
     }
-    assert!(outside_file.exists());
+
+    assert_eq!(
+        std::fs::read(&outside_file)
+            .expect("data outside the selected target must remain readable"),
+        b"outside"
+    );
+    if let Some(retained_hard_link) = retained_hard_link {
+        assert!(
+            retained_hard_link.is_file(),
+            "hard link outside the selected target must survive"
+        );
+    }
     Ok(())
+}
+
+fn create_fixture(target: &Path, data: &[u8]) -> Result<FixtureTree, Box<dyn Error>> {
+    let first_directory = target.join(fixture_component(0, data));
+    let second_directory =
+        first_directory.join(fixture_component(1, data.get(1..).unwrap_or_default()));
+    std::fs::create_dir(&first_directory)?;
+    std::fs::create_dir(&second_directory)?;
+
+    let anchor = second_directory.join(fixture_component(2, data.get(2..).unwrap_or_default()));
+    write_fixture_file(&anchor, byte_at(data, 0))?;
+
+    let mut fixture = FixtureTree {
+        directories: vec![target.to_path_buf(), first_directory, second_directory],
+        files: vec![anchor],
+    };
+    for (index, bytes) in data.chunks(4).take(MAX_DYNAMIC_ENTRIES).enumerate() {
+        let selector = bytes[0];
+        let parent = &fixture.directories[usize::from(selector) % fixture.directories.len()];
+        let path = parent.join(fixture_component(index + 3, bytes));
+        if selector & 1 == 0 {
+            std::fs::create_dir(&path)?;
+            let leaf = path.join(fixture_component(index + 3 + MAX_DYNAMIC_ENTRIES, bytes));
+            write_fixture_file(&leaf, selector)?;
+            fixture.files.push(leaf);
+            fixture.directories.push(path);
+        } else {
+            write_fixture_file(&path, selector)?;
+            fixture.files.push(path);
+        }
+    }
+    Ok(fixture)
+}
+
+fn write_fixture_file(path: &Path, selector: u8) -> std::io::Result<()> {
+    std::fs::write(path, vec![selector; usize::from(selector % 32)])
+}
+
+fn fixture_component(index: usize, data: &[u8]) -> OsString {
+    #[cfg(unix)]
+    {
+        let mut name = format!("entry-{index:02x}-").into_bytes();
+        let hostile: &[u8] = match byte_at(data, 0) % 6 {
+            0 => b"\xff",
+            1 => b"\x1b[31m",
+            2 => b"\n",
+            3 => b"\xe2\x80\xae",
+            4 => b" leading-",
+            _ => b"--",
+        };
+        name.extend_from_slice(hostile);
+        name.extend(data.iter().copied().take(8).map(|byte| match byte {
+            b'\0' | b'/' => b'_',
+            _ => byte,
+        }));
+        OsString::from_vec(name)
+    }
+    #[cfg(not(unix))]
+    {
+        OsString::from(format!("entry-{index:02x}-{:02x}", byte_at(data, 0)))
+    }
+}
+
+#[cfg(unix)]
+fn add_unix_link_variants(
+    outside: &Path,
+    fixture: &FixtureTree,
+    data: &[u8],
+) -> Result<Option<PathBuf>, Box<dyn Error>> {
+    let options = byte_at(data, 1);
+    let retained_hard_link = if options & 1 != 0 {
+        let source = &fixture.files[usize::from(byte_at(data, 3)) % fixture.files.len()];
+        let inside = fixture.directories[usize::from(byte_at(data, 4)) % fixture.directories.len()]
+            .join(fixture_component(240, data.get(4..).unwrap_or_default()));
+        std::fs::hard_link(source, inside)?;
+        let retained = outside.join("retained-hard-link");
+        std::fs::hard_link(source, &retained)?;
+        Some(retained)
+    } else {
+        None
+    };
+    if options & 2 != 0 {
+        let link = fixture.directories[usize::from(byte_at(data, 5)) % fixture.directories.len()]
+            .join(fixture_component(241, data.get(5..).unwrap_or_default()));
+        std::os::unix::fs::symlink(outside, link)?;
+    }
+    Ok(retained_hard_link)
+}
+
+fn mutate_after_review(
+    mode: u8,
+    fixture: &FixtureTree,
+    outside: &Path,
+    data: &[u8],
+) -> Result<(), Box<dyn Error>> {
+    match mode {
+        1 => {
+            let parent =
+                &fixture.directories[usize::from(byte_at(data, 3)) % fixture.directories.len()];
+            std::fs::write(
+                parent.join(fixture_component(242, data.get(6..).unwrap_or_default())),
+                b"late",
+            )?;
+        }
+        2 => {
+            let replacement = if byte_at(data, 2) & 1 != 0 {
+                fixture.directories
+                    [1 + usize::from(byte_at(data, 3)) % (fixture.directories.len() - 1)]
+                    .clone()
+            } else {
+                fixture.files[usize::from(byte_at(data, 3)) % fixture.files.len()].clone()
+            };
+            let backup = replacement
+                .with_file_name(fixture_component(243, data.get(7..).unwrap_or_default()));
+            std::fs::rename(&replacement, backup)?;
+            #[cfg(unix)]
+            {
+                if byte_at(data, 2) & 2 != 0 {
+                    std::os::unix::fs::symlink(outside, &replacement)?;
+                } else {
+                    std::fs::write(&replacement, b"replacement")?;
+                }
+            }
+            #[cfg(not(unix))]
+            {
+                let _ = outside;
+                std::fs::write(&replacement, b"replacement")?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn byte_at(data: &[u8], index: usize) -> u8 {
+    data.get(index).copied().unwrap_or_default()
 }
 
 fn reviewed_entries(root: &Path, target: &Path) -> Result<Vec<ReviewedEntry>, Box<dyn Error>> {

--- a/fuzz/seeds/deletion_plan/bounded-hostile-tree
+++ b/fuzz/seeds/deletion_plan/bounded-hostile-tree
@@ -1,0 +1,1 @@
+GCD-spilled-hostile-tree

--- a/fuzz/seeds/deletion_plan/hostile-nested-hard-links
+++ b/fuzz/seeds/deletion_plan/hostile-nested-hard-links
@@ -1,0 +1,1 @@
+DCD-hostile-nested-hard-links

--- a/fuzz/seeds/deletion_plan/invalid-unix-names
+++ b/fuzz/seeds/deletion_plan/invalid-unix-names
@@ -1,0 +1,1 @@
+HCD-invalid-unix-names

--- a/fuzz/seeds/deletion_plan/late-nested-entry
+++ b/fuzz/seeds/deletion_plan/late-nested-entry
@@ -1,0 +1,1 @@
+ACD-late-nested-entry

--- a/fuzz/seeds/deletion_plan/replacement-link
+++ b/fuzz/seeds/deletion_plan/replacement-link
@@ -1,0 +1,1 @@
+BCC-replace-with-link


### PR DESCRIPTION
## Summary

Adds bounded deterministic deletion-plan fuzz coverage to pull requests and broadens hostile filesystem scenarios.

## Changes

- Add a dedicated pinned-nightly PR fuzz workflow.
- Extend deletion-plan fuzz fixtures with hostile Unix names, nested paths, hard links, replacements, late entries, and constrained spill plans.

## Safety and compatibility

The harness continues to assert that data outside the selected target survives. Long-running scheduled and release fuzzing remain unchanged.

## Verification

- `actionlint` for the new workflow
- Pinned-nightly deletion-plan fuzz run
- 41 focused deletion-plan tests

CI will provide the full cross-platform verification.