### PR TITLE
release: prepare `v1.2.4`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
     id: version
     attributes:
       label: Excise version or commit
-      placeholder: "v1.2.3 or 0123456789abcdef"
+      placeholder: "v1.2.4 or 0123456789abcdef"
     validations:
       required: true
   - type: dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Excise preserves the historical Diskonaut changelog below. Diskonaut versions an
 
 ## [Unreleased]
 
+## [1.2.4] - 2026-09-12
+
+### Changed
+
+* Documented X-CMD's `x eget use findyourexit/excise` command for installing the pre-built GitHub Release binaries.
+* Isolated private scanner queue/spill mechanics and the Windows FFI boundary to narrow the safety-audit surface without changing user-visible behavior.
+* Updated runtime, development, fuzzing, and CI dependencies, notably `crossbeam-channel` 0.5.17, `jsonschema` 0.53.0, `redb` 4.2.0, `sha2` 0.11.0, `tachyonfx` 0.25.2, and `toml` 1.1.5.
+* CI now retains reproducible benchmark evidence and its execution context for 90 days.
+
+### Fixed
+
+* Corrected the supported Rust compiler contract to Rust 1.98 or later, matching the locked dependency set and CI.
+* Local and hosted fuzz verification now share a pinned nightly toolchain. Pull requests exercise bounded directory-deletion plans across hostile names, hard links, replacements, late entries, and temporary-storage spills.
+
 ## [1.2.3] - 2026-09-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Surgical terminal storage navigator"
 keywords = ["disk-usage", "filesystem", "terminal", "tui"]
 categories = ["command-line-utilities", "filesystem"]
 
-version = "1.2.3"
+version = "1.2.4"
 authors = ["Aram Drevekenin <aram@poor.dev>", "Tom Larcher <tom.larcher@gmail.com>"]
 readme = "README.md"
 homepage = "https://github.com/findyourexit/excise"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It is an independent fork and spiritual successor to [Diskonaut](https://github.
 ```console
 brew tap findyourexit/tap
 brew install findyourexit/tap/excise
-excise --version  # excise 1.2.3
+excise --version  # excise 1.2.4
 ```
 
 </details>
@@ -42,8 +42,8 @@ excise --version  # excise 1.2.3
 <summary><strong>crates.io</strong></summary>
 
 ```console
-cargo install excise --version 1.2.3 --locked
-excise --version  # excise 1.2.3
+cargo install excise --version 1.2.4 --locked
+excise --version  # excise 1.2.4
 ```
 
 </details>
@@ -62,7 +62,7 @@ x eget use findyourexit/excise
 <details>
 <summary><strong>Pre-built Binaries</strong></summary>
 
-Download the [v1.2.3 release](https://github.com/findyourexit/excise/releases/tag/v1.2.3) for macOS, Linux, and Windows on Apple silicon, Intel, or Arm systems.
+Download the [v1.2.4 release](https://github.com/findyourexit/excise/releases/tag/v1.2.4) for macOS, Linux, and Windows on Apple silicon, Intel, or Arm systems.
 
 Only x86_64 Linux, AArch64 macOS, and x86_64 Windows have full platform support because they are tested on those platforms. The other archives are build-only and best effort. See the [Support Policy](SUPPORT.md).
 
@@ -72,7 +72,7 @@ Only x86_64 Linux, AArch64 macOS, and x86_64 Windows have full platform support 
 <summary><strong>Build From Source</strong></summary>
 
 ```console
-git clone --branch v1.2.3 --depth 1 https://github.com/findyourexit/excise.git
+git clone --branch v1.2.4 --depth 1 https://github.com/findyourexit/excise.git
 cd excise
 cargo install --path . --locked
 excise --version
@@ -81,7 +81,7 @@ excise --version
 Nix users can run the tagged release without changing its lock file:
 
 ```console
-nix run github:findyourexit/excise/v1.2.3 -- --format table /path/to/inspect
+nix run github:findyourexit/excise/v1.2.4 -- --format table /path/to/inspect
 ```
 
 </details>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,21 +4,22 @@ Excise permanently deletes files and folders. Data-loss defects are therefore se
 
 ## Supported Versions
 
-Excise supports the latest stable release, currently `1.2.3`. The `0.3.x` line was early testing and is superseded. Report safety defects against the affected stable release or development commit. Do not trust superseded releases with irreplaceable data.
+Excise supports the latest stable release, currently `1.2.4`. The `0.3.x` line was early testing and is superseded. Report safety defects against the affected stable release or development commit. Do not trust superseded releases with irreplaceable data.
 
 | Version | Status |
 |---|---|
-| `1.2.3` | Supported stable line |
-| `1.2.2` | Superseded release. Upgrade to `1.2.3`. |
-| `1.2.1` | Superseded release. Upgrade to `1.2.3`. |
-| `1.2.0` | Superseded release. Upgrade to `1.2.3`. |
-| `1.1.x` | Superseded stable releases. Upgrade to `1.2.3`. |
-| `1.0.x` | Superseded stable releases. Upgrade to `1.2.3`. |
-| `0.3.0` | Superseded early testing. Upgrade to `1.2.3`. |
-| `0.2.0` | Superseded early testing. Upgrade to `1.2.3`. |
-| `0.1.2` | Superseded early testing. Upgrade to `1.2.3`. |
-| `0.1.1` | Superseded early testing. Upgrade to `1.2.3`. |
-| `0.1.0` | Superseded early testing. Upgrade to `1.2.3`. |
+| `1.2.4` | Supported stable line |
+| `1.2.3` | Superseded release. Upgrade to `1.2.4`. |
+| `1.2.2` | Superseded release. Upgrade to `1.2.4`. |
+| `1.2.1` | Superseded release. Upgrade to `1.2.4`. |
+| `1.2.0` | Superseded release. Upgrade to `1.2.4`. |
+| `1.1.x` | Superseded stable releases. Upgrade to `1.2.4`. |
+| `1.0.x` | Superseded stable releases. Upgrade to `1.2.4`. |
+| `0.3.0` | Superseded early testing. Upgrade to `1.2.4`. |
+| `0.2.0` | Superseded early testing. Upgrade to `1.2.4`. |
+| `0.1.2` | Superseded early testing. Upgrade to `1.2.4`. |
+| `0.1.1` | Superseded early testing. Upgrade to `1.2.4`. |
+| `0.1.0` | Superseded early testing. Upgrade to `1.2.4`. |
 | `main` | Development only |
 
 ## Report Privately

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,12 +42,12 @@ nix build
 ./result/bin/excise /path/to/inspect
 ```
 
-## Install 1.2.3 From A Release Channel
+## Install 1.2.4 From A Release Channel
 
-The `1.2.3` package is published on crates.io and can also be built locally. It is not one of the pre-built GitHub archives:
+The `1.2.4` package is published on crates.io and can also be built locally. It is not one of the pre-built GitHub archives:
 
 ```console
-cargo install excise --version 1.2.3 --locked
+cargo install excise --version 1.2.4 --locked
 excise --version
 ```
 
@@ -100,7 +100,7 @@ The interactive interface requires standard input and output connected to a term
 
 ### Current Map Behavior
 
-The dense half-block map, animated focus border, heat ramp, overflow summary, and directed map transitions are included in the stable release. Build the current source or install `1.2.3` to use them.
+The dense half-block map, animated focus border, heat ramp, overflow summary, and directed map transitions are included in the stable release. Build the current source or install `1.2.4` to use them.
 
 The interactive view uses a dense map and animated focus border on capable terminals. `--ascii`, monochrome mode, and reduced motion preserve the same selection, scope, and deletion information when visual effects are unavailable or undesirable.
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -504,7 +504,7 @@ dependencies = [
 
 [[package]]
 name = "excise"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "base64",

--- a/generated/man/excise.1
+++ b/generated/man/excise.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH excise 1  "excise 1.2.3"
+.TH excise 1  "excise 1.2.4"
 .SH NAME
 excise
 .SH SYNOPSIS
@@ -125,4 +125,4 @@ Print version
 [\fIfolder\fR]
 Folder to scan
 .SH VERSION
-v1.2.3
+v1.2.4


### PR DESCRIPTION
## Summary

Prepare the stable `v1.2.4` patch release after the changes merged since `v1.2.3`.

- Bump the package and root/fuzz lockfiles to `1.2.4`, regenerate the man page, and update current-version installation, support, and issue-report documentation.
- Curate dated release notes for X-CMD installation, the corrected Rust compiler contract, dependency maintenance, private scanner/Windows safety-boundary work, retained benchmark evidence, and strengthened fuzz verification.
- Refresh the fuzz lockfile so it matches the post-rebase root dependency graph.

## Safety and compatibility

This is a patch release. The scanner queue/spill extraction and Windows FFI consolidation retain existing public behavior. Rust `1.98+` corrects the compiler-support claim to match the locked dependency set and CI; it does not change the CLI, configuration, report schemas, deletion semantics, or platform classifications. The dependency refresh includes `redb` 4.2.0 and `sha2` 0.11.0.

## Local release rehearsal

- `cargo verify`
- `cargo check --manifest-path fuzz/Cargo.toml --locked`
- `cargo package --locked --list`
- `cargo publish --locked --dry-run`
- `cargo dist-local`, including local archive, checksum, SBOM, and archive-content validation

Hosted CI must pass before merge.
